### PR TITLE
fix(router): order VLAN netdev services after parent link

### DIFF
--- a/modules/router.nix
+++ b/modules/router.nix
@@ -12,6 +12,8 @@ let
     mkOption
     mkEnableOption
     mapAttrsToList
+    mapAttrs'
+    nameValuePair
     filterAttrs
     optionalString
     concatMapStringsSep
@@ -412,31 +414,51 @@ in
       };
       users.groups.router-dot = mkIf useStubby { };
 
-      systemd.services.router-dot-resolver = mkIf useStubby {
-        description = "Stubby DoT stub resolver for services.router";
-        after = [ "network.target" ];
-        wantedBy = [ "multi-user.target" ];
-        before = [ "dnsmasq.service" ];
-        serviceConfig = {
-          Type = "simple";
-          User = "router-dot";
-          Group = "router-dot";
-          # ExecStartPre+ runs as root so it can read the agenix-secret
-          # auth name; the rendered config is mode 0640 owned by
-          # root:router-dot so stubby (running as router-dot) can read it
-          # but it stays out of world-readable space.
-          ExecStartPre = "+${stubbyRender}";
-          ExecStart = "${pkgs.stubby}/bin/stubby -C /run/router-dot/stubby.yml";
-          Restart = "on-failure";
-          RuntimeDirectory = "router-dot";
-          RuntimeDirectoryMode = "0750";
-          NoNewPrivileges = true;
-          ProtectSystem = "strict";
-          ProtectHome = true;
-          PrivateTmp = true;
-          AmbientCapabilities = "";
+      systemd.services = {
+        # Only VLAN sub-interfaces have a `<name>-netdev.service`; the
+        # parent physical NIC is brought up by udev before any service
+        # runs, so don't add a Wants= for it (would just be a
+        # "Unit not found" log spam).
+        nftables.wants = mapAttrsToList (name: _: "${name}-netdev.service") cfg.vlans;
+
+        router-dot-resolver = mkIf useStubby {
+          description = "Stubby DoT stub resolver for services.router";
+          after = [ "network.target" ];
+          wantedBy = [ "multi-user.target" ];
+          before = [ "dnsmasq.service" ];
+          serviceConfig = {
+            Type = "simple";
+            User = "router-dot";
+            Group = "router-dot";
+            # ExecStartPre+ runs as root so it can read the agenix-secret
+            # auth name; the rendered config is mode 0640 owned by
+            # root:router-dot so stubby (running as router-dot) can read it
+            # but it stays out of world-readable space.
+            ExecStartPre = "+${stubbyRender}";
+            ExecStart = "${pkgs.stubby}/bin/stubby -C /run/router-dot/stubby.yml";
+            Restart = "on-failure";
+            RuntimeDirectory = "router-dot";
+            RuntimeDirectoryMode = "0750";
+            NoNewPrivileges = true;
+            ProtectSystem = "strict";
+            ProtectHome = true;
+            PrivateTmp = true;
+            AmbientCapabilities = "";
+          };
         };
-      };
+      }
+      # Order each VLAN's netdev service after its parent's address
+      # configuration. Without this, `<vlan>-netdev.service` can race the
+      # parent and run `ip link set <vlan> up` while the parent is still
+      # admin-down, failing with "Network is down" — leaving the VLAN
+      # without an IP and dnsmasq with nothing to offer DHCP clients.
+      // mapAttrs' (
+        name: conf:
+        nameValuePair "${name}-netdev" {
+          after = [ "network-addresses-${conf.interface}.service" ];
+          requires = [ "network-addresses-${conf.interface}.service" ];
+        }
+      ) cfg.vlans;
 
       services.dnsmasq.enable = true;
       services.dnsmasq.resolveLocalQueries = true;
@@ -609,10 +631,7 @@ in
         '';
       };
 
-      # Only VLAN sub-interfaces have a `<name>-netdev.service`; the parent
-      # physical NIC is brought up by udev before any service runs, so don't
-      # add a Wants= for it (would just be a "Unit not found" log spam).
-      systemd.services.nftables.wants = mapAttrsToList (name: _: "${name}-netdev.service") cfg.vlans;
+
 
       boot.kernel.sysctl = {
         "net.ipv4.conf.all.forwarding" = true;


### PR DESCRIPTION
## Summary

Fixes the intermittent `router_test` failure where the iot VLAN client never gets a DHCP lease.

Each `<name>-netdev.service` ran `ip link set <name> up` without ordering against its parent's link-up service. When the child raced ahead of the parent's `network-addresses-<parent>.service`, the kernel returned `RTNETLINK answers: Network is down`, the VLAN never got its IP, and dnsmasq spent the rest of the test logging `DHCP packet received on <name> which has no address` with no offer.

In the failing PR #1040 run, `iot` lost the race and `trustedvl` won; on re-run the order flipped and CI went green. The race is in `modules/router.nix`, not in CI.

This change adds `Requires=`/`After=network-addresses-<parent>.service` to each VLAN netdev unit, making the order deterministic. Also consolidates the now multi-key `systemd.services` definition into a single attrset (Nix syntax requires this) and adds `mapAttrs'` / `nameValuePair` to the `lib` inherit.

Failing-run journal that motivated the fix:

```
[54.556] Starting VLAN Interface iot...
[54.631] Starting Address configuration of eth2...
[54.707] Starting VLAN Interface trustedvl...
[55.486] iot-netdev-start: RTNETLINK answers: Network is down       ← FAIL
[55.677] network-addresses-iot-start: RTNETLINK answers: Network is down
[55.759] network-addresses-eth2-start: adding address 10.0.0.1/24... done
[56.059] network-addresses-trustedvl-start: adding address 10.0.10.1/24... done
```

## Test plan

- [x] `nix build .#checks.x86_64-linux.router -L` — passes
- [x] `nix build .#checks.x86_64-linux.router -L --rebuild` x3 — all green, no `Network is down` lines on the router
- [ ] CI `router_test` green