### PR TITLE
fix(disk): override systemd 260 SYSTEMD_READY=0 on cryptkey dm device

### DIFF
--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -5,6 +5,7 @@
     {
       checks = pkgs.lib.optionalAttrs (system == "x86_64-linux") {
         router = pkgs.callPackage ../tests/router.nix { inherit inputs; };
+        btrfs-on-luks = pkgs.callPackage ../tests/btrfs-on-luks.nix { };
       };
     };
 }

--- a/hosts/x86_64-linux/elsa.nix
+++ b/hosts/x86_64-linux/elsa.nix
@@ -37,7 +37,7 @@
   users.users.${adminUser.name}.shell = lib.mkForce pkgs.bashInteractive;
 
   system.autoUpgrade = {
-    enable = true;
+    enable = false;
     flake = "github:blazed/cake";
     allowReboot = true;
     dates = "02:00";

--- a/hosts/x86_64-linux/margot.nix
+++ b/hosts/x86_64-linux/margot.nix
@@ -44,7 +44,7 @@
   ];
 
   system.autoUpgrade = {
-    enable = true;
+    enable = false;
     flake = "github:blazed/cake";
     allowReboot = true;
     dates = "02:00";

--- a/hosts/x86_64-linux/sophia.nix
+++ b/hosts/x86_64-linux/sophia.nix
@@ -74,7 +74,7 @@
   users.users.${adminUser.name}.shell = lib.mkForce pkgs.bashInteractive;
 
   system.autoUpgrade = {
-    enable = true;
+    enable = false;
     flake = "github:blazed/cake";
     allowReboot = true;
     dates = "06:00";

--- a/profiles/disk/btrfs-on-luks.nix
+++ b/profiles/disk/btrfs-on-luks.nix
@@ -1,11 +1,25 @@
 {
   lib,
   config,
+  pkgs,
   ...
 }:
 let
   btrfsDisks = config.btrfs.disks;
   tmpfsRootSizeGb = config.tmpfsRoot.sizegb;
+  # systemd 260's 99-systemd.rules marks any CRYPT-* dm device with no
+  # detected partition table and no detected filesystem as SYSTEMD_READY=0
+  # (to avoid acting on a half-formatted encrypted volume mid-mke2fs).
+  # Our cryptkey is intentionally raw LUKS-wrapped key material, so it
+  # always matches that rule and wedges the cryptkey -> encrypted_root
+  # chain: dev-mapper-cryptkey.device never activates, encrypted_root
+  # waits forever, and /dev/disk/by-label/root times out in initrd.
+  # Shipped as 999-* so it sorts *after* 99-systemd.rules; the alternative
+  # `boot.initrd.services.udev.rules` only writes 99-local.rules, which
+  # sorts before 99-systemd.rules and is overwritten by it.
+  cryptkeySystemdReadyOverride = pkgs.writeTextDir "lib/udev/rules.d/999-cryptkey-systemd-ready.rules" ''
+    SUBSYSTEM=="block", ENV{DM_NAME}=="cryptkey", ENV{SYSTEMD_READY}="1"
+  '';
 in
 {
   fileSystems."/" = {
@@ -52,6 +66,8 @@ in
     "btrfs"
     "vfat"
   ];
+
+  boot.initrd.services.udev.packages = [ cryptkeySystemdReadyOverride ];
 
   boot.initrd.luks.devices =
     lib.recursiveUpdate

--- a/tests/btrfs-on-luks.nix
+++ b/tests/btrfs-on-luks.nix
@@ -1,0 +1,119 @@
+{ pkgs, ... }:
+# Regression test for the cryptkey -> encrypted_root LUKS chain used by
+# profiles/disk/btrfs-on-luks.nix. The original failure (systemd 260) was a
+# new rule in 99-systemd.rules that marks any CRYPT-* dm device with no
+# detected partition table and no detected filesystem as SYSTEMD_READY=0
+# (intended to skip half-formatted encrypted volumes mid-mke2fs). Our
+# cryptkey volume is intentionally raw LUKS-wrapped key material, so it
+# matched, dev-mapper-cryptkey.device never activated, and the whole
+# chain hung in initrd waiting for /dev/disk/by-label/root.
+#
+# This test reproduces the chain at runtime and ships the same udev rule
+# override that profiles/disk/btrfs-on-luks.nix installs into the initrd.
+# It pins linuxPackages_latest so the check follows whatever the latest
+# flake input bump pulled in; if a future systemd/udev change breaks
+# dm-device readiness in a way the current override doesn't cover, CI
+# fails here instead of a router failing to boot at 05:00.
+let
+  # Mirror of the rule shipped by profiles/disk/btrfs-on-luks.nix. Keep in
+  # sync: if the override condition or filename changes there, change here.
+  cryptkeySystemdReadyOverride =
+    pkgs.writeTextDir "lib/udev/rules.d/999-cryptkey-systemd-ready.rules"
+      ''
+        SUBSYSTEM=="block", ENV{DM_NAME}=="cryptkey", ENV{SYSTEMD_READY}="1"
+      '';
+in
+pkgs.testers.runNixOSTest {
+  name = "btrfs-on-luks-cryptchain";
+
+  nodes.machine =
+    { pkgs, ... }:
+    {
+      boot.kernelPackages = pkgs.linuxPackages_latest;
+      boot.initrd.systemd.enable = true;
+
+      services.udev.packages = [ cryptkeySystemdReadyOverride ];
+
+      environment.systemPackages = [
+        pkgs.cryptsetup
+        pkgs.btrfs-progs
+      ];
+    };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # Lay out the same chain btrfs-on-luks.nix uses in production:
+    # cryptkey LUKS volume opened by a static keyfile, then a second LUKS
+    # volume (encrypted_root) whose keyfile is /dev/mapper/cryptkey. The
+    # production setup uses /sys/.../product_serial for the outer keyfile;
+    # that DMI path is APU-specific and unrelated to the bug we're guarding
+    # against, so we substitute a plain file.
+    machine.succeed("printf cryptkey-test-material > /tmp/keyfile")
+    # LUKS2 defaults to a 16 MiB metadata header, so the backing files have
+    # to leave room for actual data beyond that. cryptkey only ever holds a
+    # short keyfile, but the volume must be > header size to activate at
+    # all. encrypted_root needs enough for mkfs.btrfs to succeed.
+    machine.succeed("truncate -s 32M /tmp/cryptkey.img")
+    machine.succeed("truncate -s 256M /tmp/encrypted_root.img")
+
+    machine.succeed(
+        "cryptsetup luksFormat -q --type=luks2 --pbkdf=pbkdf2 --pbkdf-force-iterations=1000 "
+        "/tmp/cryptkey.img /tmp/keyfile"
+    )
+    machine.succeed(
+        "cryptsetup luksOpen --key-file=/tmp/keyfile /tmp/cryptkey.img cryptkey"
+    )
+    # cryptsetup caps keyfile reads at 8 MiB. The cryptkey mapper device is
+    # the full LUKS data area (volume size minus the 16 MiB LUKS2 header),
+    # which here is larger than that cap. Cap the keyfile read explicitly;
+    # production's cryptkey partition is sized to stay under the cap, but
+    # making the test independent of that sizing is cleaner.
+    machine.succeed(
+        "cryptsetup luksFormat -q --type=luks2 --pbkdf=pbkdf2 --pbkdf-force-iterations=1000 "
+        "--keyfile-size=4096 --key-file=/dev/mapper/cryptkey /tmp/encrypted_root.img"
+    )
+    machine.succeed(
+        "cryptsetup luksOpen --keyfile-size=4096 --key-file=/dev/mapper/cryptkey "
+        "/tmp/encrypted_root.img encrypted_root"
+    )
+    machine.succeed("mkfs.btrfs -L root /dev/mapper/encrypted_root")
+
+    # Let udev finish processing the dm events before we read the properties.
+    machine.succeed("udevadm settle --timeout=15")
+
+    with subtest("cryptkey dm device is marked SYSTEMD_READY=1"):
+        props = machine.succeed(
+            "udevadm info --query=property --name=/dev/mapper/cryptkey"
+        )
+        assert "SYSTEMD_READY=1" in props, (
+            "cryptkey dm device was not marked SYSTEMD_READY=1 by udev; "
+            "this is the regression that prevents systemd-cryptsetup@*.service "
+            "from ever activating during initrd. udev properties:\n" + props
+        )
+
+    with subtest("encrypted_root dm device is not marked SYSTEMD_READY=0"):
+        # blkid finds btrfs inside encrypted_root, so systemd's rule that
+        # marks empty CRYPT-* devices as not-ready doesn't fire and
+        # SYSTEMD_READY is left unset (which systemd treats as ready). We
+        # only need to assert it isn't explicitly =0.
+        props = machine.succeed(
+            "udevadm info --query=property --name=/dev/mapper/encrypted_root"
+        )
+        assert "SYSTEMD_READY=0" not in props, (
+            "encrypted_root dm device was marked SYSTEMD_READY=0 unexpectedly. "
+            "udev properties:\n" + props
+        )
+
+    with subtest("systemd activates the dm-mapper device units"):
+        # If SYSTEMD_READY=1 above but these units don't activate, that's a
+        # different (but related) regression in systemd's device-unit handling.
+        machine.succeed("systemctl is-active dev-mapper-cryptkey.device")
+        machine.succeed("systemctl is-active dev-mapper-encrypted_root.device")
+
+    with subtest("by-label/root surfaces from the encrypted btrfs volume"):
+        # The original symptom was /dev/disk/by-label/root timing out in
+        # initrd. Verify the symlink shows up here as a final belt-and-braces.
+        machine.succeed("test -L /dev/disk/by-label/root")
+  '';
+}


### PR DESCRIPTION
## Summary

- **Root cause**: systemd 260's `99-systemd.rules` ships a new rule that marks any `CRYPT-*` dm device with no detected partition table and no detected filesystem as `SYSTEMD_READY=0` (intended to skip half-formatted encrypted volumes mid-`mke2fs`). Our `cryptkey` LUKS volume is intentionally raw key material — no partition table, no filesystem — so it matches, `dev-mapper-cryptkey.device` never activates, `systemd-cryptsetup@encrypted_root.service` waits forever, and initrd times out on `/dev/disk/by-label/root`. Hit anja first after the latest nixpkgs bump rolled in systemd 260.

- **Fix** (`profiles/disk/btrfs-on-luks.nix`): ship a higher-numbered initrd udev rule (`999-cryptkey-systemd-ready.rules`) via `boot.initrd.services.udev.packages` that re-asserts `SYSTEMD_READY=1` for `DM_NAME=="cryptkey"`. The `boot.initrd.services.udev.rules` option only writes `99-local.rules`, which sorts before `99-systemd.rules` and gets overwritten — hence the package + `999-` prefix.

- **Regression test** (`tests/btrfs-on-luks.nix`, wired into flake `checks`): a NixOS VM check that reproduces the cryptkey → encrypted_root chain at runtime on `linuxPackages_latest` and asserts `SYSTEMD_READY=1` on the dm devices and that the device units activate. Catches the next systemd/udev regression in CI instead of in a router at 05:00.

- **Precaution** (`hosts/x86_64-linux/{elsa,margot,sophia}.nix`): disable `system.autoUpgrade` on the other three servers using the same btrfs-on-luks profile. Re-enable in a follow-up once the override has cycled through manual upgrades on all four.

## Test plan

- [x] Manually verified anja boots cleanly with the override (initrd no longer wedges; `/dev/disk/by-label/root` appears; routing/DHCP/DNS work).
- [ ] `nix build .#checks.x86_64-linux.btrfs-on-luks` passes in CI.
- [ ] Deploy + reboot elsa, margot, sophia; each comes back routing/services healthy.
- [ ] Follow-up PR: re-enable `system.autoUpgrade` on anja/elsa/margot/sophia once all four have ridden a clean manual upgrade.