### PR TITLE
chore(firefox): set configPath

### DIFF
--- a/users/profiles/firefox.nix
+++ b/users/profiles/firefox.nix
@@ -8,6 +8,7 @@ in
   programs.firefox = {
     enable = true;
     package = firefox;
+    configPath = ".mozilla/firefox";
     profiles = {
       default = {
         extensions.packages = with pkgs.nur.repos.rycee.firefox-addons; [


### PR DESCRIPTION
Sets `programs.firefox.configPath` to `.mozilla/firefox`.