### PR TITLE
docs(pi-skills): add and refine Pi skills

### DIFF
--- a/users/profiles/pi/skills/conventional-commits/SKILL.md
+++ b/users/profiles/pi/skills/conventional-commits/SKILL.md
@@ -1,0 +1,93 @@
+---
+name: conventional-commits
+description: "Write Conventional Commits messages (v1.0.0) — type(scope): subject format for changelogs and semver. Use when drafting commit messages, PR titles, or release notes."
+metadata:
+  topic: Conventional Commits
+  keywords: ["commit", "message", "conventional", "changelog", "version", "release", "git"]
+  related: [jj-core]
+---
+
+# Conventional Commits (v1.0.0)
+
+Produce consistent commit messages that parse into changelogs and drive semantic versioning.
+
+## Format
+
+```
+type(scope): description
+
+[optional body]
+
+[optional footers]
+```
+
+Rules: header on one line; scope is optional in the spec, but prefer including it when there is a clear component/module. Separate sections with blank lines. Add `!` before `:` for breaking changes (e.g., `feat(api)!: remove v1`).
+
+## Choosing the Type
+
+**User-facing changes:**
+
+- `feat`: new user-visible behavior — new CLI flags, UI components, API endpoints
+- `fix`: corrected behavior — fixes crashes, handles edge cases, corrects output
+
+**Maintenance:**
+
+- `refactor`: structure change without behavior change — renaming, extracting utilities
+- `perf`: performance improvement — faster algorithms, reduced allocations
+- `chore`: general maintenance — dead code removal, tooling updates
+- `style`: formatting only — whitespace, semicolons, no logic changes
+- `test`: test-only changes — `.test.ts`, `.spec.ts` files
+- `build`: build system — package.json, Cargo.toml, bundler config
+- `ci`: CI/CD pipelines — GitHub Actions, deployment scripts
+- `docs`: documentation files only — `.md`, `.txt`. Code comments use the type matching the actual code change.
+
+**Reverts:**
+
+- `revert`: undo a previous commit — `revert: <original-message>`
+
+When unsure: new user behavior → `feat`, corrected behavior → `fix`, otherwise → `chore` or a more specific maintenance type.
+
+## Writing the Description
+
+Use imperative mood, be specific, avoid generic words like "stuff" or "changes".
+
+```
+✅ feat(auth): add passwordless login
+✅ fix(api): handle empty pagination cursor
+❌ docs(agent): add behavioral guidelines and core principles  (too vague)
+✅ docs(agent): add rules for dead code removal, build verification, security  (specific)
+```
+
+## Breaking Changes
+
+Mark in the header with `!`:
+
+```
+feat(api)!: remove deprecated v1 endpoints
+```
+
+Or add a `BREAKING CHANGE:` footer when you need an explanation:
+
+```
+feat(api): remove deprecated v1 endpoints
+
+BREAKING CHANGE: /v1/* endpoints are removed; migrate to /v2/*.
+```
+
+## Semantic Versioning Mapping
+
+- `fix` → patch
+- `feat` → minor
+- Any breaking change (`!` or `BREAKING CHANGE:`) → major
+
+## Rules
+
+- Subject line must be imperative mood ("add" not "added" or "adds")
+- No period at end of subject line
+- Keep subject under 72 characters
+- Use `BREAKING CHANGE:` footer for breaking changes
+- Map types to semver: fix→patch, feat→minor, breaking→major
+
+## When Asked to Write a Commit Message
+
+Collect what changed, the scope/module, whether it's user-facing, and any issue IDs. Then produce a conventional header with optional body and footers.

--- a/users/profiles/pi/skills/jj-core/SKILL.md
+++ b/users/profiles/pi/skills/jj-core/SKILL.md
@@ -200,9 +200,9 @@ add them to PATH or invoke them directly from the skill directory.
 
 ## Pi Tool
 
-Use the `jj_context` Pi tool when compact repository context is enough. It is
-implemented as a read-only inspection tool in
-`users/profiles/pi/extensions/jj-context/` and returns structured JSON/text for:
+Use the `jj_context` Pi tool for quick read-only repository orientation: current
+change, parent, dirty-file summary, conflicts, nearby bookmarks, and recovery op.
+It returns structured JSON/text for:
 
 - `mode: "summary"` (default): version, root, current change, nearest bookmarks,
   changed-file/diffstat/conflict summary, recovery operation ID, and a short log
@@ -211,9 +211,10 @@ implemented as a read-only inspection tool in
 - `mode: "recovery"`: current operation ID and recent operation log
 
 Prefer `jj_context` over several verbose `bash` calls to `jj status`, `jj log`,
-`jj diff --stat`, and `jj op log`. Use `bash` for full diffs, unusual JJ
-commands, or mutating operations. Avoid generic `jj_run` wrappers; JJ's CLI is
-already expressive and broad wrappers add risk without much token benefit.
+`jj diff --stat`, and `jj op log` when a compact overview is enough. Use the
+`jj` CLI via `bash` for precise revset inspection, full diffs, unusual commands,
+and all mutating operations. Avoid generic `jj_run` wrappers; JJ's CLI is already
+expressive and broad wrappers add risk without much token benefit.
 
 ## Recovery
 

--- a/users/profiles/pi/skills/jj-core/SKILL.md
+++ b/users/profiles/pi/skills/jj-core/SKILL.md
@@ -1,10 +1,17 @@
 ---
 name: jj-core
 description: Expert guidance for using JJ (Jujutsu) version control system. MUST be used before any `jj` or `git` command or version-control operation in JJ-backed repositories, including status/log/diff/fetch/push/bookmark/branch/history inspection. Covers JJ operations, revsets, templates, evolog, recovery, and Git interop boundaries.
-version_target: "0.41.x"
+metadata:
+  keywords: ["jj", "jujutsu", "git", "revsets", "bookmarks", "history"]
+  related: [jj-todo, conventional-commits]
+  version_target: "0.41.x"
 ---
 
 # JJ (Jujutsu) Version Control Helper
+
+Git-compatible VCS with a different data model: no staging area; the working copy is an editable commit (`@`) that is normally auto-snapshotted before JJ commands. Untracked files can still exist.
+
+> ⚠️ **Avoid `git` mutations in a JJ repo** — they bypass JJ's operation log and can confuse colocated state. Prefer `jj` for mutating operations. Read-only Git commands like `git log`, `git diff`, `git show`, `git blame`, and `git grep` are fine.
 
 Tested against `jj 0.41.0`. Prefer current canonical command names in examples;
 short aliases are often configured by default but can be disabled or confusing in

--- a/users/profiles/pi/skills/jj-todo/SKILL.md
+++ b/users/profiles/pi/skills/jj-todo/SKILL.md
@@ -1,7 +1,10 @@
 ---
 name: jj-todo
 description: Structured TODO commit workflow using JJ (Jujutsu). MUST be used at the start of any implementation task likely to involve more than one commit/revision, multi-step feature work, larger bug fixes, refactors, task DAGs, or structured progress tracking. Plans work as empty commits with [task:*] flags and dependency checks. **Requires the jj-core skill**
-version_target: "0.41.x"
+metadata:
+  keywords: ["jj", "todo", "task", "planning", "commits", "workflow"]
+  related: [jj-core, conventional-commits]
+  version_target: "0.41.x"
 ---
 
 # JJ TODO Workflow

--- a/users/profiles/pi/skills/nh/SKILL.md
+++ b/users/profiles/pi/skills/nh/SKILL.md
@@ -1,0 +1,66 @@
+---
+name: nh
+description: "Switch NixOS/Home Manager configs with nh — cleaner interface for builds, switches, and garbage collection. Use when running os/home switch or pruning old generations."
+metadata:
+  related: [nix, nix-flake]
+  keywords: ["switch", "home-switch", "nixos", "home-manager", "generation", "prune", "nh"]
+---
+
+# nh (Nix Helper)
+
+Cleaner interface for Nix operations — builds, switches, and garbage collection with readable output.
+
+## Switching Configuration
+
+Build and activate a configuration:
+
+```bash
+nh os switch path:.           # NixOS — build and activate
+nh os test path:.             # Build and activate temporarily; not boot default
+nh os build path:.            # Build only, don't activate
+nh os boot path:.             # Make it the boot default without activating
+```
+
+Home Manager:
+
+```bash
+nh home switch path:.         # Build and activate Home Manager config
+nh home build path:.          # Build only
+```
+
+macOS with nix-darwin:
+
+```bash
+nh darwin switch path:.       # Build and activate darwin config
+```
+
+Path inference works — `nh os switch` uses the local `flake.nix` in the current directory. Prefix local flake paths with `path:` to include untracked files.
+
+## Maintenance & Cleanup
+
+Clean the Nix store and old generations:
+
+```bash
+nh clean all --keep-since 7d  # Remove profiles older than 7 days
+nh clean user --keep 5        # Keep last 5 user profiles
+nh clean all                  # Full garbage collection
+```
+
+## Searching & Updating
+
+Search available packages:
+
+```bash
+nh search ripgrep             # Search by name or description
+```
+
+Update flake inputs before building:
+
+```bash
+nh os switch --update path:.  # Update inputs, then build and switch
+```
+
+## Common Options
+
+- `--dry` — show what would happen without making changes
+- `--ask` — ask for confirmation (avoid in headless/automated scripts)

--- a/users/profiles/pi/skills/nix-flake/SKILL.md
+++ b/users/profiles/pi/skills/nix-flake/SKILL.md
@@ -1,0 +1,89 @@
+---
+name: nix-flake
+description: "Creates reproducible builds, manages flake inputs, defines devShells, and builds packages with flake.nix. Use when initializing Nix projects, locking dependencies, or running nix build/develop commands."
+metadata:
+  related: [nix, nh]
+  keywords: ["flake", "nix", "build", "devShell", "lock", "reproducible", "init"]
+  requires_tools: [bash]
+---
+
+# Nix Flakes
+
+Modern Nix project management with hermeticity through `flake.lock`. Every dependency is locked to a specific revision for reproducibility.
+
+## Project Setup
+
+Initialize a new flake:
+
+```bash
+nix flake init                    # Basic flake in current directory
+nix flake new hello -t templates#hello  # From template
+```
+
+Manage dependencies:
+
+```bash
+nix flake update                  # Update all inputs in flake.lock
+nix flake update nixpkgs          # Update specific input only
+nix flake lock                    # Lock missing entries without updating
+```
+
+## Building & Running
+
+Always prefix local paths with `path:` to include untracked files:
+
+```bash
+nix build path:.                  # Build default package
+nix build path:.#packageName      # Build a specific output
+nix run path:.                    # Run the default app
+nix run path:.#appName            # Run a specific app
+nix run github:numtide/treefmt    # Run from a remote flake
+```
+
+## Development Environments
+
+Run commands inside a devShell:
+
+```bash
+nix develop path:. --command make build
+nix develop path:. --command env  # Check the environment
+```
+
+The `--command` flag is required in headless environments to avoid interactive mode.
+
+## Inspecting Flakes
+
+```bash
+nix flake show path:.             # List all outputs
+nix flake metadata path:.         # See inputs and revisions
+nix eval path:.#packages.x86_64-linux.default.name  # Evaluate a specific output
+```
+
+## Basic Flake Structure
+
+```nix
+{
+  description = "A basic flake";
+
+  inputs = {
+    nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      system = "x86_64-linux";
+      pkgs = nixpkgs.legacyPackages.${system};
+    in {
+      packages.${system}.default = pkgs.hello;
+      devShells.${system}.default = pkgs.mkShell {
+        buildInputs = [ pkgs.git pkgs.vim ];
+      };
+    };
+}
+```
+
+## Best Practices
+
+- Always commit `flake.lock` for reproducibility
+- Use `path:` prefix when building local flakes to include untracked files
+- Always use `--command` with `nix develop` in scripts and headless environments

--- a/users/profiles/pi/skills/nix/SKILL.md
+++ b/users/profiles/pi/skills/nix/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: nix
+description: "Runs packages temporarily, creates isolated shell environments, and evaluates Nix expressions. Use when executing tools without installing, debugging derivations, or working with nixpkgs."
+metadata:
+  related: [nix-flake, nh]
+  keywords: ["nix", "shell", "env", "evaluate", "derivation", "nixpkgs", "run", "package"]
+  requires_tools: [bash]
+---
+
+# Nix
+
+Package manager and functional language for reproducible environments. Run any tool once without installing it permanently.
+
+## Running Packages
+
+Execute a package from `nixpkgs` directly:
+
+```bash
+nix run nixpkgs#cowsay -- "Hello!"    # Run with arguments
+nix run nixpkgs#hello                  # Simple command
+```
+
+For long-running services, wrap in tmux: `tmux new -d 'nix run nixpkgs#some-server'`.
+
+## Shell Environments
+
+Create a temporary shell with specific tools:
+
+```bash
+nix shell nixpkgs#git nixpkgs#vim --command git --version
+```
+
+## Evaluating Expressions
+
+Debug and inspect Nix expressions in headless environments:
+
+```bash
+nix eval --expr '1 + 2'              # Simple expression
+nix eval nixpkgs#hello.name          # Inspect an attribute
+nix eval --file ./default.nix        # Evaluate a local file
+nix eval --expr 'builtins.attrNames (import <nixpkgs> {})'  # List keys
+```
+
+## Searching Packages
+
+```bash
+nix search nixpkgs python3           # Search by name or description
+```
+
+## Formatting Nix Files
+
+```bash
+nix fmt                              # Format current directory
+nix fmt -- --check                   # Check formatting without changes
+```
+
+## Hashes
+
+For fixed-output fetchers, prefer setting the hash to `""` first and letting the failed build report the expected `got:` hash. This avoids guessing hash formats.
+
+Use `nix hash` when you explicitly need local path/file hashing or hash format conversion.
+
+```nix
+fetchFromGitHub {
+  owner = "nixos";
+  repo = "nixpkgs";
+  rev = "abc123";
+  hash = "";  # let the build tell you the correct hash
+}
+```
+
+## Shebang Scripts
+
+Use Nix as a script interpreter:
+
+```bash
+#!/usr/bin/env nix
+#! nix shell nixpkgs#bash nixpkgs#curl --command bash
+curl -s https://example.com
+```
+
+## Rules
+
+- Use `nix log <derivation>` to debug broken builds
+- Use `nix why-depends` to trace dependency chains
+- Add `--no-substitute` to force local build when cache is bad
+- Use shebang scripts (`#! nix shell ... --command`) for inline nix scripts

--- a/users/profiles/pi/skills/nu/SKILL.md
+++ b/users/profiles/pi/skills/nu/SKILL.md
@@ -2,7 +2,7 @@
 name: nu
 description: Nushell guidance for writing/debugging Nu scripts and pipelines, manipulating structured data, replacing jq/sed/awk one-liners, parsing command output, working with CSV/JSON/YAML/TOML, and shell automation. Use when the user asks about Nushell/nu or when adding/editing .nu scripts.
 metadata:
-  tags: ["nushell", "nu", "shell", "structured-data", "jq"]
+  keywords: ["nushell", "nu", "shell", "structured-data", "jq"]
 ---
 
 # Nushell (`nu`)

--- a/users/profiles/pi/skills/skill-authoring/SKILL.md
+++ b/users/profiles/pi/skills/skill-authoring/SKILL.md
@@ -1,0 +1,114 @@
+---
+name: skill-authoring
+description: "Create SKILL.md files that teach the agent new domains. Use when authoring a new pi skill with frontmatter, body structure, and references."
+metadata:
+  topic: Pi Skill Authoring
+  keywords: ["skill", "author", "create", "improve", "domain"]
+---
+
+# Pi Skills
+
+Skills are Markdown files (`SKILL.md`) that teach the agent how to do something it doesn't know by default. Each skill covers one or more use cases within a single domain — e.g., "NixOS configuration management" with sub-areas for system updates, home manager, and package search. The agent loads the full file when the user's request matches the trigger description.
+
+## File Layout
+
+```
+my-skill/
+├── SKILL.md              # Frontmatter + workflow instructions (aim for ~120 lines)
+├── references/           # Deep docs loaded on demand (API specs, advanced patterns)
+└── scripts/              # Helper scripts the agent runs directly
+```
+
+Assets go in `assets/` for templates and files the agent uses in outputs. Scripts in `scripts/` are deterministic code — not rewritten each invocation.
+
+## Frontmatter
+
+Pi currently requires only `name` and `description`. Put custom conventions under `metadata`; Pi ignores them, but they remain useful human-readable metadata.
+
+### Required Fields
+
+```yaml
+---
+name: my-skill-name # kebab-case, max 64 chars
+description: "Does X. Use when Y."
+metadata:
+  keywords: ["keyword1", "keyword2", "keyword3"] # optional human hints
+---
+```
+
+- `name`: lowercase letters, numbers, hyphens only. No leading/trailing hyphens.
+- `description`: quoted string. First sentence starts with a verb. Second starts with "Use when".
+- `metadata.keywords`: optional human convention; Pi does not score or match on it.
+
+### Optional Conventions
+
+```yaml
+metadata:
+  topic: Conventional Commits # human display/grouping hint
+  related: [other-skill] # related skills to consider manually
+  requires_tools: [read, bash] # tool dependency note
+disable-model-invocation: true # Pi-supported: hide from automatic prompt; use /skill:name
+```
+
+Pi currently only acts on `disable-model-invocation`; `metadata.*` fields are convention-only.
+
+## Body Structure (aim for ~120 lines)
+
+```markdown
+# Skill Name
+
+One-line summary of the domain this skill covers.
+
+## Workflow / Commands
+
+Step-by-step examples or command reference with inline code snippets.
+
+## Details
+
+Common variations, edge cases, or tricky parts specific to this domain.
+
+## Constraints / Best Practices
+
+Rules, gotchas, and things the agent must do (or not do).
+
+See [deep reference](references/DEEP.md) for API specs and advanced usage.
+```
+
+- **Workflow/Commands**: numbered steps with concrete inline examples — command, code snippet, or config.
+- **Details**: short context for variations on the main use cases.
+- Link to `references/` for anything deep. One level of linking only.
+
+## Examples from Existing Skills
+
+**Good — focused domain, multiple use cases:**
+
+```yaml
+# nh: one domain (Nix operations), three sub-domains (system updates, home manager, package search)
+description: "Switches NixOS/Home Manager configurations, cleans old generations, and performs system maintenance. Use when running os/home switch, pruning the Nix store, or managing system generations."
+```
+
+**Good — single use case within a domain:**
+
+```yaml
+# transcribe-audio: one domain (audio transcription), one primary use case
+description: "Transcribes audio files to text using whisper-cpp. Use when converting speech to text, transcribing podcasts, lectures, or meetings."
+```
+
+## Validation Checklist
+
+- [ ] `name` is kebab-case (matching directory name is recommended for portability)
+- [ ] `description` is a quoted string with verb-first sentence + "Use when..." clause
+- [ ] `metadata.keywords`, if present, are useful human hints
+- [ ] `metadata.topic`, `metadata.related`, and `metadata.requires_tools` are convention-only
+- [ ] Body aims for ~120 lines (move excess to `references/`)
+- [ ] At least one concrete inline example per key concept
+- [ ] No duplicated content between SKILL.md and references
+- [ ] All file links resolve to existing paths
+
+## Common Mistakes
+
+- Description uses `>` chevron instead of `"quoted"` — convert to quoted string
+- Missing "Use when..." clause — add trigger conditions
+- Duplicate content between SKILL.md and references — keep detail only in references
+- Long explanations of concepts the agent already knows — delete them
+- Extra files the agent never reads (README, changelog) — remove them


### PR DESCRIPTION
## Summary
- add skill-authoring and conventional-commits skills
- add Nix, Nix flakes, and nh skills
- refine existing JJ/Nu skill metadata and JJ guidance

## Validation
- Loaded all Pi skills with Pi skill loader; 8 skills loaded with no diagnostics.