### PR TITLE
feat(router,k3s): cilium L2 announcements + WAN port forwards

### DIFF
--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -102,6 +102,18 @@
         mac = "24:4b:fe:98:14:aa";
       }
     ];
+    portForwards = [
+      # HTTPS → istio-gateway (Cilium L2 VIP)
+      {
+        port = 443;
+        target = "10.0.10.14:443";
+      }
+      # SSH → exsules-ssh (Cilium L2 VIP)
+      {
+        port = 22;
+        target = "10.0.10.15:22";
+      }
+    ];
     dotUpstreams = [
       "45.90.28.0"
       "45.90.30.0"

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -226,6 +226,35 @@ in
         };
       });
     };
+    portForwards = mkOption {
+      default = [ ];
+      description = ''
+        WAN-side port forwards. Each entry DNATs traffic arriving on the
+        external interface to an internal address:port. The forward chain
+        accepts DNAT'd traffic via `ct status dnat`, so no separate filter
+        rule is required per forward.
+      '';
+      type = listOf (submodule {
+        options = {
+          protocol = mkOption {
+            type = enum [ "tcp" "udp" ];
+            default = "tcp";
+            description = "Transport protocol.";
+          };
+          port = mkOption {
+            type = port;
+            description = "External (WAN-side) port to listen on.";
+          };
+          target = mkOption {
+            type = str;
+            description = ''
+              Internal target as `IP:PORT` (e.g. `10.0.10.14:443`). nftables
+              syntax allows the destination port to differ from the WAN port.
+            '';
+          };
+        };
+      });
+    };
     vlans = mkOption {
       default = { };
       type = attrsOf (
@@ -472,6 +501,12 @@ in
               iifname { ${concatStringsSep "," allInternalNames} } oifname { "${cfg.externalInterface}" } counter accept comment "Allow LAN to WAN"
               iifname { "${cfg.externalInterface}" } oifname { ${concatStringsSep "," allInternalNames} } ct state { established, related } counter accept comment "Allow established back to LANs"
 
+              # DNAT'd WAN ingress: prerouting rewrites destination, here we
+              # accept the resulting forward. `ct status dnat` is set by nftables
+              # whenever the connection's first packet was DNAT'd, so this
+              # implicitly trusts only the explicit `services.router.portForwards`.
+              iifname "${cfg.externalInterface}" ct status dnat counter accept comment "Allow DNAT'd WAN ingress"
+
               # Free routing within the trusted zone (parent <-> trusted VLAN,
               # trusted VLAN <-> trusted VLAN, etc.).
               iifname { ${concatStringsSep "," trustedAll} } oifname { ${concatStringsSep "," trustedAll} } counter accept comment "Allow trusted-to-trusted forwarding"
@@ -486,6 +521,9 @@ in
           table ip nat {
             chain prerouting {
               type nat hook prerouting priority dstnat; policy accept;
+              ${concatMapStringsSep "\n              " (
+                f: ''iifname "${cfg.externalInterface}" ${f.protocol} dport ${toString f.port} dnat to ${f.target}''
+              ) cfg.portForwards}
             }
 
             chain postrouting {

--- a/profiles/k3s-master.nix
+++ b/profiles/k3s-master.nix
@@ -55,12 +55,43 @@ in
             --set enableNodePort=true \
             --set ipam.operator.clusterPoolIPv4PodCIDRList=${settings.cluster-cidr} \
             --set gatewayAPI.enabled=true \
-            --set encryption.enabled=false > "$out"/cilium.yaml
+            --set encryption.enabled=false \
+            --set l2announcements.enabled=true \
+            --set k8sClientRateLimit.qps=10 \
+            --set k8sClientRateLimit.burst=20 > "$out"/cilium.yaml
+        '';
+        ciliumL2 = pkgs.writeText "cilium-l2.yaml" ''
+          ---
+          apiVersion: cilium.io/v2
+          kind: CiliumLoadBalancerIPPool
+          metadata:
+            name: lan-pool
+          spec:
+            blocks:
+              - start: "10.0.10.14"
+                stop: "10.0.10.20"
+          ---
+          apiVersion: cilium.io/v2
+          kind: CiliumL2AnnouncementPolicy
+          metadata:
+            name: lan-announce
+          spec:
+            serviceSelector:
+              matchLabels:
+                cilium.io/l2-announce: "true"
+            nodeSelector:
+              matchLabels:
+                kubernetes.io/os: linux
+            interfaces:
+              - "^eno[1-9]$"
+            externalIPs: false
+            loadBalancerIPs: true
         '';
       in
       {
         kured = "${pkgs.kured-yaml}/kured.yaml";
         cilium = "${cilium}/cilium.yaml";
+        cilium-l2 = "${ciliumL2}";
       };
   };
 }


### PR DESCRIPTION
Replaces the per-node NodePort + pfSense HAProxy round-robin with a Cilium L2-announced VIP per service. anja DNATs WAN 443/22 to the VIPs; Cilium picks an active speaker among the k3s nodes.

- profiles/k3s-master.nix: enable l2announcements in cilium helm values (with k8sClientRateLimit qps/burst bumps required by the feature), and ship a CiliumLoadBalancerIPPool (10.0.10.14-.20)
  + CiliumL2AnnouncementPolicy as an autoDeploy manifest.
- modules/router.nix: new services.router.portForwards option; rendered into the nat prerouting chain as DNAT rules, with a matching ct status dnat accept in forward.
- hosts/x86_64-linux/anja.nix: forward 443 -> 10.0.10.14:443 (istio gateway) and 22 -> 10.0.10.15:22 (exsules-ssh).

Service-side switch from NodePort to LoadBalancer lives in exsules/argocd-apps.