### PR TITLE
feat(ai): jailed AI coding agent harnesses (jail.nix)

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -76,6 +76,64 @@
         "type": "github"
       }
     },
+    "blueprint": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ]
+      },
+      "locked": {
+        "lastModified": 1776249299,
+        "narHash": "sha256-Dt9t1TGRmJFc0xVYhttNBD6QsAgHOHCArqGa0AyjrJY=",
+        "owner": "numtide",
+        "repo": "blueprint",
+        "rev": "56131e8628f173d24a27f6d27c0215eff57e40dd",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "blueprint",
+        "type": "github"
+      }
+    },
+    "bun2nix": {
+      "inputs": {
+        "flake-parts": [
+          "llm-agents",
+          "flake-parts"
+        ],
+        "nixpkgs": [
+          "llm-agents",
+          "nixpkgs"
+        ],
+        "systems": [
+          "llm-agents",
+          "systems"
+        ],
+        "treefmt-nix": [
+          "llm-agents",
+          "treefmt-nix"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778446047,
+        "narHash": "sha256-oQvcadh2BCkrog+SGrG6YffKJrveYpjj3TdQJWaKhaM=",
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "rev": "f2bc12af1a6369648aac41041ceeaa0b866599c6",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "bun2nix",
+        "type": "github"
+      }
+    },
     "cachix": {
       "inputs": {
         "devenv": [
@@ -173,6 +231,27 @@
       "original": {
         "type": "tarball",
         "url": "https://github.com/cilium/charts/raw/refs/heads/master/cilium-1.18.9.tgz"
+      }
+    },
+    "claude-code": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1779510126,
+        "narHash": "sha256-AN19hN63A3nuuUsOo42dERR/fmMt/rSEqNc1F3xjpAs=",
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "rev": "304b96c0998c76633bacbb44daa6a5de40f92273",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sadjow",
+        "repo": "claude-code-nix",
+        "type": "github"
       }
     },
     "crane": {
@@ -530,6 +609,27 @@
     "flake-parts_8": {
       "inputs": {
         "nixpkgs-lib": [
+          "llm-agents",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1778716662,
+        "narHash": "sha256-m1Yf0wZ8j1OHjTc2UwHwyQRSnNeSgLJOd7q5Y45hzi4=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "f7c1a2d347e4c52d5fb8d10cb4d94b5884e546fb",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
+    "flake-parts_9": {
+      "inputs": {
+        "nixpkgs-lib": [
           "nur",
           "nixpkgs"
         ]
@@ -564,6 +664,24 @@
       }
     },
     "flake-utils": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
       "inputs": {
         "systems": [
           "systems"
@@ -973,7 +1091,7 @@
         "hyprwire": "hyprwire",
         "nixpkgs": "nixpkgs",
         "pre-commit-hooks": "pre-commit-hooks",
-        "systems": "systems_2",
+        "systems": "systems_3",
         "xdph": "xdph"
       },
       "locked": {
@@ -1240,6 +1358,21 @@
         "type": "github"
       }
     },
+    "jail-nix": {
+      "locked": {
+        "lastModified": 1772137954,
+        "narHash": "sha256-h4MGNbOo7L3RHi4uNFmsg5g17/DHXEfnv/xiG6BrNFQ=",
+        "owner": "~alexdavid",
+        "repo": "jail.nix",
+        "rev": "42b355c38ca63dab4904acc5c0d95f17954a8c9b",
+        "type": "sourcehut"
+      },
+      "original": {
+        "owner": "~alexdavid",
+        "repo": "jail.nix",
+        "type": "sourcehut"
+      }
+    },
     "kured": {
       "flake": false,
       "locked": {
@@ -1253,6 +1386,31 @@
       "original": {
         "owner": "kubereboot",
         "repo": "kured",
+        "type": "github"
+      }
+    },
+    "llm-agents": {
+      "inputs": {
+        "blueprint": "blueprint",
+        "bun2nix": "bun2nix",
+        "flake-parts": "flake-parts_8",
+        "nixpkgs": [
+          "nixpkgs"
+        ],
+        "systems": "systems_4",
+        "treefmt-nix": "treefmt-nix_3"
+      },
+      "locked": {
+        "lastModified": 1779704624,
+        "narHash": "sha256-INy8z/zDl0EQSaxIV+S4Xkq99NCWaqBKtxHmJoOdfyE=",
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
+        "rev": "b4d59ea23a029466b3e8314835ac7714296f2595",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "llm-agents.nix",
         "type": "github"
       }
     },
@@ -1667,7 +1825,7 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_8",
+        "flake-parts": "flake-parts_9",
         "nixpkgs": "nixpkgs_4"
       },
       "locked": {
@@ -1779,17 +1937,20 @@
         "cachix": "cachix",
         "candle": "candle",
         "cilium-chart": "cilium-chart",
+        "claude-code": "claude-code",
         "crane": "crane",
         "devenv": "devenv_2",
         "disko": "disko",
         "fenix": "fenix",
         "flake-compat": "flake-compat_2",
         "flake-parts": "flake-parts_7",
-        "flake-utils": "flake-utils",
+        "flake-utils": "flake-utils_2",
         "home-manager": "home-manager",
         "hyprland": "hyprland",
         "impermanence": "impermanence",
+        "jail-nix": "jail-nix",
         "kured": "kured",
+        "llm-agents": "llm-agents",
         "mk-shell-bin": "mk-shell-bin",
         "nix2container": "nix2container_2",
         "nixos-generators": "nixos-generators",
@@ -1799,7 +1960,7 @@
         "persway": "persway",
         "pre-commit-hooks": "pre-commit-hooks_2",
         "rust-overlay": "rust-overlay_2",
-        "systems": "systems_3",
+        "systems": "systems_5",
         "zen-browser": "zen-browser"
       }
     },
@@ -1878,6 +2039,21 @@
     },
     "systems_2": {
       "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_3": {
+      "locked": {
         "lastModified": 1689347949,
         "narHash": "sha256-12tWmuL2zgBgZkdoB6qXZsgJEH9LR3oUgpaQq2RbI80=",
         "owner": "nix-systems",
@@ -1891,7 +2067,22 @@
         "type": "github"
       }
     },
-    "systems_3": {
+    "systems_4": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_5": {
       "locked": {
         "lastModified": 1681028828,
         "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
@@ -1934,6 +2125,27 @@
         "nixpkgs": [
           "devenv",
           "nixd",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1775636079,
+        "narHash": "sha256-pc20NRoMdiar8oPQceQT47UUZMBTiMdUuWrYu2obUP0=",
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "rev": "790751ff7fd3801feeaf96d7dc416a8d581265ba",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "treefmt-nix",
+        "type": "github"
+      }
+    },
+    "treefmt-nix_3": {
+      "inputs": {
+        "nixpkgs": [
+          "llm-agents",
           "nixpkgs"
         ]
       },

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,8 @@
     };
     cilium-chart.url = "https://github.com/cilium/charts/raw/refs/heads/master/cilium-1.18.9.tgz";
     cilium-chart.flake = false;
+    claude-code.url = "github:sadjow/claude-code-nix";
+    claude-code.inputs.nixpkgs.follows = "nixpkgs";
     crane.url = "github:ipetkov/crane";
     devenv.inputs.flake-compat.follows = "flake-compat";
     devenv.inputs.nixpkgs.follows = "nixpkgs";
@@ -49,8 +51,11 @@
     home-manager.url = "github:nix-community/home-manager";
     hyprland.url = "github:hyprwm/Hyprland";
     impermanence.url = "github:nix-community/impermanence";
+    jail-nix.url = "sourcehut:~alexdavid/jail.nix";
     kured.flake = false;
     kured.url = "github:kubereboot/kured";
+    llm-agents.url = "github:numtide/llm-agents.nix";
+    llm-agents.inputs.nixpkgs.follows = "nixpkgs";
     mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
     nix2container.url = "github:nlewo/nix2container";

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -7,6 +7,7 @@
         router = pkgs.callPackage ../tests/router.nix { inherit inputs; };
         btrfs-on-luks = pkgs.callPackage ../tests/btrfs-on-luks.nix { };
         jail-leak-audit = pkgs.callPackage ../tests/jail-leak-audit.nix { inherit inputs; };
+        jail-jj-workspace = pkgs.callPackage ../tests/jail-jj-workspace.nix { inherit inputs; };
       };
     };
 }

--- a/flake/checks.nix
+++ b/flake/checks.nix
@@ -6,6 +6,7 @@
       checks = pkgs.lib.optionalAttrs (system == "x86_64-linux") {
         router = pkgs.callPackage ../tests/router.nix { inherit inputs; };
         btrfs-on-luks = pkgs.callPackage ../tests/btrfs-on-luks.nix { };
+        jail-leak-audit = pkgs.callPackage ../tests/jail-leak-audit.nix { inherit inputs; };
       };
     };
 }

--- a/tests/jail-jj-workspace.nix
+++ b/tests/jail-jj-workspace.nix
@@ -1,0 +1,75 @@
+{ pkgs, inputs, ... }:
+let
+  builders = import ../users/profiles/jailed-agents-builders.nix { inherit pkgs inputs; };
+
+  # Probe wrapped in claude's exact sandbox (which includes the jjWorkspace
+  # combinator). Run from inside a jj workspace, it must be able to drive jj
+  # against the shared store while NOT seeing a sibling workspace's working tree
+  # or the (signing-enabled) user jj config.
+  probe = builders.jail "jj-probe" "${pkgs.writeShellScript "jj-probe-script" ''
+    echo "JJ_USER=$JJ_USER JJ_EMAIL=$JJ_EMAIL"
+    echo "JJ_EDITOR=$JJ_EDITOR"
+    jj describe -m "from jail" 2>&1 | head -3
+    # editor-driven (no -m): must NOT hang on an interactive editor. JJ_EDITOR=echo
+    # makes jj reuse the existing description. timeout guards against a regression.
+    timeout 20 jj describe 2>&1 | head -2 && echo DESCRIBE_NOEDITOR_OK || echo DESCRIBE_NOEDITOR_HANG
+    jj --ignore-working-copy log --no-graph -r '@' 2>&1 | head -2
+    cat ./FEATURE.txt >/dev/null 2>&1 && echo FEATURE_OK || echo FEATURE_MISSING
+    if cat "$HOME/proj/MAIN_SECRET.txt" >/dev/null 2>&1; then echo MAIN_LEAK; else echo MAIN_BLOCKED; fi
+    if cat "$HOME/.config/jj/config.toml" >/dev/null 2>&1; then echo CONFIG_LEAK; else echo CONFIG_NOT_BOUND; fi
+  ''}" (builders.permsFor builders.agents.claude);
+in
+pkgs.testers.runNixOSTest {
+  name = "jail-jj-workspace";
+
+  nodes.machine = {
+    environment.systemPackages = [
+      probe
+      pkgs.jujutsu
+    ];
+    users.users.tester = {
+      isNormalUser = true;
+      home = "/home/tester";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # jj identity in the user config (no signing yet, so the host setup commits
+    # below can be created — the VM has no ssh signing key).
+    machine.succeed(
+        "su - tester -c 'mkdir -p ~/.config/jj && "
+        "printf \"[user]\\nname = \\\"Tester\\\"\\nemail = \\\"tester@example.com\\\"\\n\" "
+        "> ~/.config/jj/config.toml'"
+    )
+
+    # colocated repo with a secret working file in main + a second workspace.
+    machine.succeed(
+        "su - tester -c 'mkdir ~/proj && cd ~/proj && jj git init --colocate && "
+        "echo secret-in-main > MAIN_SECRET.txt && jj describe -m init && jj new -m wip && "
+        "jj workspace add --name feat ~/proj-feat && echo feature > ~/proj-feat/FEATURE.txt'"
+    )
+
+    # NOW enable ssh signing in the user config. With no key on the VM this would
+    # make any host-side commit fail — which is exactly the point: the jail must
+    # neither bind this config nor attempt signing.
+    machine.succeed(
+        "su - tester -c 'printf \"[signing]\\nbehavior = \\\"own\\\"\\nbackend = \\\"ssh\\\"\\n\" "
+        ">> ~/.config/jj/config.toml'"
+    )
+
+    with subtest("jj works in-jail from a workspace; identity injected; isolation holds"):
+        # forward a bogus interactive JJ_EDITOR — the jail must override it with echo.
+        out = machine.succeed("su - tester -c 'cd ~/proj-feat && TERM=xterm JJ_EDITOR=nano jj-probe'")
+        print(out)
+        assert "from jail" in out, out                 # jj describe succeeded (unsigned)
+        assert "tester@example.com" in out, out         # identity injected via JJ_EMAIL
+        assert "Signing error" not in out, out          # signing not attempted in jail
+        assert "JJ_EDITOR=echo" in out, out             # editor forced to no-op, beats forwarded nano
+        assert "DESCRIBE_NOEDITOR_OK" in out and "DESCRIBE_NOEDITOR_HANG" not in out, out  # no interactive hang
+        assert "FEATURE_OK" in out, out                 # own workspace files reachable
+        assert "MAIN_BLOCKED" in out and "MAIN_LEAK" not in out, out   # sibling tree hidden
+        assert "CONFIG_NOT_BOUND" in out and "CONFIG_LEAK" not in out, out  # jj config not bound
+  '';
+}

--- a/tests/jail-leak-audit.nix
+++ b/tests/jail-leak-audit.nix
@@ -1,0 +1,105 @@
+{ pkgs, inputs, ... }:
+let
+  builders = import ../users/profiles/jailed-agents-builders.nix { inherit pkgs inputs; };
+
+  # Audit payload, wrapped in claude's *exact* sandbox permission set. Uses only
+  # bash builtins + coreutils so it doesn't depend on the curated toolset (whose
+  # presence/absence is itself checked). Exits non-zero on any leak.
+  auditScript = pkgs.writeShellScript "leak-audit" ''
+    set -u
+    rc=0
+    blocked() { # must NOT be reachable
+      if ls -d "$1" >/dev/null 2>&1 || cat "$1" >/dev/null 2>&1; then
+        echo "LEAK: $1 reachable"; rc=1
+      else echo "ok:   $1 blocked"; fi
+    }
+    allowed() { # must be reachable
+      if ls -d "$1" >/dev/null 2>&1; then echo "ok:   $1 reachable (intended)"
+      else echo "MISSING: $1 not reachable"; rc=1; fi
+    }
+
+    echo "## HOME=$HOME ; ls ~ ->"; ls -a1 "$HOME"
+
+    echo "## secrets that must be blocked"
+    for p in .ssh .aws .gnupg .kube .config/gcloud .codex .pi code; do
+      blocked "$HOME/$p"
+    done
+    blocked /run/agenix/fake-key
+    blocked /etc/shadow
+
+    echo "## paths the agent should reach"
+    allowed "$HOME/.claude"
+    allowed "$HOME/.claude.json"
+    if [ -e ./LEAK_MARKER.txt ]; then echo "ok:   CWD mounted"; else echo "MISSING: cwd marker"; rc=1; fi
+
+    echo "## environment: secret-looking vars stripped, benign project vars forwarded"
+    # DATABASE_URL embeds user:pass@ in its value, so it must be stripped by value
+    # even though its name matches no deny pattern.
+    for v in AWS_SECRET_ACCESS_KEY GITHUB_TOKEN DB_PASSWORD MYSQL_PWD DATABASE_URL MY_API_KEY SSH_AUTH_SOCK; do
+      if [ -n "''${!v:-}" ]; then echo "LEAK: secret env $v present"; rc=1; else echo "ok:   secret env $v stripped"; fi
+    done
+    if [ "''${PROJECT_SETTING:-}" = "ok" ]; then echo "ok:   benign env PROJECT_SETTING forwarded"; else echo "MISSING: PROJECT_SETTING not forwarded"; rc=1; fi
+    # A credential-free URL must NOT be stripped (value-based rule needs :pass@).
+    if [ "''${SERVICE_URL:-}" = "http://localhost:9292" ]; then echo "ok:   credential-free SERVICE_URL forwarded"; else echo "MISSING: SERVICE_URL stripped/absent"; rc=1; fi
+
+    echo "## process namespace isolation"
+    set -- /proc/[0-9]*
+    echo "visible PIDs: $#"
+    if [ "$#" -lt 20 ]; then echo "ok:   pid namespace isolated"; else echo "LEAK: $# PIDs visible"; rc=1; fi
+
+    echo
+    if [ "$rc" -eq 0 ]; then echo "RESULT: NO LEAKS"; else echo "RESULT: LEAKS DETECTED"; fi
+    exit "$rc"
+  '';
+
+  auditJail = builders.jail "leak-audit" "${auditScript}" (builders.permsFor builders.agents.claude);
+in
+pkgs.testers.runNixOSTest {
+  name = "jail-leak-audit";
+
+  nodes.machine = {
+    environment.systemPackages = [
+      auditJail
+      pkgs.bubblewrap
+    ];
+    users.users.tester = {
+      isNormalUser = true;
+      home = "/home/tester";
+    };
+  };
+
+  testScript = ''
+    machine.wait_for_unit("multi-user.target")
+
+    # A world-readable "secret" outside $HOME — the jail must block it even
+    # though unix perms alone wouldn't (mirrors agenix runtime secrets).
+    machine.succeed("mkdir -p /run/agenix && echo SENTINEL > /run/agenix/fake-key && chmod 644 /run/agenix/fake-key")
+
+    # Plant real secrets + the allowed config dirs as the tester user.
+    machine.succeed(
+        "su - tester -c 'umask 077; "
+        "mkdir -p ~/.ssh ~/.aws ~/.gnupg ~/.kube ~/.config/gcloud ~/.codex ~/.pi ~/code ~/.claude ~/work; "
+        "echo PRIVKEY > ~/.ssh/id_ed25519; "
+        "echo CREDS > ~/.aws/credentials; "
+        "echo {} > ~/.claude.json; "
+        "echo allowed > ~/.claude/settings.json; "
+        "echo MARKER > ~/work/LEAK_MARKER.txt'"
+    )
+
+    with subtest("test data is genuinely readable on the host (so blocking is meaningful)"):
+        machine.succeed("su - tester -c 'cat ~/.ssh/id_ed25519'")
+        machine.succeed("su - tester -c 'cat /run/agenix/fake-key'")
+
+    with subtest("jailed agent sandbox leaks nothing"):
+        out = machine.succeed(
+            "su - tester -c 'cd ~/work && "
+            "AWS_SECRET_ACCESS_KEY=should-not-leak GITHUB_TOKEN=ghp_x DB_PASSWORD=hunter2 "
+            "MYSQL_PWD=hunter2 DATABASE_URL=postgres://u:p@h/db SERVICE_URL=http://localhost:9292 "
+            "MY_API_KEY=sk-x SSH_AUTH_SOCK=/run/user/0/keyring/ssh "
+            "PROJECT_SETTING=ok TERM=xterm "
+            "leak-audit'"
+        )
+        print(out)
+        assert "RESULT: NO LEAKS" in out, out
+  '';
+}

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -18,6 +18,7 @@ in
     ./firefox.nix
     ./git.nix
     ./gitui.nix
+    ./jailed-agents.nix
     ./jujutsu.nix
     ./mergiraf.nix
     ./neovim.nix

--- a/users/profiles/jailed-agents-builders.nix
+++ b/users/profiles/jailed-agents-builders.nix
@@ -1,0 +1,149 @@
+# Pure builders for the jailed agent wrappers.
+#
+# This is the single source of truth for the bubblewrap permission set. It is
+# consumed by the home-manager profile (./jailed-agents.nix, which installs
+# `wrappers`) and by the NixOS tests under ../../tests: jail-leak-audit.nix wraps
+# an audit payload with `permsFor agents.claude`, and jail-jj-workspace.nix
+# exercises the same sandbox from inside a jj workspace. Keeping the permissions
+# here means the tests exercise the exact sandbox the agents run in — a leaky
+# bind added to `common` would make the audit fail.
+{ pkgs, inputs }:
+let
+  inherit (pkgs.stdenv.hostPlatform) system;
+  jail = inputs.jail-nix.lib.init pkgs;
+  llm = inputs.llm-agents.packages.${system};
+
+  # Tools on PATH inside every jail. Deliberately excludes gcloud/kubectl/aws/ssh
+  # so a runaway agent can't reach cloud or remote credentials.
+  devTools = with pkgs; [
+    # keep-sorted start
+    bashInteractive
+    curl
+    diffutils
+    fd
+    findutils
+    gawkInteractive
+    git
+    gnugrep
+    gnused
+    gnutar
+    jq
+    jujutsu
+    nodejs
+    nushell
+    ps
+    python3
+    ripgrep
+    unzip
+    which
+    # keep-sorted end
+  ];
+  devToolsPath = pkgs.lib.makeBinPath devTools;
+
+  # Make the agent usable inside a devenv/direnv-activated project: mount the
+  # whole store read-only (so devenv-provided tools resolve) and forward the
+  # caller's environment + PATH into the jail, MINUS secret-looking variables.
+  # The agent's own API key is forwarded explicitly via each agent's `extra`.
+  # Curated devTools are prepended to PATH so they're always present, with the
+  # project's (devenv) PATH after them.
+  forwardHostEnv =
+    c: with c; [
+      (ro-bind "/nix/store" "/nix/store")
+      (add-runtime ''
+        shopt -s nocasematch
+        # Drop secret-looking vars by NAME. Case-insensitive (nocasematch).
+        # `_PWD$` catches MySQL's documented plaintext-password var MYSQL_PWD
+        # (and DB_PWD/REDIS_PWD/…) without stripping the benign PWD/OLDPWD (no
+        # underscore before PWD there).
+        __deny='^(AWS_|GH_|GITHUB_|OP_)|TOKEN|SECRET|KEY|PASSWORD|PASSWD|CREDENTIAL|_PWD$|^SSH_AUTH_SOCK$|^PATH$'
+        # Also drop by VALUE: connection strings with embedded credentials
+        # (scheme://user:pass@host — DATABASE_URL/POSTGRES_URL/MONGODB_URI/…),
+        # whatever the var is named. Requires a `:password@`, so credential-free
+        # URLs (OPENAI_BASE_URL=http://host:port) and ssh://git@host remotes stay.
+        __denyval='://[^@/]*:[^@/]+@'
+        while IFS= read -r -d "" __kv; do
+          __name=''${__kv%%=*}
+          __val=''${__kv#*=}
+          if [[ $__name =~ $__deny ]]; then continue; fi
+          if [[ $__val =~ $__denyval ]]; then continue; fi
+          RUNTIME_ARGS+=(--setenv "$__name" "$__val")
+        done < <(${pkgs.coreutils}/bin/env -0)
+        RUNTIME_ARGS+=(--setenv PATH "${devToolsPath}:$PATH")
+      '')
+    ];
+
+  # Permissions shared by every jailed agent.
+  common =
+    c:
+    (with c; [
+      network # API calls (and local llama on :9292 if used)
+      time-zone
+      mount-cwd # current project dir, read-write
+      no-new-session # interactive TUIs need to feed input to the terminal
+      (try-fwd-env "TERM")
+      (try-fwd-env "COLORTERM")
+      (try-fwd-env "LANG")
+      (add-pkg-deps devTools)
+      # Provide /usr/bin/env so `#!/usr/bin/env bash|sh|nu|...` shebangs work for
+      # scripts the agent runs; the interpreters are on the in-jail PATH.
+      (ro-bind "${pkgs.coreutils}/bin/env" "/usr/bin/env")
+    ])
+    ++ forwardHostEnv c;
+
+  # Build the permission list for an agent spec: shared baseline + the agent's
+  # own read-write config paths (~ expands at runtime) + any extra combinators
+  # (e.g. forwarded API-key env vars).
+  permsFor =
+    spec: c:
+    common c
+    ++ map (p: c.try-readwrite (c.noescape p)) (spec.paths or [ ])
+    ++ (spec.extra or (_: [ ])) c;
+
+  # name -> { pkg; paths?; extra?; }
+  agents = {
+    claude = {
+      # github:sadjow/claude-code-nix, defaulted to YOLO mode — safe because the
+      # jail is the boundary. User args are still passed through.
+      pkg = pkgs.writeShellScriptBin "claude" ''
+        exec ${
+          pkgs.lib.getExe inputs.claude-code.packages.${system}.default
+        } --dangerously-skip-permissions "$@"
+      '';
+      paths = [
+        "~/.claude"
+        "~/.claude.json"
+      ];
+      extra = c: [ (c.try-fwd-env "ANTHROPIC_API_KEY") ];
+    };
+    codex = {
+      # github:numtide/llm-agents.nix, defaulted to YOLO mode (jail is the boundary).
+      pkg = pkgs.writeShellScriptBin "codex" ''
+        exec ${pkgs.lib.getExe llm.codex} --dangerously-bypass-approvals-and-sandbox "$@"
+      '';
+      paths = [
+        "~/.agents"
+        "~/.codex"
+      ];
+      extra = c: [ (c.try-fwd-env "OPENAI_API_KEY") ];
+    };
+    pi = {
+      pkg = llm.pi; # github:numtide/llm-agents.nix
+      paths = [
+        "~/.agents"
+        "~/.pi"
+      ];
+    };
+  };
+
+  wrappers = pkgs.lib.mapAttrsToList (
+    name: spec: jail "jailed-${name}" spec.pkg (permsFor spec)
+  ) agents;
+in
+{
+  inherit
+    jail
+    agents
+    permsFor
+    wrappers
+    ;
+}

--- a/users/profiles/jailed-agents-builders.nix
+++ b/users/profiles/jailed-agents-builders.nix
@@ -39,6 +39,8 @@ let
     # keep-sorted end
   ];
   devToolsPath = pkgs.lib.makeBinPath devTools;
+  cu = "${pkgs.coreutils}/bin";
+  jjBin = "${pkgs.jujutsu}/bin/jj";
 
   # Make the agent usable inside a devenv/direnv-activated project: mount the
   # whole store read-only (so devenv-provided tools resolve) and forward the
@@ -72,6 +74,53 @@ let
       '')
     ];
 
+  # Make jj usable inside the jail. We deliberately do NOT bind the user's
+  # ~/.config/jj: it commonly enables SSH commit signing, which can't work in the
+  # jail (no ssh-keygen, and the signing key lives in ~/.ssh which we block on
+  # purpose). Instead we inject just the identity via JJ_USER/JJ_EMAIL (read from
+  # the host config) — jailed commits are unsigned; you sign on review/merge.
+  # We also force JJ_EDITOR=echo so editor-driven commands (squash/split/describe)
+  # don't hang on a missing interactive editor in the jail.
+  #
+  # When $PWD is in a jj repo we also auto-bind the workspace root, the shared
+  # repo store (resolved from the .jj/repo pointer), and the colocated .git, all
+  # rw at their real paths. This lets several agents work the same repo in
+  # separate jj workspaces; each jail sees only its own workspace's working tree
+  # plus the shared history. No-op outside a jj repo.
+  jjWorkspace =
+    c: with c; [
+      (add-runtime ''
+        __jjuser=$(${jjBin} config get user.name 2>/dev/null) || __jjuser=""
+        __jjemail=$(${jjBin} config get user.email 2>/dev/null) || __jjemail=""
+        [ -n "$__jjuser" ] && RUNTIME_ARGS+=(--setenv JJ_USER "$__jjuser")
+        [ -n "$__jjemail" ] && RUNTIME_ARGS+=(--setenv JJ_EMAIL "$__jjemail")
+        # Editor-driven jj commands (squash/split/describe with no -m, etc.) would
+        # block on an interactive editor in the jail; point JJ_EDITOR at a no-op so
+        # they fall back to the existing description instead of hanging. This is
+        # appended after forwardHostEnv, so it wins over any inherited JJ_EDITOR.
+        RUNTIME_ARGS+=(--setenv JJ_EDITOR echo)
+        __ws="$PWD"
+        while [ "$__ws" != "/" ] && [ ! -e "$__ws/.jj" ]; do __ws=$(${cu}/dirname "$__ws"); done
+        if [ -e "$__ws/.jj" ]; then
+          RUNTIME_ARGS+=(--bind "$__ws" "$__ws")
+          __repo="$__ws/.jj/repo"
+          if [ -f "$__repo" ]; then
+            __store=$(${cu}/realpath -m "$__ws/.jj/$(<"$__repo")")
+          else
+            __store="$__repo"
+          fi
+          if [ -e "$__store" ]; then
+            RUNTIME_ARGS+=(--bind "$__store" "$__store")
+            __gt="$__store/store/git_target"
+            if [ -f "$__gt" ]; then
+              __git=$(${cu}/realpath -m "$__store/store/$(<"$__gt")")
+              [ -e "$__git" ] && RUNTIME_ARGS+=(--bind "$__git" "$__git")
+            fi
+          fi
+        fi
+      '')
+    ];
+
   # Permissions shared by every jailed agent.
   common =
     c:
@@ -88,7 +137,8 @@ let
       # scripts the agent runs; the interpreters are on the in-jail PATH.
       (ro-bind "${pkgs.coreutils}/bin/env" "/usr/bin/env")
     ])
-    ++ forwardHostEnv c;
+    ++ forwardHostEnv c
+    ++ jjWorkspace c;
 
   # Build the permission list for an agent spec: shared baseline + the agent's
   # own read-write config paths (~ expands at runtime) + any extra combinators
@@ -135,9 +185,160 @@ let
     };
   };
 
-  wrappers = pkgs.lib.mapAttrsToList (
+  wrappersByName = pkgs.lib.mapAttrs (
     name: spec: jail "jailed-${name}" spec.pkg (permsFor spec)
   ) agents;
+  wrappers = pkgs.lib.attrValues wrappersByName;
+
+  # Derive the launcher's `new <agent>` dispatch from wrappersByName so adding an
+  # agent to `agents` above auto-extends the launcher — no hardcoded claude|codex|
+  # pi arms to drift out of sync. agentNames feeds the usage/error messages.
+  agentNames = pkgs.lib.concatStringsSep "|" (builtins.attrNames agents);
+  agentArms = pkgs.lib.concatStringsSep "\n" (
+    pkgs.lib.mapAttrsToList (
+      name: w: "            ${name}) bin=${w}/bin/jailed-${name} ;;"
+    ) wrappersByName
+  );
+
+  # Manage per-feature jj workspaces for jailed agents. Subcommands:
+  #   jailed-agent-ws new <agent> <feature> [agent args...]   (agent ∈ agents)
+  #       create (or reuse) a sibling workspace <repo>-<feature>, activate its
+  #       own devenv via direnv (built on the host), then launch the jailed agent
+  #   jailed-agent-ws rm <feature> [--force]
+  #       forget the workspace and delete its dir. Refuses if the workspace head
+  #       isn't reachable from a bookmark or a remote bookmark (i.e. unsaved
+  #       work), unless --force. Commits stay in the op log regardless.
+  #   jailed-agent-ws ls
+  #       list workspaces and their on-disk dirs
+  launcher = pkgs.writeShellApplication {
+    name = "jailed-agent-ws";
+    runtimeInputs = with pkgs; [
+      jujutsu
+      direnv
+      coreutils
+      gnugrep
+    ];
+    text = ''
+            # Resolve the MAIN repo root so subcommands work from any workspace (a
+            # workspace's .jj/repo is a pointer file to <main>/.jj/repo).
+            mainroot() {
+              local root ptr store
+              root=$(jj workspace root 2>/dev/null) || return 1
+              ptr="$root/.jj/repo"
+              if [ -f "$ptr" ]; then
+                store=$(realpath -m "$root/.jj/$(<"$ptr")")
+              else
+                store="$ptr"
+              fi
+              dirname "$(dirname "$store")"
+            }
+
+            sub="''${1:-}"
+            if [ "$#" -gt 0 ]; then shift; fi
+            case "$sub" in
+              new)
+                if [ "$#" -lt 2 ]; then
+                  echo "usage: jailed-agent-ws new <${agentNames}> <feature> [agent args...]" >&2
+                  exit 2
+                fi
+                agent="$1"; shift
+                name="$1"; shift
+                case "$agent" in
+      ${agentArms}
+                  *) echo "unknown agent '$agent' (expected ${agentNames})" >&2; exit 2 ;;
+                esac
+                mr=$(mainroot) || { echo "not inside a jj repo" >&2; exit 1; }
+                ws="$(dirname "$mr")/$(basename "$mr")-$name"
+                if [ ! -e "$ws/.jj" ]; then
+                  echo "creating jj workspace: $ws" >&2
+                  jj workspace add --name "$name" "$ws"
+                fi
+                cd "$ws" || exit 1
+                # Activate the workspace's own devenv (builds on the host, where nix
+                # works) then jail; the agent forwards the resulting env minus secrets.
+                if [ -f .envrc ]; then
+                  direnv allow . || true
+                  exec direnv exec "$PWD" "$bin" "$@"
+                fi
+                exec "$bin" "$@"
+                ;;
+              rm)
+                force=0
+                name=""
+                for a in "$@"; do
+                  case "$a" in
+                    --force | -f) force=1 ;;
+                    -*) echo "unknown flag '$a'" >&2; exit 2 ;;
+                    *) name="$a" ;;
+                  esac
+                done
+                if [ -z "$name" ]; then
+                  echo "usage: jailed-agent-ws rm <feature> [--force]" >&2
+                  exit 2
+                fi
+                if [ "$name" = "default" ]; then
+                  echo "refusing to remove the main (default) workspace" >&2
+                  exit 1
+                fi
+                curroot=$(jj workspace root 2>/dev/null) || { echo "not inside a jj repo" >&2; exit 1; }
+                mr=$(mainroot) || { echo "not inside a jj repo" >&2; exit 1; }
+                ws="$(dirname "$mr")/$(basename "$mr")-$name"
+                if [ "$curroot" = "$ws" ]; then
+                  echo "refusing to remove the workspace you're in; run from the main checkout" >&2
+                  exit 1
+                fi
+                if ! jj workspace list | cut -d: -f1 | grep -qx "$name"; then
+                  echo "no jj workspace named '$name'" >&2
+                  exit 1
+                fi
+                if [ "$force" -ne 1 ]; then
+                  # commits unique to this workspace's head that aren't reachable from
+                  # any (local or remote) bookmark — i.e. work that only lives here.
+                  # Fail CLOSED: if jj log errors (locked repo, bad head, …) we must not
+                  # fall through to rm -rf and lose the working copy. --force overrides.
+                  if ! unsaved=$(jj log --no-graph --ignore-working-copy \
+                    -r "(::$name@ ~ ::(bookmarks() | remote_bookmarks())) ~ empty()" \
+                    -T '"x"' 2>/dev/null); then
+                    echo "could not check '$name' for unsaved work (jj log failed); refusing to rm." >&2
+                    echo "fix the repo, or pass --force if you're sure (commits stay in the op log)." >&2
+                    exit 1
+                  fi
+                  if [ -n "$unsaved" ]; then
+                    echo "workspace '$name' has commits not reachable from a bookmark:" >&2
+                    jj log -r "(::$name@ ~ ::(bookmarks() | remote_bookmarks())) ~ empty()" >&2 || true
+                    echo "bookmark or merge them first, or pass --force (commits stay in the op log)." >&2
+                    exit 1
+                  fi
+                fi
+                echo "forgetting workspace '$name' and removing $ws" >&2
+                jj workspace forget "$name"
+                rm -rf "$ws"
+                ;;
+              ls)
+                mr=$(mainroot) || { echo "not inside a jj repo" >&2; exit 1; }
+                parent=$(dirname "$mr")
+                base=$(basename "$mr")
+                jj workspace list | while IFS= read -r line; do
+                  n=''${line%%:*}
+                  if [ "$n" = "default" ]; then
+                    echo "$line"
+                  elif [ -d "$parent/$base-$n" ]; then
+                    echo "$line  -> $parent/$base-$n"
+                  else
+                    echo "$line  -> (dir missing: $parent/$base-$n)"
+                  fi
+                done
+                ;;
+              *)
+                echo "usage: jailed-agent-ws <new|rm|ls> ..." >&2
+                echo "  new <${agentNames}> <feature> [args...]  create/enter a jailed agent workspace" >&2
+                echo "  rm  <feature> [--force]                    forget the workspace and remove its dir" >&2
+                echo "  ls                                         list workspaces and their dirs" >&2
+                exit 2
+                ;;
+            esac
+    '';
+  };
 in
 {
   inherit
@@ -145,5 +346,7 @@ in
     agents
     permsFor
     wrappers
+    wrappersByName
+    launcher
     ;
 }

--- a/users/profiles/jailed-agents.nix
+++ b/users/profiles/jailed-agents.nix
@@ -3,11 +3,15 @@
 # store, and a curated dev toolset — not SSH keys, cloud creds, or the rest of
 # $HOME. The caller's environment + PATH are forwarded (minus secret-looking
 # vars) so the agent inherits an active devenv shell. Adds parallel `jailed-*`
-# commands alongside the unjailed ones.
+# commands alongside the unjailed ones, plus `jailed-agent-ws` to launch an
+# agent in a per-feature jj workspace.
 #
 # The sandbox permission set lives in ./jailed-agents-builders.nix (shared with
 # the NixOS tests tests/jail-leak-audit.nix and tests/jail-jj-workspace.nix).
 { pkgs, inputs, ... }:
+let
+  agents = import ./jailed-agents-builders.nix { inherit pkgs inputs; };
+in
 {
-  home.packages = (import ./jailed-agents-builders.nix { inherit pkgs inputs; }).wrappers;
+  home.packages = agents.wrappers ++ [ agents.launcher ];
 }

--- a/users/profiles/jailed-agents.nix
+++ b/users/profiles/jailed-agents.nix
@@ -1,0 +1,13 @@
+# Jailed AI coding agents: claude/codex/pi wrapped in bubblewrap (jail.nix) so
+# they only see the CWD, their own config dir, the network, the (read-only) Nix
+# store, and a curated dev toolset — not SSH keys, cloud creds, or the rest of
+# $HOME. The caller's environment + PATH are forwarded (minus secret-looking
+# vars) so the agent inherits an active devenv shell. Adds parallel `jailed-*`
+# commands alongside the unjailed ones.
+#
+# The sandbox permission set lives in ./jailed-agents-builders.nix (shared with
+# the NixOS tests tests/jail-leak-audit.nix and tests/jail-jj-workspace.nix).
+{ pkgs, inputs, ... }:
+{
+  home.packages = (import ./jailed-agents-builders.nix { inherit pkgs inputs; }).wrappers;
+}


### PR DESCRIPTION
## Summary

Run AI coding agents (Claude Code, Codex, Pi) in **bubblewrap sandboxes** via
[jail.nix](https://alexdav.id/projects/jail-nix/), so they can run in autonomous
"YOLO" mode without exposing SSH keys, cloud creds, or the rest of `$HOME`. Adds
parallel `jailed-*` commands plus a `jailed-agent-ws` launcher for running several
agents on the same repo in separate jj workspaces.

## What's in here (2 commits)

**1. Jail the agents**
- `jailed-claude` / `jailed-codex` / `jailed-pi`: each jail sees only the CWD (rw),
  its own config dir, the network, the read-only Nix store, and a curated dev
  toolset (git, jj, nushell, ripgrep, fd, …) — not SSH keys, `~/.aws`, gcloud,
  `~/.kube`, GPG, or other projects.
- Agents come from fast-moving flakes: `claude-code` (sadjow), `codex`+`pi`
  (numtide/llm-agents.nix).
- YOLO flags baked in (`--dangerously-skip-permissions`,
  `--dangerously-bypass-approvals-and-sandbox`) — the jail is the boundary.
- **devenv support:** whole store mounted read-only + the caller's env/PATH
  forwarded (minus a secret denylist), so an activated devenv shell carries in.
- `/usr/bin/env` bound so `#!/usr/bin/env bash|sh|nu` scripts run.

**2. jj workspaces + launcher**
- Auto-binds the workspace root + shared store + colocated `.git` when `$PWD` is in
  a jj repo, so jj works inside the jail. Each jail sees only its own workspace's
  working tree plus shared history → multiple agents, different features.
- jj identity injected via `JJ_USER`/`JJ_EMAIL` (the signing-enabled `~/.config/jj`
  is intentionally not bound — no key/ssh-keygen in the jail; jailed commits are
  unsigned, signed on review).
- `jailed-agent-ws new|rm|ls`: create a per-feature workspace (and activate its own
  devenv via direnv), tear one down (refuses to drop un-bookmarked work unless
  `--force`), and list.

## Tests
- `checks.jail-leak-audit` — NixOS VM test that plants real secrets and asserts the
  jail blocks them (`RESULT: NO LEAKS`).
- `checks.jail-jj-workspace` — VM test: jj works in-jail from a workspace, identity
  injected, sibling working tree + jj config not visible.

## Threat model
Protects against **accidental damage and lateral secret access**. It is *not* a hard
boundary against a deliberately malicious/compromised agent: network egress is open
and the agent can read its own API token. Suitable for supervised autonomous runs.

## Note
First-run auth must be done with the **unjailed** `claude` (browser OAuth doesn't work
in the jail); the token in `~/.claude.json` is then reused by the jailed wrapper.
