### PR TITLE
perf(ci): replace magic-nix-cache with cachix on all jobs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,8 +19,9 @@ jobs:
       with:
         extra-conf: |
           accept-flake-config = true
-    - name: Run the Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v13
+    - uses: cachix/cachix-action@v17
+      with:
+        name: blazed
     - run: |
         nix run .#cake -- lint
 
@@ -32,8 +33,9 @@ jobs:
         with:
           extra-conf: |
             accept-flake-config = true
-      - name: Run the Magic Nix Cache
-        uses: DeterminateSystems/magic-nix-cache-action@v13
+      - uses: cachix/cachix-action@v17
+        with:
+          name: blazed
       - run: |
           nix run .#cake -- check
 
@@ -47,8 +49,9 @@ jobs:
       with:
         extra-conf: |
           accept-flake-config = true
-    - name: Run the Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v13
+    - uses: cachix/cachix-action@v17
+      with:
+        name: blazed
     - id: job-matrix
       run: |
         echo "matrix=$(nix eval .#github-actions-package-matrix-x86-64-linux --json)" >> "$GITHUB_OUTPUT"
@@ -63,8 +66,9 @@ jobs:
       with:
         extra-conf: |
           accept-flake-config = true
-    - name: Run the Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v13
+    - uses: cachix/cachix-action@v17
+      with:
+        name: blazed
     - id: job-matrix
       run: |
         echo "matrix=$(nix eval .#github-actions-host-matrix-x86-64-linux --json)" >> "$GITHUB_OUTPUT"
@@ -85,8 +89,6 @@ jobs:
       with:
         name: blazed
         authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
-    - name: Run the Magic Nix Cache
-      uses: DeterminateSystems/magic-nix-cache-action@v13
     - env:
         PKG: ${{ matrix.pkg }}
       run: |


### PR DESCRIPTION
## Summary

`DeterminateSystems/magic-nix-cache-action` was sunset in early 2025 and no longer provides a useful cache, so every CI job has been doing cold builds. This swaps it out for `cachix/cachix-action` (read-only) on the lint, check, and matrix-eval jobs so they pull from the existing `blazed.cachix.org` cache, and removes the redundant magic-nix-cache step from the package build job (which already had Cachix).

- Drops the deprecated `magic-nix-cache-action` from all five jobs.
- Adds `cachix-action` (no auth, read-only) to `nix_lint`, `nix_check`, `pkgs_x86_64_linux`, and `hosts_x86_64_linux` so they substitute from `blazed.cachix.org` instead of rebuilding `.#cake` and friends from scratch.
- `pkg_x86_64_linux` keeps its existing authenticated Cachix push.

## Test plan

- [ ] Confirm CI is green on this PR.
- [ ] Check job durations vs. the previous run on main to verify cache hits are reducing runtime.