### PR TITLE
fix(ai): track llama.cpp webui move to tools/ui

### DIFF
--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -7,12 +7,12 @@
   services.llama-swap = {
     enable = true;
     package = pkgs.llama-swap.overrideAttrs (oa: rec {
-      version = "213";
+      version = "216";
       src = pkgs.fetchFromGitHub {
         owner = "mostlygeek";
         repo = "llama-swap";
         tag = "v${version}";
-        hash = "sha256-B3LI2VfsNDNwj2dkCa3KSEOaWQ/4BgcsDQj7xotCtEk=";
+        hash = "sha256-PHSY4z2h406xL+EcIYyrzr4s28txO7SCsWm8hrXf+2U=";
         leaveDotGit = true;
         postFetch = ''
           cd "$out"
@@ -50,19 +50,20 @@
             cudaSupport = false;
           }).overrideAttrs
             (oa: rec {
-              version = "9172";
+              version = "9247";
               src = pkgs.fetchFromGitHub {
                 owner = "ggml-org";
                 repo = "llama.cpp";
                 tag = "b${version}";
-                hash = "sha256-n7I3XJab5CoYq1q6F4oZlbtzItdJ+f7S8GbJeNDan+s=";
+                hash = "sha256-gc5Ky5Jr9T8x1jOKmM7dWc65VnwTrZS4lZ5qv/UjCa8=";
                 leaveDotGit = true;
                 postFetch = ''
                   git -C "$out" rev-parse --short HEAD > $out/COMMIT
                   find "$out" -name .git -print0 | xargs -0 rm -rf
                 '';
               };
-              npmDepsHash = "sha256-WaEePrEZ7O/7deP2KJhe0AwiSKYA8HOqETmMHUkmBe0=";
+              npmRoot = "tools/ui";
+              npmDepsHash = "sha256-Iyg8FpcTKf2UYHuK7mA3cTAqVaLcQPcS0YCa5Qf01Gc=";
 
               cmakeFlags = (oa.cmakeFlags or [ ]) ++ [
                 "-DGGML_NATIVE=ON"

--- a/scripts/update-ai.sh
+++ b/scripts/update-ai.sh
@@ -67,7 +67,7 @@ let pkgs = import <nixpkgs> {};
     src = ${llama_cpp_src_expr//@HASH@/$src_hash};
 in pkgs.fetchNpmDeps {
   inherit src;
-  preBuild = "pushd tools/server/webui";
+  preBuild = "pushd tools/ui";
   hash = "$FAKE_HASH";
 }
 NIX


### PR DESCRIPTION
## Summary

- The Nix Autoupdater workflow has been failing on every run since llama.cpp `b9180` because the web UI was relocated from `tools/server/webui` to `tools/ui`. Both `fetchNpmDeps` and `preConfigure` errored with `pushd: tools/server/webui: No such file or directory`.
- Override `npmRoot = "tools/ui"` in `profiles/ai.nix` (consumed by both `fetchNpmDeps` and `preConfigure` via `finalAttrs.npmRoot`).
- Update `scripts/update-ai.sh` to probe `npmDepsHash` against the new path so future runs of the script work too.
- Bump llama-swap `213 → 216` and llama.cpp `9172 → 9247` so the repo stays buildable (the `npmRoot` override would otherwise break the previously-pinned `b9172`, where `tools/ui` doesn't yet exist).

## Test plan

- [x] `bash scripts/update-ai.sh` succeeds and produces new src/npmDeps hashes for both projects.
- [x] `nix-instantiate` on the overridden `llama-cpp` derivation evaluates with `npmRoot = "tools/ui"` and successfully constructs the `npm-deps.drv`.
- [ ] Re-run the **Nix Autoupdater** workflow after this merges; the **Update llama-swap and llama.cpp** step should exit 0 (and be a no-op, since this PR already includes the latest pins).
- [ ] `nixos-rebuild build` on a host that imports `profiles/ai.nix` completes (full llama.cpp build).