### PR TITLE
fix(defaults): force command-not-found dbPath

### DIFF
--- a/profiles/defaults.nix
+++ b/profiles/defaults.nix
@@ -145,7 +145,7 @@ in
 
   programs.fish.enable = true;
 
-  programs.command-not-found.dbPath = "${./..}/programs.sqlite";
+  programs.command-not-found.dbPath = lib.mkForce "${./..}/programs.sqlite";
 
   security.sudo.extraConfig = ''
     Defaults  lecture="never"


### PR DESCRIPTION
Adds `lib.mkForce` to `programs.command-not-found.dbPath` so it overrides any conflicting module setting.