### PR TITLE
feat(pi): add provider quota footer

### DIFF
--- a/users/profiles/pi/extensions/footer/codex-usage.ts
+++ b/users/profiles/pi/extensions/footer/codex-usage.ts
@@ -1,0 +1,205 @@
+/**
+ * ChatGPT Codex usage quota tracker.
+ */
+
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+
+export interface QuotaWindowSnapshot {
+  usedPercent: number;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+export interface QuotaSnapshot {
+  limitId: string | null;
+  limitName: string | null;
+  primary: QuotaWindowSnapshot | null;
+  secondary: QuotaWindowSnapshot | null;
+  tertiary?: QuotaWindowSnapshot | null;
+}
+
+export interface QuotaTracker {
+  setEnabled: (enabled: boolean) => void;
+  getSnapshot: () => QuotaSnapshot | null;
+  dispose: () => void;
+}
+
+interface ChatGptUsageWindow {
+  used_percent?: unknown;
+  limit_window_seconds?: unknown;
+  reset_at?: unknown;
+}
+
+interface ChatGptUsageResponse {
+  rate_limit?: {
+    primary_window?: ChatGptUsageWindow;
+    secondary_window?: ChatGptUsageWindow;
+  };
+}
+
+const CHATGPT_BASE_URL = (
+  process.env.CHATGPT_BASE_URL || "https://chatgpt.com/backend-api"
+).replace(/\/+$/, "");
+const OPENAI_AUTH_CLAIM = "https://api.openai.com/auth";
+const REFRESH_INTERVAL_MS = 60_000;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+function decodeJwtPayload(token: string): Record<string, unknown> {
+  const parts = token.split(".");
+  if (parts.length < 2) return {};
+
+  try {
+    const decoded = Buffer.from(parts[1], "base64url").toString("utf8");
+    const payload = JSON.parse(decoded) as unknown;
+    return payload && typeof payload === "object" && !Array.isArray(payload)
+      ? (payload as Record<string, unknown>)
+      : {};
+  } catch {
+    return {};
+  }
+}
+
+function extractChatGptAccountId(token: string): string | undefined {
+  const payload = decodeJwtPayload(token);
+  const auth = payload[OPENAI_AUTH_CLAIM];
+  if (!auth || typeof auth !== "object" || Array.isArray(auth)) return undefined;
+
+  const accountId = (auth as Record<string, unknown>).chatgpt_account_id;
+  return typeof accountId === "string" && accountId.length > 0 ? accountId : undefined;
+}
+
+function normalizeWindow(window: ChatGptUsageWindow | undefined): QuotaWindowSnapshot | null {
+  if (!window || typeof window !== "object") return null;
+  if (typeof window.used_percent !== "number") return null;
+
+  const durationSeconds =
+    typeof window.limit_window_seconds === "number" ? window.limit_window_seconds : null;
+  const resetSeconds = typeof window.reset_at === "number" ? window.reset_at : null;
+
+  return {
+    usedPercent: window.used_percent,
+    windowDurationMins: durationSeconds === null ? null : Math.round(durationSeconds / 60),
+    resetsAt: resetSeconds === null ? null : resetSeconds * 1000,
+  };
+}
+
+function extractQuotaSnapshot(payload: ChatGptUsageResponse): QuotaSnapshot | null {
+  const rateLimit = payload.rate_limit;
+  if (!rateLimit || typeof rateLimit !== "object") return null;
+
+  const primary = normalizeWindow(rateLimit.primary_window);
+  const secondary = normalizeWindow(rateLimit.secondary_window);
+  if (!primary && !secondary) return null;
+
+  return {
+    limitId: "codex",
+    limitName: "OpenAI",
+    primary,
+    secondary,
+  };
+}
+
+function timeoutSignal(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timeout),
+  };
+}
+
+async function readCodexQuotaSnapshot(ctx: ExtensionContext): Promise<QuotaSnapshot | null> {
+  const model = ctx.model;
+  if (!model) return null;
+
+  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+  if (!auth.ok || !auth.apiKey) return null;
+
+  const headers = new Headers(auth.headers);
+  headers.set("Authorization", `Bearer ${auth.apiKey}`);
+  headers.set("Accept", "application/json");
+  headers.set("User-Agent", "cake-footer");
+
+  const accountId = extractChatGptAccountId(auth.apiKey);
+  if (accountId) {
+    headers.set("chatgpt-account-id", accountId);
+  }
+
+  const timeout = timeoutSignal(REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${CHATGPT_BASE_URL}/wham/usage`, {
+      headers,
+      signal: timeout.signal,
+    });
+    if (!response.ok) return null;
+    return extractQuotaSnapshot((await response.json()) as ChatGptUsageResponse);
+  } catch {
+    return null;
+  } finally {
+    timeout.cancel();
+  }
+}
+
+export function createCodexQuotaTracker(ctx: ExtensionContext, onUpdate: () => void): QuotaTracker {
+  let enabled = false;
+  let snapshot: QuotaSnapshot | null = null;
+  let lastRefreshAt = 0;
+  let refreshInFlight: Promise<void> | null = null;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let disposed = false;
+
+  const refresh = async (): Promise<void> => {
+    if (disposed || refreshInFlight) return;
+
+    refreshInFlight = (async () => {
+      const next = await readCodexQuotaSnapshot(ctx);
+      const previous = snapshot ? JSON.stringify(snapshot) : null;
+      const current = next ? JSON.stringify(next) : null;
+      snapshot = next;
+      lastRefreshAt = Date.now();
+      if (previous !== current) {
+        onUpdate();
+      }
+    })().finally(() => {
+      refreshInFlight = null;
+    });
+
+    await refreshInFlight;
+  };
+
+  const stopInterval = (): void => {
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+  };
+
+  const startInterval = (): void => {
+    if (interval) return;
+    interval = setInterval(() => {
+      void refresh();
+    }, REFRESH_INTERVAL_MS);
+  };
+
+  return {
+    setEnabled(nextEnabled: boolean): void {
+      enabled = nextEnabled;
+      if (!enabled) {
+        stopInterval();
+        return;
+      }
+
+      startInterval();
+      if (!snapshot || Date.now() - lastRefreshAt >= REFRESH_INTERVAL_MS) {
+        void refresh();
+      }
+    },
+    getSnapshot(): QuotaSnapshot | null {
+      return snapshot;
+    },
+    dispose(): void {
+      disposed = true;
+      stopInterval();
+    },
+  };
+}

--- a/users/profiles/pi/extensions/footer/index.ts
+++ b/users/profiles/pi/extensions/footer/index.ts
@@ -3,7 +3,7 @@
  *
  * Replaces the built-in footer with a custom layout:
  *   Left:  MODEL | think LEVEL | VCS_BRANCH +add -del
- *   Right: tok TOKENS | $COST | PROVIDER used/total
+ *   Right: tok TOKENS | $COST | PROVIDER quota used/total
  *
  * Supports jj (Jujutsu) and git VCS backends (auto-detected).
  */
@@ -17,10 +17,13 @@ import type {
   Theme,
 } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { createCodexQuotaTracker, type QuotaTracker } from "./codex-usage.ts";
+import { createOpenCodeGoQuotaTracker } from "./opencode-go-usage.ts";
 import {
   renderCost,
   renderModel,
   renderProviderContext,
+  renderQuota,
   renderThinking,
   renderTokens,
   renderVcs,
@@ -255,6 +258,24 @@ function providerLabel(provider: string | undefined): string | undefined {
   return KNOWN_PROVIDER_LABELS[provider] ?? provider;
 }
 
+function getModelProvider(model: { id?: string; provider?: string } | undefined): string | undefined {
+  return (
+    model?.provider ??
+    (model?.id?.includes("/") ? model.id.slice(0, model.id.indexOf("/")) : undefined)
+  )?.toLowerCase();
+}
+
+/** Return true when the active model uses ChatGPT Codex subscription auth. */
+function isOpenAICodexModel(model: { id?: string; provider?: string } | undefined): boolean {
+  const provider = getModelProvider(model);
+  return provider === "openai-codex" || /^openai-codex-\d+$/.test(provider ?? "");
+}
+
+/** Return true when the active model uses the OpenCode Go provider. */
+function isOpenCodeGoModel(model: { id?: string; provider?: string } | undefined): boolean {
+  return getModelProvider(model) === "opencode-go";
+}
+
 // ── Footer line builder ─────────────────────────────────────
 
 function buildLine(
@@ -262,6 +283,8 @@ function buildLine(
   ctx: ExtensionContext,
   pi: ExtensionAPI,
   footerData: ReadonlyFooterDataProvider,
+  codexQuotaTracker: QuotaTracker,
+  openCodeGoQuotaTracker: QuotaTracker,
   width: number,
 ): string {
   if (width <= 0) return "";
@@ -276,6 +299,11 @@ function buildLine(
   const modelId = ctx.model?.id;
   const modelProvider = ctx.model?.provider;
   const thinkingLevel = pi.getThinkingLevel() as string | undefined;
+  const typedModel = ctx.model as { id?: string; provider?: string } | undefined;
+  const showCodexQuotaUsage = isOpenAICodexModel(typedModel);
+  const showOpenCodeGoQuotaUsage = isOpenCodeGoModel(typedModel);
+  codexQuotaTracker.setEnabled(showCodexQuotaUsage);
+  openCodeGoQuotaTracker.setEnabled(showOpenCodeGoQuotaUsage);
 
   // ── Left segments ──
   const left: string[] = [];
@@ -298,12 +326,32 @@ function buildLine(
   const costSeg = renderCost(theme, usage.cost);
   if (costSeg) right.push(costSeg);
 
+  let quotaSeg: string | null = null;
+  if (showCodexQuotaUsage || showOpenCodeGoQuotaUsage) {
+    const quota = showOpenCodeGoQuotaUsage
+      ? openCodeGoQuotaTracker.getSnapshot()
+      : codexQuotaTracker.getSnapshot();
+    quotaSeg = renderQuota(
+      theme,
+      quota
+        ? {
+            limitId: quota.limitId,
+            limitName: quota.limitName,
+            primary: quota.primary,
+            secondary: quota.secondary,
+            tertiary: quota.tertiary ?? null,
+          }
+        : null,
+    );
+  }
+
   const pLabel = providerLabel(modelProvider);
   const provCtxSeg = renderProviderContext(
     theme,
     pLabel,
     contextUsage?.tokens ?? null,
     contextUsage?.contextWindow ?? 0,
+    quotaSeg,
   );
   if (provCtxSeg) right.push(provCtxSeg);
 
@@ -349,15 +397,34 @@ export default function footerExtension(pi: ExtensionAPI): void {
         tui.requestRender();
       });
 
+      const codexQuotaTracker = createCodexQuotaTracker(ctx, () => {
+        tui.requestRender();
+      });
+      const openCodeGoQuotaTracker = createOpenCodeGoQuotaTracker(ctx, () => {
+        tui.requestRender();
+      });
+
       const component = {
         invalidate() {
           lastVcsRefresh = 0;
         },
         render(width: number): string[] {
-          return [buildLine(theme, ctx, pi, footerData, width)];
+          return [
+            buildLine(
+              theme,
+              ctx,
+              pi,
+              footerData,
+              codexQuotaTracker,
+              openCodeGoQuotaTracker,
+              width,
+            ),
+          ];
         },
         dispose() {
           unsubscribeBranchChange();
+          codexQuotaTracker.dispose();
+          openCodeGoQuotaTracker.dispose();
         },
       };
       return component;

--- a/users/profiles/pi/extensions/footer/opencode-go-usage.ts
+++ b/users/profiles/pi/extensions/footer/opencode-go-usage.ts
@@ -1,0 +1,295 @@
+/**
+ * OpenCode Go usage quota tracker.
+ *
+ * Prefers the API-key endpoint proposed upstream (`/zen/go/v1/usage`) and falls
+ * back to scraping the Go dashboard when OPENCODE_GO_WORKSPACE_ID and
+ * OPENCODE_GO_AUTH_COOKIE are configured.
+ */
+
+import { readFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { QuotaSnapshot, QuotaTracker, QuotaWindowSnapshot } from "./codex-usage.ts";
+
+interface OpenCodeGoUsageWindow {
+  usagePercent?: unknown;
+  resetInSec?: unknown;
+}
+
+interface OpenCodeGoUsageResponse {
+  rollingUsage?: OpenCodeGoUsageWindow;
+  weeklyUsage?: OpenCodeGoUsageWindow;
+  monthlyUsage?: OpenCodeGoUsageWindow;
+}
+
+interface OpenCodeGoDashboardConfig {
+  workspaceId: string;
+  authCookie: string;
+}
+
+interface ScrapedWindowUsage {
+  usagePercent: number;
+  resetInSec: number;
+}
+
+const OPENCODE_GO_BASE_URL = (
+  process.env.OPENCODE_GO_BASE_URL || "https://opencode.ai/zen/go/v1"
+).replace(/\/+$/, "");
+const DASHBOARD_URL_PREFIX = "https://opencode.ai/workspace/";
+const DASHBOARD_URL_SUFFIX = "/go";
+const REFRESH_INTERVAL_MS = 60_000;
+const REQUEST_TIMEOUT_MS = 15_000;
+
+const ROLLING_WINDOW_MINS = 5 * 60;
+const WEEKLY_WINDOW_MINS = 7 * 24 * 60;
+const MONTHLY_WINDOW_MINS = 30 * 24 * 60;
+
+const SCRAPED_NUMBER_PATTERN = String.raw`(-?\d+(?:\.\d+)?)`;
+const RE_ROLLING_PCT_FIRST = new RegExp(
+  String.raw`rollingUsage:\$R\[\d+\]=\{[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_ROLLING_RESET_FIRST = new RegExp(
+  String.raw`rollingUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_WEEKLY_PCT_FIRST = new RegExp(
+  String.raw`weeklyUsage:\$R\[\d+\]=\{[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_WEEKLY_RESET_FIRST = new RegExp(
+  String.raw`weeklyUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_MONTHLY_PCT_FIRST = new RegExp(
+  String.raw`monthlyUsage:\$R\[\d+\]=\{[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+const RE_MONTHLY_RESET_FIRST = new RegExp(
+  String.raw`monthlyUsage:\$R\[\d+\]=\{[^}]*resetInSec:${SCRAPED_NUMBER_PATTERN}[^}]*usagePercent:${SCRAPED_NUMBER_PATTERN}[^}]*\}`,
+);
+
+function timeoutSignal(timeoutMs: number): { signal: AbortSignal; cancel: () => void } {
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), timeoutMs);
+  return {
+    signal: controller.signal,
+    cancel: () => clearTimeout(timeout),
+  };
+}
+
+function normalizeWindow(
+  window: OpenCodeGoUsageWindow | undefined,
+  windowDurationMins: number,
+): QuotaWindowSnapshot | null {
+  if (!window || typeof window !== "object") return null;
+  if (typeof window.usagePercent !== "number") return null;
+
+  const resetInSec = typeof window.resetInSec === "number" ? window.resetInSec : null;
+  return {
+    usedPercent: Math.max(0, Math.min(100, window.usagePercent)),
+    windowDurationMins,
+    resetsAt: resetInSec === null ? null : Date.now() + Math.max(0, resetInSec) * 1000,
+  };
+}
+
+function extractQuotaSnapshot(payload: OpenCodeGoUsageResponse): QuotaSnapshot | null {
+  const rolling = normalizeWindow(payload.rollingUsage, ROLLING_WINDOW_MINS);
+  const weekly = normalizeWindow(payload.weeklyUsage, WEEKLY_WINDOW_MINS);
+  const monthly = normalizeWindow(payload.monthlyUsage, MONTHLY_WINDOW_MINS);
+  if (!rolling && !weekly && !monthly) return null;
+
+  return {
+    limitId: "opencode-go",
+    limitName: "OpenCode Go",
+    primary: rolling,
+    secondary: weekly,
+    tertiary: monthly,
+  };
+}
+
+async function readOfficialUsageEndpoint(ctx: ExtensionContext): Promise<QuotaSnapshot | null> {
+  const model = ctx.model;
+  if (!model) return null;
+
+  const auth = await ctx.modelRegistry.getApiKeyAndHeaders(model);
+  if (!auth.ok || !auth.apiKey) return null;
+
+  const headers = new Headers(auth.headers);
+  headers.set("Authorization", `Bearer ${auth.apiKey}`);
+  headers.set("Accept", "application/json");
+  headers.set("User-Agent", "cake-footer");
+
+  const timeout = timeoutSignal(REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(`${OPENCODE_GO_BASE_URL}/usage`, {
+      headers,
+      signal: timeout.signal,
+    });
+    if (!response.ok) return null;
+    return extractQuotaSnapshot((await response.json()) as OpenCodeGoUsageResponse);
+  } catch {
+    return null;
+  } finally {
+    timeout.cancel();
+  }
+}
+
+async function readDashboardConfig(): Promise<OpenCodeGoDashboardConfig | null> {
+  const workspaceId = process.env.OPENCODE_GO_WORKSPACE_ID?.trim();
+  const authCookie = process.env.OPENCODE_GO_AUTH_COOKIE?.trim();
+  if (workspaceId && authCookie) return { workspaceId, authCookie };
+
+  try {
+    const configPath = join(homedir(), ".config", "opencode", "opencode-quota", "opencode-go.json");
+    const parsed = JSON.parse(await readFile(configPath, "utf8")) as Record<string, unknown>;
+    const fileWorkspaceId = typeof parsed.workspaceId === "string" ? parsed.workspaceId.trim() : "";
+    const fileAuthCookie = typeof parsed.authCookie === "string" ? parsed.authCookie.trim() : "";
+    if (fileWorkspaceId && fileAuthCookie) {
+      return { workspaceId: fileWorkspaceId, authCookie: fileAuthCookie };
+    }
+  } catch {
+    // No dashboard config; official API-key endpoint may still work in the future.
+  }
+
+  return null;
+}
+
+function parseWindowUsage(
+  html: string,
+  rePctFirst: RegExp,
+  reResetFirst: RegExp,
+): ScrapedWindowUsage | null {
+  const pctFirstMatch = rePctFirst.exec(html);
+  if (pctFirstMatch) {
+    const usagePercent = Number(pctFirstMatch[1]);
+    const resetInSec = Number(pctFirstMatch[2]);
+    if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
+      return { usagePercent, resetInSec };
+    }
+  }
+
+  const resetFirstMatch = reResetFirst.exec(html);
+  if (resetFirstMatch) {
+    const resetInSec = Number(resetFirstMatch[1]);
+    const usagePercent = Number(resetFirstMatch[2]);
+    if (Number.isFinite(usagePercent) && Number.isFinite(resetInSec)) {
+      return { usagePercent, resetInSec };
+    }
+  }
+
+  return null;
+}
+
+function scrapedWindowToUsage(window: ScrapedWindowUsage | null): OpenCodeGoUsageWindow | undefined {
+  if (!window) return undefined;
+  return {
+    usagePercent: window.usagePercent,
+    resetInSec: window.resetInSec,
+  };
+}
+
+async function readDashboardUsage(): Promise<QuotaSnapshot | null> {
+  const config = await readDashboardConfig();
+  if (!config) return null;
+
+  const timeout = timeoutSignal(REQUEST_TIMEOUT_MS);
+  try {
+    const response = await fetch(
+      `${DASHBOARD_URL_PREFIX}${encodeURIComponent(config.workspaceId)}${DASHBOARD_URL_SUFFIX}`,
+      {
+        headers: {
+          Accept: "text/html",
+          Cookie: `auth=${config.authCookie}`,
+          "User-Agent": "Mozilla/5.0 cake-footer",
+        },
+        signal: timeout.signal,
+      },
+    );
+    if (!response.ok) return null;
+
+    const html = await response.text();
+    return extractQuotaSnapshot({
+      rollingUsage: scrapedWindowToUsage(
+        parseWindowUsage(html, RE_ROLLING_PCT_FIRST, RE_ROLLING_RESET_FIRST),
+      ),
+      weeklyUsage: scrapedWindowToUsage(
+        parseWindowUsage(html, RE_WEEKLY_PCT_FIRST, RE_WEEKLY_RESET_FIRST),
+      ),
+      monthlyUsage: scrapedWindowToUsage(
+        parseWindowUsage(html, RE_MONTHLY_PCT_FIRST, RE_MONTHLY_RESET_FIRST),
+      ),
+    });
+  } catch {
+    return null;
+  } finally {
+    timeout.cancel();
+  }
+}
+
+async function readOpenCodeGoQuotaSnapshot(ctx: ExtensionContext): Promise<QuotaSnapshot | null> {
+  return (await readOfficialUsageEndpoint(ctx)) ?? (await readDashboardUsage());
+}
+
+export function createOpenCodeGoQuotaTracker(
+  ctx: ExtensionContext,
+  onUpdate: () => void,
+): QuotaTracker {
+  let enabled = false;
+  let snapshot: QuotaSnapshot | null = null;
+  let lastRefreshAt = 0;
+  let refreshInFlight: Promise<void> | null = null;
+  let interval: ReturnType<typeof setInterval> | null = null;
+  let disposed = false;
+
+  const refresh = async (): Promise<void> => {
+    if (disposed || refreshInFlight) return;
+
+    refreshInFlight = (async () => {
+      const next = await readOpenCodeGoQuotaSnapshot(ctx);
+      const previous = snapshot ? JSON.stringify(snapshot) : null;
+      const current = next ? JSON.stringify(next) : null;
+      snapshot = next;
+      lastRefreshAt = Date.now();
+      if (previous !== current) {
+        onUpdate();
+      }
+    })().finally(() => {
+      refreshInFlight = null;
+    });
+
+    await refreshInFlight;
+  };
+
+  const stopInterval = (): void => {
+    if (interval) {
+      clearInterval(interval);
+      interval = null;
+    }
+  };
+
+  const startInterval = (): void => {
+    if (interval) return;
+    interval = setInterval(() => {
+      void refresh();
+    }, REFRESH_INTERVAL_MS);
+  };
+
+  return {
+    setEnabled(nextEnabled: boolean): void {
+      enabled = nextEnabled;
+      if (!enabled) {
+        stopInterval();
+        return;
+      }
+
+      startInterval();
+      if (!snapshot || Date.now() - lastRefreshAt >= REFRESH_INTERVAL_MS) {
+        void refresh();
+      }
+    },
+    getSnapshot(): QuotaSnapshot | null {
+      return snapshot;
+    },
+    dispose(): void {
+      disposed = true;
+      stopInterval();
+    },
+  };
+}

--- a/users/profiles/pi/extensions/footer/segments.ts
+++ b/users/profiles/pi/extensions/footer/segments.ts
@@ -23,6 +23,20 @@ export interface VcsInfo {
   hasConflict?: boolean;
 }
 
+export interface QuotaWindowInput {
+  usedPercent: number;
+  windowDurationMins: number | null;
+  resetsAt: number | null;
+}
+
+export interface QuotaSegmentInput {
+  limitId: string | null;
+  limitName: string | null;
+  primary: QuotaWindowInput | null;
+  secondary: QuotaWindowInput | null;
+  tertiary?: QuotaWindowInput | null;
+}
+
 // ── Thinking-level maps ─────────────────────────────────────
 
 const THINKING_LABELS: Record<string, string> = {
@@ -42,6 +56,7 @@ const THINKING_COLORS: Record<string, ThemeColor> = {
   high: "warning",
   xhigh: "error",
 };
+
 
 // ── Segment renderers ───────────────────────────────────────
 
@@ -119,9 +134,69 @@ export function renderCost(theme: Theme, costUsd: number): string | null {
   return theme.fg("text", formatCost(costUsd));
 }
 
+
+function formatWindowDuration(windowDurationMins: number | null): string | null {
+  if (windowDurationMins === null || windowDurationMins <= 0) return null;
+  if (windowDurationMins % (60 * 24 * 7) === 0) {
+    return `${windowDurationMins / (60 * 24 * 7)}w`;
+  }
+  if (windowDurationMins % (60 * 24) === 0) {
+    return `${windowDurationMins / (60 * 24)}d`;
+  }
+  if (windowDurationMins % 60 === 0) {
+    return `${windowDurationMins / 60}h`;
+  }
+  return `${windowDurationMins}m`;
+}
+
+function formatPercentCompact(value: number): string {
+  const rounded = Number.isInteger(value) ? value.toFixed(0) : value.toFixed(1);
+  return `${rounded}%`;
+}
+function quotaAvailablePercent(window: QuotaWindowInput): number {
+  return Math.max(0, Math.min(100, 100 - window.usedPercent));
+}
+
+function renderQuotaWindow(theme: Theme, window: QuotaWindowInput): string | null {
+  if (!Number.isFinite(window.usedPercent)) return null;
+
+  const availablePercent = quotaAvailablePercent(window);
+  const color: ThemeColor =
+    availablePercent <= 10 ? "error" : availablePercent <= 30 ? "warning" : "dim";
+  const label = formatWindowDuration(window.windowDurationMins);
+  const percentText = formatPercentCompact(availablePercent);
+
+  if (label) {
+    return `${theme.fg(color, label)} ${theme.fg(color, percentText)}`;
+  }
+  return theme.fg(color, percentText);
+}
+
+/** Render provider quota usage segment. Returns null if usage is unavailable. */
+export function renderQuota(theme: Theme, input: QuotaSegmentInput | null): string | null {
+  if (!input) return null;
+
+  const windows = [input.primary, input.secondary, input.tertiary ?? null].filter(
+    (value): value is QuotaWindowInput => value !== null,
+  );
+  if (windows.length === 0) return null;
+
+  const tightestWindow = windows.reduce((tightest, window) => {
+    const availableDelta = quotaAvailablePercent(window) - quotaAvailablePercent(tightest);
+    if (availableDelta < 0) return window;
+    if (availableDelta > 0) return tightest;
+
+    const windowDuration = window.windowDurationMins ?? Number.MAX_SAFE_INTEGER;
+    const tightestDuration = tightest.windowDurationMins ?? Number.MAX_SAFE_INTEGER;
+    return windowDuration < tightestDuration ? window : tightest;
+  });
+
+  return renderQuotaWindow(theme, tightestWindow);
+}
+
 /**
  * Render provider + context-usage segment.
- * Shows e.g. "DeepSeek 45k/128k" with color-coded percentage.
+ * Shows e.g. "OpenCode Go 5h 72% 45k/128k" with color-coded usage.
  * Falls back to "Context" label when no provider is known.
  */
 export function renderProviderContext(
@@ -129,8 +204,14 @@ export function renderProviderContext(
   providerLabel: string | undefined,
   used: number | null,
   total: number,
+  quota?: string | null,
 ): string | null {
-  if (total <= 0) return null;
+  const label = providerLabel ?? "Context";
+  const quotaPart = quota ? ` ${quota}` : "";
+
+  if (total <= 0) {
+    return quota ? `${theme.fg("muted", label)}${quotaPart}` : null;
+  }
 
   const tokens = used === null
     ? theme.fg("muted", "?")
@@ -141,6 +222,5 @@ export function renderProviderContext(
         return theme.fg(color, formatTokens(used));
       })();
 
-  const label = providerLabel ?? "Context";
-  return `${theme.fg("muted", label)} ${tokens}/${theme.fg("text", formatTokens(total))}`;
+  return `${theme.fg("muted", label)}${quotaPart} ${tokens}/${theme.fg("text", formatTokens(total))}`;
 }


### PR DESCRIPTION
## Summary
- add Codex and OpenCode Go quota tracking for the Pi footer
- merge compact quota into the provider/context segment
- show only the tightest quota window with remaining-quota color thresholds

## Validation
- just lint
- nix run nixpkgs#esbuild -- --bundle --platform=node --format=esm users/profiles/pi/extensions/footer/index.ts --outfile=/tmp/cake-footer-check.js --external:@earendil-works/* --external:node:*