### PR TITLE
feat(observability): node + dnsmasq exporters and alloy log shipping on anja

### DIFF
--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -11,12 +11,23 @@
     ../../profiles/admin-user/user.nix
     ../../profiles/disk/btrfs-on-luks.nix
     ../../profiles/hardware/apu.nix
+    ../../profiles/observability.nix
     ../../profiles/server.nix
     ../../profiles/state.nix
     ../../profiles/tailscale.nix
     ../../profiles/uuid_disk_crypt.nix
     ../../profiles/zram.nix
   ];
+
+  modules.observability = {
+    enable = true;
+    # Loki is exposed on the tailnet by the cluster's tailscale operator
+    # (see exsules-infra-argocd-apps services/loki). The hostname resolves
+    # via the dnsForwarders rule below — anja's dnsmasq sends `*.ts.net`
+    # to tailscale's MagicDNS so we don't need accept-dns=true on the
+    # tailscale auth (which would clash with running dnsmasq locally).
+    lokiURL = "http://loki.tailef5cf.ts.net:3100/loki/api/v1/push";
+  };
 
   disk.dosLabel = true;
 
@@ -130,6 +141,14 @@
       "45.90.30.0"
     ];
     dotTlsAuthNameFile = config.age.secrets.nextdns-profile.path;
+    # Forward the tailscale magic-DNS suffix to the tailscale resolver
+    # itself so internal services exposed via the tailscale operator
+    # (`*.tailef5cf.ts.net`) resolve from anja without having to
+    # `accept-dns=true` on the tailscale auth (which would clash with
+    # running our own dnsmasq on this host).
+    dnsForwarders = {
+      "tailef5cf.ts.net" = "100.100.100.100";
+    };
     dnsMasqSettings = {
       no-resolv = true;
       bogus-priv = true;

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -144,6 +144,21 @@ in
         (in which case dnsmasq forwards to a local stubby instance).
       '';
     };
+    dnsForwarders = mkOption {
+      type = attrsOf str;
+      default = { };
+      example = {
+        "tailef5cf.ts.net" = "100.100.100.100";
+      };
+      description = ''
+        Per-domain DNS forwarders, rendered as dnsmasq
+        `server=/<domain>/<upstream>` directives. Useful for splitting
+        a specific domain (e.g. tailscale's MagicDNS suffix) off to a
+        dedicated upstream while leaving the rest of the resolver
+        chain untouched. Coexists with `upstreamDnsServers` /
+        `dotUpstreams` — those handle everything else.
+      '';
+    };
     dotUpstreams = mkOption {
       type = listOf str;
       default = [ ];
@@ -426,7 +441,9 @@ in
       services.dnsmasq.enable = true;
       services.dnsmasq.resolveLocalQueries = true;
       services.dnsmasq.settings = {
-        server = if useStubby then [ stubbyAddress ] else cfg.upstreamDnsServers;
+        server =
+          (if useStubby then [ stubbyAddress ] else cfg.upstreamDnsServers)
+          ++ (mapAttrsToList (domain: srv: "/${domain}/${srv}") cfg.dnsForwarders);
         domain = cfg.localDomain;
         local = "/${cfg.localDomain}/";
         # Listen on lo (so the router itself can resolve via 127.0.0.1 from

--- a/profiles/observability.nix
+++ b/profiles/observability.nix
@@ -1,0 +1,89 @@
+{
+  config,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  cfg = config.modules.observability;
+in
+{
+  options.modules.observability = {
+    enable = lib.mkEnableOption "observability — host metrics + log shipping";
+
+    lokiURL = lib.mkOption {
+      type = lib.types.nullOr lib.types.str;
+      default = null;
+      example = "http://loki.tailef5cf.ts.net:3100/loki/api/v1/push";
+      description = ''
+        Loki push endpoint URL. When non-null, Grafana Alloy is
+        enabled and ships systemd-journal entries here. Leave null
+        to skip log shipping (metrics still work).
+      '';
+    };
+  };
+
+  config = lib.mkIf cfg.enable {
+    # Host metrics. node_exporter binds 0.0.0.0:9100 by default; the
+    # router's nftables policy drops unsolicited WAN ingress and only
+    # accepts trusted-interface traffic, so it's not publicly reachable.
+    services.prometheus.exporters.node = {
+      enable = true;
+      port = 9100;
+      enabledCollectors = [
+        "conntrack"
+        "systemd"
+        "textfile"
+        "processes"
+      ];
+      extraFlags = [
+        "--collector.textfile.directory=/var/lib/node_exporter/textfile"
+      ];
+    };
+
+    systemd.tmpfiles.rules = [
+      "d /var/lib/node_exporter/textfile 0755 nobody nobody -"
+    ];
+
+    # dnsmasq metrics — only meaningful where dnsmasq is in use.
+    services.prometheus.exporters.dnsmasq = lib.mkIf config.services.dnsmasq.enable {
+      enable = true;
+      port = 9153;
+      leasesPath = "/var/lib/dnsmasq/dnsmasq.leases";
+    };
+
+    # Alloy: read systemd-journal and push to Loki. Only enabled when a
+    # push URL is configured — this profile is otherwise metrics-only.
+    services.alloy = lib.mkIf (cfg.lokiURL != null) {
+      enable = true;
+      configPath = pkgs.writeText "config.alloy" ''
+        loki.write "default" {
+          endpoint {
+            url = "${cfg.lokiURL}"
+          }
+        }
+
+        loki.relabel "journal" {
+          forward_to = [loki.write.default.receiver]
+          rule {
+            source_labels = ["__journal__systemd_unit"]
+            target_label  = "unit"
+          }
+          rule {
+            source_labels = ["__journal_priority_keyword"]
+            target_label  = "level"
+          }
+        }
+
+        loki.source.journal "default" {
+          forward_to    = [loki.relabel.journal.receiver]
+          max_age       = "12h"
+          labels        = {
+            job  = "systemd-journal",
+            host = "${config.networking.hostName}",
+          }
+        }
+      '';
+    };
+  };
+}


### PR DESCRIPTION
## Summary

Adds host-level observability to `anja` (and any future NixOS host that imports the new profile). Three pieces:

- **`profiles/observability.nix`** — reusable profile gated on `modules.observability.enable`:
  - `prometheus.exporters.node` with `conntrack`/`systemd`/`textfile`/`processes` collectors. The conntrack collector is the most useful one for a router — connection-table fill is something you want graphed.
  - `prometheus.exporters.dnsmasq` (only when dnsmasq is enabled), with `leasesPath` pinned to the NixOS dnsmasq default (`/var/lib/dnsmasq/dnsmasq.leases`) — the upstream module defaults to the Debian path which doesn't exist on NixOS.
  - Grafana Alloy when `lokiURL` is set. Reads systemd-journal, ships to Loki with `unit` and `level` labels relabeled from journal fields; static `job` + `host` labels.

- **`modules/router.nix`** — new `dnsForwarders = { domain = upstream; }` option, rendered alongside the existing `server` directives. Lets you split a domain off to a dedicated upstream (e.g. `*.tailef5cf.ts.net → 100.100.100.100`) without losing any of the existing resolver chain (DoT via stubby, NextDNS auth, etc.).

- **`hosts/x86_64-linux/anja.nix`** — imports the profile, sets `lokiURL` to the tailscale-exposed Loki, sets `dnsForwarders` for `*.tailef5cf.ts.net → 100.100.100.100` so anja can resolve Loki's tailnet hostname without flipping `accept-dns=true` on its tailscale auth (which would clash with running dnsmasq locally).

## Companion PR

The Loki tailscale exposure + Prometheus scrape config live in `exsules-infra-argocd-apps`. Order of apply: this PR is fine to merge first (Alloy will buffer + retry until Loki's tailnet endpoint is reachable; node + dnsmasq exporters listen for whoever scrapes them, no harm if no one does yet).

## Test plan

- [ ] `nix flake check` passes (the existing router VM test still runs — `dnsForwarders` defaults to `{}` so nothing changes there).
- [ ] After merge + anja rebuild:
  - `curl http://10.0.10.1:9100/metrics` returns node-exporter metrics.
  - `curl http://10.0.10.1:9153/metrics` returns dnsmasq-exporter metrics.
  - `dig @10.0.10.1 loki.tailef5cf.ts.net` resolves once the tailnet exposure ships in argocd-apps.
  - `journalctl -u alloy` shows successful Loki pushes once the endpoint is up.