### PR TITLE
feat: expose llama-swap over HTTPS for Pi

### DIFF
--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   ...
@@ -387,6 +388,26 @@
           every = "15s";
         };
       };
+  };
+
+  systemd.services.tailscale-serve-llama-swap = {
+    description = "Expose llama-swap over Tailscale HTTPS";
+    after = [
+      "tailscaled.service"
+      "tailscale-auth.service"
+      "llama-swap.service"
+    ];
+    wants = [
+      "tailscaled.service"
+      "llama-swap.service"
+    ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${lib.getExe config.services.tailscale.package} serve --bg --https=443 http://127.0.0.1:9292";
+      ExecStop = "${lib.getExe config.services.tailscale.package} serve --https=443 off";
+    };
   };
 
   systemd.services.llama-swap.serviceConfig = {

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -55,16 +55,16 @@ let
   localExtensionPaths = [ ];
 
   settings = {
-    defaultProvider = "opencode-go";
-    defaultModel = "deepseek-v4-flash";
-    defaultThinkingLevel = "high";
+    defaultProvider = "openai-codex";
+    defaultModel = "gpt-5.5";
+    defaultThinkingLevel = "medium";
     enableInstallTelemetry = false;
     enableSkillCommands = true;
     extensions = localExtensionPaths;
     packages = thirdPartyPackages;
     skills = extraSkillDirs;
     steeringMode = "all";
-    followupMode = "all";
+    followUpMode = "all";
   };
   settingsJson = pkgs.writeText "pi-settings.json" (builtins.toJSON settings);
 
@@ -73,9 +73,56 @@ let
     mcpServers = { };
   };
 
-  # Custom providers/models. Empty = use Pi's built-ins only.
+  # Custom providers/models. llama-swap exposes an OpenAI-compatible API over
+  # Tailscale HTTPS; Qwen models use llama.cpp's Qwen chat-template thinking
+  # control, which Pi enables via compat.thinkingFormat = "qwen-chat-template".
   models = {
-    providers = { };
+    providers = {
+      "margot" = {
+        baseUrl = "https://margot.tailef5cf.ts.net/v1";
+        api = "openai-responses";
+        apiKey = "llama-swap";
+        compat = {
+          supportsStore = false;
+          supportsDeveloperRole = false;
+          supportsReasoningEffort = false;
+          supportsUsageInStreaming = false;
+          maxTokensField = "max_tokens";
+          supportsStrictMode = false;
+          supportsLongCacheRetention = false;
+          thinkingFormat = "qwen-chat-template";
+        };
+        models =
+          map
+            (id: {
+              inherit id;
+              name = id;
+              reasoning = true;
+              input = [
+                "text"
+                "image"
+              ];
+              contextWindow = 262144;
+              maxTokens = 32768;
+              cost = {
+                input = 0;
+                output = 0;
+                cacheRead = 0;
+                cacheWrite = 0;
+              };
+            })
+            [
+              "qwen3.6:27b-mtp-q4"
+              "qwen3.6:27b-mtp-q8"
+              "qwen3.6:27b-q4"
+              "qwen3.6:27b-q8"
+              "qwen3.6:35b-a3b-mtp-q4"
+              "qwen3.6:35b-a3b-mtp-q8"
+              "qwen3.6:35b-a3b-q4"
+              "qwen3.6:35b-a3b-q8"
+            ];
+      };
+    };
   };
 
   # pi-web-access config (~/.pi/web-search.json — directly under ~/.pi, NOT


### PR DESCRIPTION
## Summary
- expose llama-swap on margot through Tailscale HTTPS
- add llama-swap Qwen models to Pi with local Qwen compatibility settings

## Validation
- statix check profiles/ai.nix
- statix check users/profiles/pi/default.nix
- nix eval path:.#nixosConfigurations.margot.config.system.build.toplevel.drvPath
- nix eval path:.#nixosConfigurations.nicolina.config.system.build.toplevel.drvPath