### PR TITLE
feat(router): hairpin NAT support + share LAN VIP for git/registry

### DIFF
--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -103,15 +103,23 @@
       }
     ];
     portForwards = [
-      # HTTPS → istio-gateway (Cilium L2 VIP)
+      # HTTPS → istio-gateway (Cilium L2 VIP). Hairpin enabled as a
+      # safety net for LAN clients that bypass anja's dnsmasq (e.g.
+      # browsers using DoH); known WAN-pointing hostnames have explicit
+      # `dnsMasqSettings.address` overrides below to keep real LAN IPs.
       {
         port = 443;
         target = "10.0.10.14:443";
+        hairpin = true;
       }
-      # SSH → exsules-ssh (Cilium L2 VIP)
+      # SSH → shares VIP .14 with istio-gateway via Cilium's
+      # lbipam.cilium.io/sharing-key. exsules-ssh listens on :22, istio
+      # gateway on :443 — non-overlapping ports, one VIP, one DNS entry
+      # per hostname.
       {
         port = 22;
-        target = "10.0.10.15:22";
+        target = "10.0.10.14:22";
+        hairpin = true;
       }
     ];
     dotUpstreams = [
@@ -123,6 +131,21 @@
       no-resolv = true;
       bogus-priv = true;
       strict-order = true;
+      # Split DNS for hostnames whose public A record points at our WAN
+      # IP. LAN clients using anja's dnsmasq resolve directly to the
+      # internal VIP, skipping the router entirely — so the application
+      # backend sees the real LAN client IP instead of the router's IP
+      # (which is what hairpin SNAT would force). External traffic is
+      # unaffected — public DNS still hands out the WAN IP, and the
+      # WAN-side prerouting DNAT routes it as before.
+      #
+      # Hairpin remains enabled in `services.router.portForwards` as a
+      # safety net for LAN clients that bypass anja's dnsmasq.
+      address = [
+        "/registry.exsules.com/10.0.10.14"
+        "/git.exsules.com/10.0.10.14"
+        "/git.exsules.dev/10.0.10.14"
+      ];
     };
   };
 

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -90,9 +90,13 @@ let
   // mapAttrs (_: conf: mkInternal conf.prefixLength conf.address) cfg.vlans;
 
   internalInterfaceNames = attrNames internalInterfaces;
+  internalInterfaceAddresses = map (n: n.address) (builtins.attrValues internalInterfaces);
 
   trustedVlanNames = attrNames (filterAttrs (_: v: v.trusted) cfg.vlans);
   untrustedVlanNames = attrNames (filterAttrs (_: v: !v.trusted) cfg.vlans);
+
+  hairpinForwards = builtins.filter (f: f.hairpin) cfg.portForwards;
+  hasHairpin = hairpinForwards != [ ];
 
   useStubby = cfg.dotUpstreams != [ ];
   stubbyPort = 5453;
@@ -250,6 +254,30 @@ in
             description = ''
               Internal target as `IP:PORT` (e.g. `10.0.10.14:443`). nftables
               syntax allows the destination port to differ from the WAN port.
+            '';
+          };
+          hairpin = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              Enable NAT reflection (hairpin). When true, LAN-side traffic
+              destined for any of anja's IPs other than the configured
+              internal-interface addresses (typically the WAN IP) on this
+              port is also DNAT'd to `target`, with a postrouting masquerade
+              so the reply comes back through the router.
+
+              Note that hairpin necessarily SNATs the LAN client to the
+              router's IP — the application backend will see the router as
+              the source, not the real LAN client. To preserve real LAN
+              client IP, prefer adding a `services.dnsmasq.settings.address`
+              entry that resolves the public hostname to the internal VIP
+              directly, skipping the router on the LAN-side path entirely.
+
+              The `ip daddr != <internalInterfaceAddresses>` guard prevents
+              hijacking traffic to the router's own LAN IPs (e.g. `ssh
+              <router>` from the LAN keeps reaching local SSHD), but you
+              should still avoid enabling hairpin on ports the router
+              binds locally on the WAN interface.
             '';
           };
         };
@@ -524,11 +552,29 @@ in
               ${concatMapStringsSep "\n              " (
                 f: ''iifname "${cfg.externalInterface}" ${f.protocol} dport ${toString f.port} dnat to ${f.target}''
               ) cfg.portForwards}
+              ${optionalString hasHairpin (concatMapStringsSep "\n              " (
+                # Hairpin DNAT: LAN-arriving traffic for any local IP that
+                # isn't an internal-interface address (i.e. the WAN IP) on
+                # this port also gets DNAT'd to `target`. The `ip daddr !=`
+                # set keeps `LAN-client → router-LAN-IP:<port>` reaching the
+                # router's own services rather than being hijacked.
+                f: ''iifname { ${concatStringsSep "," allInternalNames} } ip daddr != { ${concatStringsSep "," internalInterfaceAddresses} } fib daddr type local ${f.protocol} dport ${toString f.port} dnat to ${f.target}''
+              ) hairpinForwards)}
             }
 
             chain postrouting {
               type nat hook postrouting priority srcnat; policy accept;
               oifname "${cfg.externalInterface}" masquerade
+              ${optionalString hasHairpin ''
+                # Hairpin SNAT: a LAN-arriving connection that was DNAT'd in
+                # prerouting is now exiting back to a LAN interface. Without
+                # masquerade the backend would reply directly to the LAN
+                # client (whose source was unchanged), and the client's TCP
+                # stack would reject the reply as coming from the wrong
+                # address. Masquerading sources the connection from the
+                # router so replies traverse it on the way back.
+                ct status dnat iifname { ${concatStringsSep "," allInternalNames} } oifname { ${concatStringsSep "," allInternalNames} } counter masquerade comment "Hairpin NAT reflection"
+              ''}
             }
           }
 


### PR DESCRIPTION
Adds a hairpin opt-in to services.router.portForwards as a safety net for LAN clients that resolve a public hostname to anja's WAN IP (e.g. browsers using DoH that bypass anja's dnsmasq).

The hairpin path masquerades the LAN client to anja, which means the application backend sees anja's IP, not the real LAN client. For known hot paths we therefore *also* add explicit dnsmasq overrides so LAN clients skip anja entirely and the backend sees the real LAN IP — split DNS over hairpin is the preferred path, hairpin only catches what the overrides miss.

Hairpin DNAT matches LAN-arriving traffic to any local IP that *isn't* one of the configured internal-interface addresses, so LAN→router-LAN-IP:<port> still reaches the router's own services (e.g. SSH to anja itself). The companion postrouting rule SNATs DNAT'd LAN→LAN traffic so the reply path stays valid.

anja: enable hairpin on both port forwards; change SSH target from .15 to .14 so it shares the VIP with istio-gateway via Cilium's lbipam sharing-key; add dnsmasq overrides for registry.exsules.com, git.exsules.com, git.exsules.dev — all three resolve to .14 on the LAN, hitting istio-gateway:443 or exsules-ssh:22 directly without the router hop.