### PR TITLE
feat(pi): add plan mode and jj_todo dry-runs

### DIFF
--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -32,8 +32,8 @@ let
   thirdPartyPackages = [
     "npm:@juicesharp/rpiv-ask-user-question@1.13.0"
     "npm:@juicesharp/rpiv-todo@1.13.0"
-    "npm:pi-hashline-edit@0.6.1"
-    # "npm:pi-hashline-readmap@0.8.14"
+    # "npm:pi-hashline-edit@0.6.1"
+    "npm:pi-hashline-readmap@0.8.15"
     # Pure-HTTP web search + fetch (no browser) — jail-friendly. Non-secret config
     # is ~/.pi/web-search.json (below); web_search uses Exa, whose key comes from
     # the exa-api-key agenix secret, injected into the jail by the pi spec in

--- a/users/profiles/pi/extensions/jj-todo/index.ts
+++ b/users/profiles/pi/extensions/jj-todo/index.ts
@@ -29,6 +29,7 @@ interface JjTodoParams {
   draft?: boolean;
   limit?: number;
   fresh?: boolean;
+  dryRun?: boolean;
 }
 
 interface CommandResult {
@@ -36,6 +37,11 @@ interface CommandResult {
   stdout: string;
   stderr: string;
   code: number;
+}
+
+interface WouldRun {
+  command: "jj";
+  args: string[];
 }
 
 interface TaskInfo {
@@ -76,6 +82,9 @@ const jjTodoParams = Type.Object({
   })),
   fresh: Type.Optional(Type.Boolean({
     description: "For read-only actions, true/default lets JJ snapshot first; false uses --ignore-working-copy.",
+  })),
+  dryRun: Type.Optional(Type.Boolean({
+    description: "Preview create/update without mutating JJ history; previews default to fresh=false.",
   })),
 });
 
@@ -120,6 +129,10 @@ function compactError(command: string[], result: CommandResult): string {
   const stdout = result.stdout.trim();
   const message = stderr || stdout || `jj exited with code ${result.code}`;
   return `${command.join(" ")}: ${message}`;
+}
+
+function wouldRun(args: string[]): WouldRun {
+  return { command: "jj", args };
 }
 
 async function runJj(
@@ -243,6 +256,7 @@ async function nextTasks(pi: ExtensionAPI, ctx: ExtensionContext, signal: AbortS
 }
 
 async function createTask(pi: ExtensionAPI, ctx: ExtensionContext, signal: AbortSignal | undefined, params: JjTodoParams) {
+  const fresh = params.dryRun ? (params.fresh ?? false) : true;
   const parent = params.parent?.trim() || "@";
   const title = params.title?.trim();
   if (!title) throw new Error("action=create requires title");
@@ -250,41 +264,77 @@ async function createTask(pi: ExtensionAPI, ctx: ExtensionContext, signal: Abort
   const flag = params.flag ?? (params.draft ? "draft" : "todo");
   if (!isTaskFlag(flag)) throw new Error(`invalid task flag: ${flag}`);
 
-  await requireJjRepo(pi, ctx, signal, true);
   const body = params.body?.trim();
   const message = body ? `[task:${flag}] ${title}\n\n${body}` : `[task:${flag}] ${title}`;
-  const result = await runJj(pi, ctx, ["new", "--no-edit", parent, "-m", message], signal, true);
+  const args = ["new", "--no-edit", parent, "-m", message];
+
+  if (params.dryRun === true) {
+    await requireJjRepo(pi, ctx, signal, fresh);
+    await taskDescription(pi, ctx, signal, parent, fresh);
+    return {
+      action: "create",
+      dryRun: true,
+      parent,
+      flag,
+      title,
+      message,
+      wouldRun: wouldRun(args),
+      previewTask: { flag, title, firstLine: `[task:${flag}] ${title}`, parent, body: body ?? "" },
+    };
+  }
+
+  await requireJjRepo(pi, ctx, signal, fresh);
+  const result = await runJj(pi, ctx, args, signal, fresh);
   if (!result.ok) throw new Error(compactError(["jj", "new", "--no-edit", parent], result));
 
   const created = result.stdout.match(/Created new commit\s+([a-z]+)/)?.[1];
-  const task = created ? await taskInfo(pi, ctx, signal, created, true) : undefined;
+  const task = created ? await taskInfo(pi, ctx, signal, created, fresh) : undefined;
   return { action: "create", parent, created, task, stdout: result.stdout.trim() };
 }
 
 async function updateTask(pi: ExtensionAPI, ctx: ExtensionContext, signal: AbortSignal | undefined, params: JjTodoParams) {
+  const fresh = params.dryRun ? (params.fresh ?? false) : true;
   const rev = params.rev?.trim() || "@";
   const flag = params.flag;
   if (!flag) throw new Error("action=update requires flag");
   if (!isTaskFlag(flag)) throw new Error(`invalid task flag: ${flag}`);
 
-  await requireJjRepo(pi, ctx, signal, true);
-  const currentDescription = await taskDescription(pi, ctx, signal, rev, true);
+  await requireJjRepo(pi, ctx, signal, fresh);
+  const currentDescription = await taskDescription(pi, ctx, signal, rev, fresh);
   const firstLine = currentDescription.split(/\r?\n/, 1)[0] ?? "";
   const current = detectTask(firstLine);
-
-  if (current.flag === flag) {
-    const task = await taskInfo(pi, ctx, signal, rev, true);
-    return { action: "update", rev, changed: false, from: current.flag, to: flag, task };
-  }
-
   const nextDescription = current.flag
     ? currentDescription.replace(/^\[task:[^\]]+\]/, `[task:${flag}]`)
     : `[task:${flag}] ${currentDescription}`;
+  const changed = current.flag !== flag;
+  const args = ["describe", rev, "-m", nextDescription];
 
-  const result = await runJj(pi, ctx, ["describe", rev, "-m", nextDescription], signal, true);
+  if (!changed) {
+    const task = await taskInfo(pi, ctx, signal, rev, fresh);
+    return { action: "update", ...(params.dryRun === true ? { dryRun: true } : {}), rev, changed: false, from: current.flag, to: flag, task };
+  }
+
+  if (params.dryRun === true) {
+    const nextFirstLine = nextDescription.split(/\r?\n/, 1)[0] ?? "";
+    const preview = detectTask(nextFirstLine);
+    return {
+      action: "update",
+      dryRun: true,
+      rev,
+      changed: true,
+      from: current.flag,
+      to: flag,
+      currentDescription,
+      nextDescription,
+      wouldRun: wouldRun(args),
+      previewTask: { flag: preview.flag, title: preview.title, firstLine: nextFirstLine, rev },
+    };
+  }
+
+  const result = await runJj(pi, ctx, args, signal, fresh);
   if (!result.ok) throw new Error(compactError(["jj", "describe", rev], result));
 
-  const task = await taskInfo(pi, ctx, signal, rev, true);
+  const task = await taskInfo(pi, ctx, signal, rev, fresh);
   return { action: "update", rev, changed: true, from: current.flag, to: flag, task };
 }
 
@@ -315,10 +365,11 @@ export default function jjTodoExtension(pi: ExtensionAPI) {
   pi.registerTool({
     name: "jj_todo",
     label: "JJ TODO",
-    description: "Perform compact JJ TODO workflow operations: list task commits, find ready child tasks, create task commits, update task flags, and check task state.",
-    promptSnippet: "Manage mechanical JJ TODO workflow operations with compact structured output.",
+    description: "Perform compact JJ TODO workflow operations: list task commits, find ready child tasks, create or preview task commits, update or preview task flags, and check task state.",
+    promptSnippet: "Manage mechanical JJ TODO workflow operations with compact structured output. Use dryRun: true to preview create/update before changing JJ history.",
     promptGuidelines: [
       "Use jj_todo for routine JJ TODO mechanics such as listing tasks, creating task commits, and updating [task:*] flags; keep planning and task judgment in normal reasoning.",
+      "Use dryRun: true with create/update to preview the exact jj command and resulting metadata without mutating history.",
       "Use jj_todo read actions before verbose jj shell commands when task state summaries are enough; use bash with jj for full graph inspection, rebases, splits, and unusual mutations.",
     ],
     parameters: jjTodoParams,

--- a/users/profiles/pi/extensions/plan-mode/index.ts
+++ b/users/profiles/pi/extensions/plan-mode/index.ts
@@ -1,3 +1,4 @@
+// Plan mode is a Pi tool/UI guard, not an OS sandbox; bash is disabled rather than allowlisted.
 import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
@@ -94,6 +95,8 @@ function isCustomContextMessage(message: unknown, customType: string): boolean {
 
 export default function blazedPlanMode(pi: ExtensionAPI): void {
   let state: PlanModeState = createInitialState();
+  let latestCommandContext: ExtensionCommandContext | null = null;
+  let freshHandoffTimer: ReturnType<typeof setTimeout> | null = null;
 
   function ensurePlan(ctx: ExtensionContext): string {
     if (!state.planFilePath) {
@@ -232,6 +235,42 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     }
   }
 
+  function scheduleFreshHandoff(ctx: ExtensionContext, planPath: string): string {
+    if (!latestCommandContext) {
+      if (ctx.hasUI) {
+        ctx.ui.setEditorText("/plan fresh");
+        ctx.ui.notify("Plan approved. Submit the prefilled /plan fresh command to start the fresh session.", "warning");
+      }
+      return `Plan approved for fresh-session implementation, but no command context is available to switch sessions automatically. Submit /plan fresh to continue with ${planPath}.`;
+    }
+
+    if (freshHandoffTimer) clearTimeout(freshHandoffTimer);
+    const commandCtx = latestCommandContext;
+
+    const runWhenIdle = async () => {
+      freshHandoffTimer = null;
+      if (!commandCtx.isIdle() || commandCtx.hasPendingMessages()) {
+        freshHandoffTimer = setTimeout(runWhenIdle, 100);
+        return;
+      }
+      await performFreshHandoff(commandCtx);
+    };
+
+    freshHandoffTimer = setTimeout(() => {
+      runWhenIdle().catch((error) => {
+        if (ctx.hasUI) {
+          ctx.ui.setEditorText("/plan fresh");
+          ctx.ui.notify(
+            `Automatic fresh-session handoff failed: ${error instanceof Error ? error.message : String(error)}. Submit /plan fresh manually.`,
+            "error",
+          );
+        }
+      });
+    }, 100);
+
+    return `Plan approved. Scheduled a fresh-session handoff for ${planPath}.`;
+  }
+
   async function runApprovalLoop(ctx: ExtensionContext): Promise<string> {
     const planPath = ensurePlan(ctx);
     const plan = readPlan(planPath) ?? "";
@@ -239,7 +278,7 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     if (!ctx.hasUI) return "ExitPlanMode requires an interactive/RPC UI approval flow; no approval was granted.";
 
     const title = extractPlanTitle(plan);
-    const choice = await ctx.ui.select(`Review plan: ${title}`, [
+    const choice = await ctx.ui.select(`${buildPlanReview(plan, planPath)}\n\nChoose approval action for: ${title}`, [
       APPROVE_HERE,
       APPROVE_FRESH,
       EDIT_PLAN,
@@ -260,8 +299,7 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
       state.lastApprovedPlanFilePath = planPath;
       state.pendingFreshImplementation = { planFilePath: planPath, requestedAt: new Date().toISOString() };
       exitPlanMode(ctx, "approved");
-      pi.sendUserMessage("/plan fresh", { deliverAs: "followUp" });
-      return `Plan approved. Queued a fresh-session handoff for ${planPath}.`;
+      return scheduleFreshHandoff(ctx, planPath);
     }
 
     if (choice === EDIT_PLAN) {
@@ -292,6 +330,7 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
   pi.registerCommand("plan", {
     description: "Plan before implementing. Usage: /plan <task>, /plan open|review|status|off|clear|fresh",
     handler: async (args, ctx) => {
+      latestCommandContext = ctx;
       const trimmed = args.trim();
 
       if (trimmed === "fresh") {
@@ -339,7 +378,11 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
 
       if (trimmed === "clear") {
         const planPath = ensurePlan(ctx);
-        const ok = !ctx.hasUI || (await ctx.ui.confirm("Clear plan?", `Empty the current plan file?\n\n${planPath}`));
+        if (!ctx.hasUI) {
+          ctx.ui.notify("Plan clear requires UI confirmation.", "warning");
+          return;
+        }
+        const ok = await ctx.ui.confirm("Clear plan?", `Empty the current plan file?\n\n${planPath}`);
         if (!ok) {
           ctx.ui.notify("Plan clear cancelled.", "info");
           return;

--- a/users/profiles/pi/extensions/plan-mode/index.ts
+++ b/users/profiles/pi/extensions/plan-mode/index.ts
@@ -1,0 +1,575 @@
+/**
+ * Blazed plan mode for Pi.
+ *
+ * Combines the official Pi plan-mode example with the stronger file-backed,
+ * approve-before-implementation flow from community plan-mode extensions.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
+import { Key } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { execSync } from "node:child_process";
+import {
+  createInitialState,
+  extractPlanTitle,
+  extractTodoItems,
+  generateUniquePlanPath,
+  isSafeReadOnlyCommand,
+  markCompletedSteps,
+  readPlan,
+  samePath,
+  type PlanState,
+  type TodoItem,
+  writePlan,
+} from "./utils.ts";
+
+const STATUS_KEY = "blazed-plan-mode";
+const WIDGET_KEY = "blazed-plan-mode-widget";
+const STATE_ENTRY = "blazed-plan-mode-state";
+const EXECUTE_ENTRY = "blazed-plan-mode-execute";
+
+const WRITE_TOOLS = new Set(["write", "edit", "ast_rewrite"]);
+const ALWAYS_SAFE_TOOLS = new Set([
+  "read",
+  "grep",
+  "find",
+  "ls",
+  "web_search",
+  "fetch_content",
+  "get_search_content",
+  "code_search",
+  "ask_user_question",
+  "todo",
+  "jj_context",
+  "EnterPlanMode",
+  "ExitPlanMode",
+]);
+
+function assistantText(message: unknown): string {
+  const candidate = message as { role?: unknown; content?: unknown };
+  if (candidate.role !== "assistant") return "";
+  if (typeof candidate.content === "string") return candidate.content;
+  if (!Array.isArray(candidate.content)) return "";
+  return candidate.content
+    .map((block) => {
+      const value = block as { type?: unknown; text?: unknown };
+      return value.type === "text" && typeof value.text === "string" ? value.text : "";
+    })
+    .filter(Boolean)
+    .join("\n");
+}
+
+function buildPlanningPrompt(task: string, planPath: string): string {
+  return `Enter plan mode for this task:\n\n${task}\n\nYour plan file is: ${planPath}\n\nStart with read-only exploration. Write or update the plan file as you learn. Ask concise user-answerable questions if requirements or tradeoffs are ambiguous. When the plan is ready, call ExitPlanMode for approval.`;
+}
+
+function buildImplementationPrompt(plan: string, planPath: string): string {
+  return `Implement this approved plan step by step.\n\nPlan file: ${planPath}\n\n${plan}\n\nFollow the plan. After completing each tracked step, include a [DONE:n] marker in your response. If reality differs from the plan, pause and explain the required adjustment before making broad changes.`;
+}
+
+function buildPlanReview(plan: string, planPath: string): string {
+  return `📋 Plan Review\n\n${plan}\n\nPlan file: ${planPath}`;
+}
+
+function buildPlanModeInstructions(planPath: string, existingPlan: string | null, reentry: boolean): string {
+  return `[PLAN MODE ACTIVE]
+You are in read-only plan mode. The user wants detailed planning before implementation.
+
+Plan file: ${planPath}
+${existingPlan?.trim() ? `\nCurrent plan content:\n${existingPlan.trim()}\n` : ""}
+${reentry ? "\nYou are re-entering plan mode after a prior approval/exit. Read and reassess the existing plan before revising it.\n" : ""}
+Hard restrictions:
+- Do not implement until the user approves via ExitPlanMode.
+- Do not write/edit any file except the plan file above.
+- Do not run mutating shell commands, installs, VCS mutations, switches, or destructive commands.
+- Use read-only exploration tools and bash only for read-only inspection.
+
+Planning workflow:
+1. Explore first: inspect relevant files, symbols, configs, tests, and docs. Do not make evidence-free plans.
+2. Capture findings in the plan file as you go; do not wait until the end.
+3. Ask only user-answerable questions. Never ask what you can discover by reading code.
+4. Converge when the plan names exact files/functions to change, existing utilities to reuse, validation commands, risks, and rollback notes.
+5. Call ExitPlanMode when the plan is ready. Do not ask for approval in plain text.
+
+Plan file format:
+# Plan: <short name>
+
+## Goal
+One paragraph describing done.
+
+## Evidence
+- \`path/to/file\`: what you verified
+
+## Assumptions / Decisions
+- Record clarified requirements and tradeoffs.
+
+## Critical Files
+- \`path/to/file\`: why it matters
+
+## Tasks
+### Task 1: <component>
+- [ ] Concrete 5-15 minute implementation step with exact names/paths
+- [ ] Concrete validation or test step
+- [ ] Commit: \`type(scope): message\`
+
+## Verification
+- Specific commands/checks to run.
+
+## Risks / Rollback
+- Risks, compatibility notes, and how to back out.
+
+Quality bar:
+- Zero placeholders: no TBD, "as needed", or vague "update config" steps.
+- A developer should be able to execute the plan without architectural guessing.`;
+}
+
+export default function blazedPlanMode(pi: ExtensionAPI): void {
+  let state: PlanState = createInitialState();
+  let executionMode = false;
+  let todoItems: TodoItem[] = [];
+  let lastCommandCtx: ExtensionCommandContext | null = null;
+
+  function ensurePlan(ctx: ExtensionContext): string {
+    if (!state.planFilePath) {
+      const generated = generateUniquePlanPath(ctx.cwd);
+      state.planSlug = generated.slug;
+      state.planFilePath = generated.path;
+      writePlan(generated.path, "");
+    }
+    return state.planFilePath;
+  }
+
+  function persistState(): void {
+    pi.appendEntry(STATE_ENTRY, {
+      ...state,
+      executionMode,
+      todoItems,
+    });
+  }
+
+  function updateUI(ctx: ExtensionContext): void {
+    if (!ctx.hasUI) return;
+
+    if (state.active) {
+      ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("warning", "⏸ plan"));
+      ctx.ui.setWidget(WIDGET_KEY, [
+        ctx.ui.theme.fg("warning", "Plan Mode") + ctx.ui.theme.fg("muted", ` — ${state.planFilePath ?? "no plan file"}`),
+      ]);
+      return;
+    }
+
+    if (executionMode && todoItems.length > 0) {
+      const completed = todoItems.filter((item) => item.completed).length;
+      ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("accent", `📋 ${completed}/${todoItems.length}`));
+      ctx.ui.setWidget(
+        WIDGET_KEY,
+        todoItems.map((item) =>
+          item.completed
+            ? ctx.ui.theme.fg("success", "☑ ") + ctx.ui.theme.fg("muted", ctx.ui.theme.strikethrough(item.text))
+            : `${ctx.ui.theme.fg("muted", "☐ ")}${item.text}`,
+        ),
+      );
+      return;
+    }
+
+    ctx.ui.setStatus(STATUS_KEY, undefined);
+    ctx.ui.setWidget(WIDGET_KEY, undefined);
+  }
+
+  function activatePlanMode(ctx: ExtensionContext): string {
+    const planPath = ensurePlan(ctx);
+    state.active = true;
+    state.lastTransition = "entered";
+    executionMode = false;
+    todoItems = [];
+    persistState();
+    updateUI(ctx);
+    return planPath;
+  }
+
+  function deactivatePlanMode(ctx: ExtensionContext, transition: "approved" | "cancelled" | null): void {
+    state.active = false;
+    state.lastTransition = transition;
+    state.hasExitedPlanModeInSession = transition === "approved" || state.hasExitedPlanModeInSession;
+    persistState();
+    updateUI(ctx);
+  }
+
+  async function approveCurrentPlan(ctx: ExtensionContext, editedDuringReview: boolean, freshSession: boolean): Promise<string> {
+    const planPath = ensurePlan(ctx);
+    const plan = readPlan(planPath) ?? "";
+    state.lastApprovedPlanFilePath = planPath;
+    state.lastTransition = "approved";
+    state.hasExitedPlanModeInSession = true;
+    executionMode = true;
+    todoItems = extractTodoItems(plan);
+    pi.setSessionName(extractPlanTitle(plan));
+    pi.appendEntry(EXECUTE_ENTRY, { planFilePath: planPath, todoItems, freshSession });
+    deactivatePlanMode(ctx, "approved");
+    updateUI(ctx);
+
+    const implementationPrompt = buildImplementationPrompt(plan, planPath);
+    const prefix = editedDuringReview ? "Plan approved after edits." : "Plan approved.";
+
+    if (!freshSession) return `${prefix}\n\n${implementationPrompt}`;
+
+    if (!lastCommandCtx) {
+      return `${prefix}\n\nI could not start a fresh session from this approval context. Run /plan fresh to clear the planning context and implement from the approved plan file.`;
+    }
+
+    const result = await lastCommandCtx.newSession({
+      parentSession: ctx.sessionManager.getSessionFile(),
+      withSession: async (newCtx) => {
+        await newCtx.sendUserMessage(implementationPrompt);
+      },
+    });
+
+    if (result.cancelled) {
+      return `${prefix}\n\nFresh session creation was cancelled. Run /plan fresh later, or implement in this session with:\n\n${implementationPrompt}`;
+    }
+
+    return `${prefix}\n\nStarted a fresh implementation session seeded only with the approved plan.`;
+  }
+
+  async function runApprovalLoop(ctx: ExtensionContext): Promise<string> {
+    const planPath = ensurePlan(ctx);
+    let plan = readPlan(planPath) ?? "";
+    if (!plan.trim()) return `No plan found in ${planPath}. Write a plan first, then call ExitPlanMode again.`;
+
+    if (!ctx.hasUI) return approveCurrentPlan(ctx, false, false);
+
+    let editedDuringReview = false;
+    while (true) {
+      ctx.ui.notify(buildPlanReview(plan, planPath), "info");
+      const choice = await ctx.ui.select("How would you like to proceed?", [
+        "✓ Accept — implement here",
+        "↻ Accept — clear context and implement",
+        "✎ Edit plan first",
+        "✗ Reject — give feedback",
+        "⟳ Start over",
+      ]);
+
+      if (!choice) return "Plan review dismissed. Continue refining the plan and call ExitPlanMode when ready.";
+
+      if (choice.startsWith("✓")) return approveCurrentPlan(ctx, editedDuringReview, false);
+      if (choice.startsWith("↻")) return approveCurrentPlan(ctx, editedDuringReview, true);
+
+      if (choice.startsWith("✎")) {
+        const editor = process.env.EDITOR || process.env.VISUAL;
+        if (editor) {
+          try {
+            execSync(`${editor} ${JSON.stringify(planPath)}`, { stdio: "inherit" });
+          } catch {
+            ctx.ui.notify("Editor closed or failed.", "warning");
+          }
+        } else {
+          const edited = await ctx.ui.editor("Edit Plan", plan);
+          if (edited !== undefined) writePlan(planPath, edited);
+        }
+        plan = readPlan(planPath) ?? plan;
+        editedDuringReview = true;
+        continue;
+      }
+
+      if (choice.startsWith("✗")) {
+        const feedback = await ctx.ui.input("What should change?", "Describe what to revise");
+        persistState();
+        return feedback?.trim()
+          ? `Plan rejected. User feedback: ${feedback.trim()}\n\nRevise the plan file and call ExitPlanMode again when ready.`
+          : "Plan rejected. Revise the plan file and call ExitPlanMode again when ready.";
+      }
+
+      if (choice.startsWith("⟳")) {
+        const direction = await ctx.ui.input("New direction?", "Optional focus for the new plan");
+        writePlan(planPath, "");
+        state.lastApprovedPlanFilePath = null;
+        persistState();
+        return direction?.trim()
+          ? `The user discarded the plan. Start over with this focus: ${direction.trim()}\n\nCreate a fresh plan in ${planPath}.`
+          : `The user discarded the plan. Start over and create a fresh plan in ${planPath}.`;
+      }
+    }
+  }
+
+  pi.registerFlag("plan", {
+    description: "Start Pi in read-only plan mode",
+    type: "boolean",
+    default: false,
+  });
+
+  pi.registerCommand("plan", {
+    description: "Plan before implementing. Usage: /plan <task>, /plan open|review|fresh|status|off|resume|clear",
+    handler: async (args, ctx) => {
+      const trimmed = args.trim();
+      lastCommandCtx = ctx;
+
+      if (trimmed === "off") {
+        deactivatePlanMode(ctx, "cancelled");
+        ctx.ui.notify("Plan mode cancelled.", "info");
+        return;
+      }
+
+      if (trimmed === "status") {
+        const content = readPlan(state.planFilePath);
+        ctx.ui.notify(
+          `Plan mode status\n\nActive: ${state.active ? "yes" : "no"}\nExecuting: ${executionMode ? "yes" : "no"}\nPlan file: ${state.planFilePath ?? "none"}\nApproved plan: ${state.lastApprovedPlanFilePath ?? "none"}\nPlan content: ${content?.trim() ? "present" : "empty/missing"}`,
+          "info",
+        );
+        return;
+      }
+
+      if (trimmed === "review") {
+        const planPath = ensurePlan(ctx);
+        ctx.ui.notify(buildPlanReview(readPlan(planPath) ?? "", planPath), "info");
+        return;
+      }
+
+      if (trimmed === "open") {
+        const planPath = ensurePlan(ctx);
+        const editor = process.env.EDITOR || process.env.VISUAL;
+        if (editor) {
+          execSync(`${editor} ${JSON.stringify(planPath)}`, { stdio: "inherit" });
+        } else {
+          const current = readPlan(planPath) ?? "";
+          const edited = await ctx.ui.editor("Edit Plan", current);
+          if (edited !== undefined) writePlan(planPath, edited);
+        }
+        ctx.ui.notify(`Plan saved: ${planPath}`, "info");
+        return;
+      }
+
+      if (trimmed === "clear") {
+        const planPath = ensurePlan(ctx);
+        if (ctx.hasUI) {
+          const confirmed = await ctx.ui.confirm("Clear plan?", `Erase ${planPath}?`);
+          if (!confirmed) return;
+        }
+        writePlan(planPath, "");
+        state.lastApprovedPlanFilePath = null;
+        persistState();
+        ctx.ui.notify("Plan cleared.", "info");
+        return;
+      }
+
+      if (trimmed === "resume") {
+        const planPath = activatePlanMode(ctx);
+        ctx.ui.notify(`Plan mode resumed. Plan file: ${planPath}`, "info");
+        return;
+      }
+
+      if (trimmed === "fresh") {
+        const planPath = state.lastApprovedPlanFilePath ?? state.planFilePath;
+        const plan = readPlan(planPath);
+        if (!planPath || !plan?.trim()) {
+          ctx.ui.notify("No approved plan is available for a fresh session.", "warning");
+          return;
+        }
+        await ctx.newSession({
+          parentSession: ctx.sessionManager.getSessionFile(),
+          withSession: async (newCtx) => {
+            await newCtx.sendUserMessage(buildImplementationPrompt(plan, planPath));
+          },
+        });
+        return;
+      }
+
+      if (!trimmed) {
+        if (state.active) {
+          const planPath = ensurePlan(ctx);
+          ctx.ui.notify(buildPlanReview(readPlan(planPath) ?? "", planPath), "info");
+        } else {
+          const planPath = activatePlanMode(ctx);
+          ctx.ui.notify(`Plan mode enabled. Plan file: ${planPath}`, "info");
+        }
+        return;
+      }
+
+      const planPath = activatePlanMode(ctx);
+      ctx.ui.notify(`Plan mode enabled. Plan file: ${planPath}`, "info");
+      pi.sendUserMessage(buildPlanningPrompt(trimmed, planPath), { deliverAs: "followUp" });
+    },
+  });
+
+  pi.registerCommand("todos", {
+    description: "Show approved plan execution progress",
+    handler: async (_args, ctx) => {
+      if (todoItems.length === 0) {
+        ctx.ui.notify("No tracked approved-plan tasks.", "info");
+        return;
+      }
+      const completed = todoItems.filter((item) => item.completed).length;
+      ctx.ui.notify(
+        `Plan progress ${completed}/${todoItems.length}\n` +
+          todoItems.map((item) => `${item.step}. ${item.completed ? "✓" : "○"} ${item.text}`).join("\n"),
+        "info",
+      );
+    },
+  });
+
+  pi.registerShortcut(Key.ctrlAlt("p"), {
+    description: "Toggle plan mode",
+    handler: async (ctx) => {
+      if (state.active) {
+        deactivatePlanMode(ctx, "cancelled");
+        ctx.ui.notify("Plan mode disabled.", "info");
+      } else {
+        const planPath = activatePlanMode(ctx);
+        ctx.ui.notify(`Plan mode enabled. Plan file: ${planPath}`, "info");
+      }
+    },
+  });
+
+  pi.registerTool({
+    name: "EnterPlanMode",
+    label: "Enter Plan Mode",
+    description: "Enter read-only plan mode before implementing a non-trivial task. Requires user approval in UI mode.",
+    promptSnippet: "Enter read-only plan mode and prepare an implementation plan before coding",
+    promptGuidelines: [
+      "For complex or ambiguous work, use EnterPlanMode before editing code.",
+      "In plan mode, write the evolving plan to the plan file and call ExitPlanMode when ready for user approval.",
+    ],
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      if (state.active) {
+        return { content: [{ type: "text", text: `Already in plan mode. Plan file: ${ensurePlan(ctx)}` }], details: { active: true } };
+      }
+      if (ctx.hasUI) {
+        const approved = await ctx.ui.confirm(
+          "Enter Plan Mode?",
+          "The agent wants to switch to read-only planning before implementation. Approve?",
+        );
+        if (!approved) {
+          return { content: [{ type: "text", text: "User declined plan mode. Continue normally." }], details: { approved: false } };
+        }
+      }
+      const planPath = activatePlanMode(ctx);
+      return {
+        content: [{ type: "text", text: `Plan mode activated. Write the plan to ${planPath}, then call ExitPlanMode for approval.` }],
+        details: { approved: true, planFilePath: planPath },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "ExitPlanMode",
+    label: "Exit Plan Mode",
+    description: "Present the current plan for user approval. Use only when the plan file is ready for review.",
+    promptSnippet: "Present the completed plan for approval before implementation",
+    promptGuidelines: [
+      "Only call ExitPlanMode after writing a complete plan file.",
+      "Do not ask for approval in plain text; use ExitPlanMode.",
+      "If the user rejects the plan, stay in plan mode and revise the plan file.",
+    ],
+    parameters: Type.Object({}),
+    async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
+      if (!state.active) {
+        return { content: [{ type: "text", text: "Not currently in plan mode." }], details: { active: false } };
+      }
+      const text = await runApprovalLoop(ctx);
+      return { content: [{ type: "text", text }], details: { approved: state.lastTransition === "approved", planFilePath: state.planFilePath } };
+    },
+  });
+
+  pi.on("tool_call", async (event) => {
+    if (!state.active) return;
+
+    if (event.toolName === "bash") {
+      const command = typeof event.input.command === "string" ? event.input.command : "";
+      if (!isSafeReadOnlyCommand(command)) {
+        return { block: true, reason: `Plan mode blocked non-read-only bash command: ${command}` };
+      }
+      return;
+    }
+
+    if (isToolCallEventType("write", event) || isToolCallEventType("edit", event)) {
+      if (samePath(event.input.path, state.planFilePath)) return;
+      return { block: true, reason: `Plan mode allows writes only to the plan file: ${state.planFilePath}` };
+    }
+
+    if (WRITE_TOOLS.has(event.toolName)) {
+      return { block: true, reason: `Plan mode blocks mutating tool ${event.toolName}.` };
+    }
+
+    if (event.toolName === "jj_todo") {
+      const action = (event.input as { action?: unknown }).action;
+      if (action === "create" || action === "update") {
+        return { block: true, reason: "Plan mode blocks mutating jj_todo actions." };
+      }
+    }
+
+    if (ALWAYS_SAFE_TOOLS.has(event.toolName)) return;
+  });
+
+  pi.on("before_agent_start", async (event, ctx) => {
+    if (state.active) {
+      const planPath = ensurePlan(ctx);
+      const existingPlan = readPlan(planPath);
+      const reentry = state.hasExitedPlanModeInSession;
+      if (reentry) {
+        state.hasExitedPlanModeInSession = false;
+        persistState();
+      }
+      return {
+        message: {
+          customType: "blazed-plan-mode-context",
+          content: buildPlanModeInstructions(planPath, existingPlan, reentry),
+          display: false,
+        },
+        systemPrompt: `${event.systemPrompt}\n\n[PLAN MODE] Read-only planning is active. Use the plan file and call ExitPlanMode for approval before implementation.`,
+      };
+    }
+
+    const planPath = state.lastApprovedPlanFilePath;
+    const plan = readPlan(planPath);
+    if (planPath && plan?.trim()) {
+      return {
+        message: {
+          customType: "blazed-approved-plan-context",
+          content: `[APPROVED PLAN]\nPlan file: ${planPath}\n\n${plan}\n\nIf this plan is relevant and not complete, continue following it.`,
+          display: false,
+        },
+      };
+    }
+  });
+
+  pi.on("turn_end", async (event, ctx) => {
+    if (!executionMode || todoItems.length === 0) return;
+    const count = markCompletedSteps(assistantText(event.message), todoItems);
+    if (count > 0) {
+      persistState();
+      updateUI(ctx);
+    }
+    if (todoItems.every((item) => item.completed)) {
+      executionMode = false;
+      persistState();
+      updateUI(ctx);
+      ctx.ui.notify("Approved plan complete.", "info");
+    }
+  });
+
+  pi.on("session_start", async (_event, ctx) => {
+    state = createInitialState();
+    executionMode = false;
+    todoItems = [];
+
+    for (const entry of ctx.sessionManager.getEntries().slice().reverse()) {
+      const candidate = entry as { type?: string; customType?: string; data?: Partial<PlanState> & { executionMode?: boolean; todoItems?: TodoItem[] } };
+      if (candidate.type === "custom" && candidate.customType === STATE_ENTRY && candidate.data) {
+        state = { ...state, ...candidate.data };
+        executionMode = candidate.data.executionMode ?? false;
+        todoItems = candidate.data.todoItems ?? [];
+        break;
+      }
+    }
+
+    if (pi.getFlag("plan") === true) activatePlanMode(ctx);
+    updateUI(ctx);
+  });
+
+  pi.on("session_shutdown", async (_event, ctx) => {
+    if (!ctx.hasUI) return;
+    ctx.ui.setStatus(STATUS_KEY, undefined);
+    ctx.ui.setWidget(WIDGET_KEY, undefined);
+  });
+}

--- a/users/profiles/pi/extensions/plan-mode/index.ts
+++ b/users/profiles/pi/extensions/plan-mode/index.ts
@@ -492,9 +492,10 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     }
 
     if (event.toolName === "jj_todo") {
-      const action = (event.input as { action?: unknown }).action;
-      if (action === "create" || action === "update") {
-        return { block: true, reason: "Plan mode blocks mutating jj_todo actions." };
+      const input = event.input as { action?: unknown; dryRun?: unknown };
+      const action = input.action;
+      if ((action === "create" || action === "update") && input.dryRun !== true) {
+        return { block: true, reason: "Plan mode blocks mutating jj_todo actions; use dryRun: true to preview." };
       }
     }
 

--- a/users/profiles/pi/extensions/plan-mode/index.ts
+++ b/users/profiles/pi/extensions/plan-mode/index.ts
@@ -290,7 +290,7 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
   });
 
   pi.registerCommand("plan", {
-    description: "Plan before implementing. Usage: /plan <task>, /plan review|status|off|clear|fresh",
+    description: "Plan before implementing. Usage: /plan <task>, /plan open|review|status|off|clear|fresh",
     handler: async (args, ctx) => {
       const trimmed = args.trim();
 
@@ -300,15 +300,19 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
       }
 
       if (trimmed === "off") {
-        exitPlanMode(ctx, "cancelled");
-        ctx.ui.notify("Plan mode cancelled.", "info");
+        if (state.active) {
+          exitPlanMode(ctx, "cancelled");
+          ctx.ui.notify("Plan mode cancelled and tools restored.", "info");
+        } else {
+          ctx.ui.notify("Plan mode is not active.", "info");
+        }
         return;
       }
 
       if (trimmed === "status") {
         const plan = readPlan(state.planFilePath);
         ctx.ui.notify(
-          `Plan mode status\n\nActive: ${state.active ? "yes" : "no"}\n${buildPlanFileSummary(plan, state.planFilePath)}\nApproved plan: ${state.lastApprovedPlanFilePath ?? "none"}\nActive tools: ${pi.getActiveTools().join(", ")}`,
+          `Plan mode status\n\nActive: ${state.active ? "yes" : "no"}\n${buildPlanFileSummary(plan, state.planFilePath)}\nApproved plan: ${state.lastApprovedPlanFilePath ?? "none"}\nPending fresh handoff: ${state.pendingFreshImplementation?.planFilePath ?? "none"}\nActive tools: ${pi.getActiveTools().join(", ")}`,
           "info",
         );
         return;
@@ -320,8 +324,26 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
         return;
       }
 
+      if (trimmed === "open") {
+        const planPath = ensurePlan(ctx);
+        const edited = await ctx.ui.editor("Edit plan", readPlan(planPath) ?? "");
+        if (typeof edited !== "string") {
+          ctx.ui.notify("Plan edit cancelled.", "info");
+          return;
+        }
+        writePlan(planPath, edited);
+        persistState();
+        ctx.ui.notify(`Plan saved: ${planPath}`, "info");
+        return;
+      }
+
       if (trimmed === "clear") {
         const planPath = ensurePlan(ctx);
+        const ok = !ctx.hasUI || (await ctx.ui.confirm("Clear plan?", `Empty the current plan file?\n\n${planPath}`));
+        if (!ok) {
+          ctx.ui.notify("Plan clear cancelled.", "info");
+          return;
+        }
         writePlan(planPath, "");
         state.lastApprovedPlanFilePath = null;
         state.pendingFreshImplementation = null;

--- a/users/profiles/pi/extensions/plan-mode/index.ts
+++ b/users/profiles/pi/extensions/plan-mode/index.ts
@@ -1,36 +1,27 @@
-/**
- * Blazed plan mode for Pi.
- *
- * Combines the official Pi plan-mode example with the stronger file-backed,
- * approve-before-implementation flow from community plan-mode extensions.
- */
-
-import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
-import { execSync } from "node:child_process";
 import {
+  buildPlanFileSummary,
   createInitialState,
   extractPlanTitle,
-  extractTodoItems,
   generateUniquePlanPath,
-  isSafeReadOnlyCommand,
-  markCompletedSteps,
+  isPlanFileTarget,
   readPlan,
-  samePath,
-  type PlanState,
-  type TodoItem,
+  resolvePlanTargetPath,
+  sanitizePlanModeState,
+  type PlanModeState,
   writePlan,
 } from "./utils.ts";
 
 const STATUS_KEY = "blazed-plan-mode";
 const WIDGET_KEY = "blazed-plan-mode-widget";
 const STATE_ENTRY = "blazed-plan-mode-state";
-const EXECUTE_ENTRY = "blazed-plan-mode-execute";
+const PLAN_CONTEXT_TYPE = "blazed-plan-mode-context";
+const LEGACY_APPROVED_CONTEXT_TYPE = "blazed-approved-plan-context";
 
-const WRITE_TOOLS = new Set(["write", "edit", "ast_rewrite"]);
-const ALWAYS_SAFE_TOOLS = new Set([
+const PLAN_TOOL_NAMES = [
   "read",
   "grep",
   "find",
@@ -42,115 +33,86 @@ const ALWAYS_SAFE_TOOLS = new Set([
   "ask_user_question",
   "todo",
   "jj_context",
+  "jj_todo",
+  "write",
+  "edit",
   "EnterPlanMode",
   "ExitPlanMode",
-]);
+];
 
-function assistantText(message: unknown): string {
-  const candidate = message as { role?: unknown; content?: unknown };
-  if (candidate.role !== "assistant") return "";
-  if (typeof candidate.content === "string") return candidate.content;
-  if (!Array.isArray(candidate.content)) return "";
-  return candidate.content
-    .map((block) => {
-      const value = block as { type?: unknown; text?: unknown };
-      return value.type === "text" && typeof value.text === "string" ? value.text : "";
-    })
-    .filter(Boolean)
-    .join("\n");
-}
+const WRITE_TOOL_NAMES = new Set(["write", "edit"]);
+
+type StoredStateEntry = { type?: string; customType?: string; data?: Partial<PlanModeState> };
+type PathInput = { path?: unknown };
+type JjTodoInput = { action?: unknown; dryRun?: unknown; fresh?: unknown };
 
 function buildPlanningPrompt(task: string, planPath: string): string {
-  return `Enter plan mode for this task:\n\n${task}\n\nYour plan file is: ${planPath}\n\nStart with read-only exploration. Write or update the plan file as you learn. Ask concise user-answerable questions if requirements or tradeoffs are ambiguous. When the plan is ready, call ExitPlanMode for approval.`;
+  return `Enter plan mode for this task:\n\n${task}\n\nPlan file: ${planPath}\n\nExplore with non-mutating tools, keep the plan file updated, and call ExitPlanMode only when the plan is ready for approval.`;
 }
 
-function buildImplementationPrompt(plan: string, planPath: string): string {
-  return `Implement this approved plan step by step.\n\nPlan file: ${planPath}\n\n${plan}\n\nFollow the plan. After completing each tracked step, include a [DONE:n] marker in your response. If reality differs from the plan, pause and explain the required adjustment before making broad changes.`;
+function buildPlanModeInstructions(planPath: string, existingPlan: string | null): string {
+  return `[PLAN MODE ACTIVE]\nYou are planning only. Do not implement until ExitPlanMode approval completes.\n\nPlan file: ${planPath}\n${existingPlan?.trim() ? `\nCurrent plan content:\n${existingPlan.trim()}\n` : ""}\nRules:\n- Explore first with read-only tools.\n- Write or edit only the plan file above.\n- Bash is disabled in plan mode.\n- Ask the user only for preferences or tradeoffs that cannot be discovered.\n- Keep the plan self-contained and call ExitPlanMode when ready.`;
 }
 
 function buildPlanReview(plan: string, planPath: string): string {
-  return `📋 Plan Review\n\n${plan}\n\nPlan file: ${planPath}`;
+  return `📋 Plan Review\n\n${plan}\n\n${buildPlanFileSummary(plan, planPath)}`;
 }
 
-function buildPlanModeInstructions(planPath: string, existingPlan: string | null, reentry: boolean): string {
-  return `[PLAN MODE ACTIVE]
-You are in read-only plan mode. The user wants detailed planning before implementation.
+function hasDeleteOrRenameOperation(value: unknown): boolean {
+  if (Array.isArray(value)) return value.some(hasDeleteOrRenameOperation);
+  if (!value || typeof value !== "object") return false;
 
-Plan file: ${planPath}
-${existingPlan?.trim() ? `\nCurrent plan content:\n${existingPlan.trim()}\n` : ""}
-${reentry ? "\nYou are re-entering plan mode after a prior approval/exit. Read and reassess the existing plan before revising it.\n" : ""}
-Hard restrictions:
-- Do not implement until the user approves via ExitPlanMode.
-- Do not write/edit any file except the plan file above.
-- Do not run mutating shell commands, installs, VCS mutations, switches, or destructive commands.
-- Use read-only exploration tools and bash only for read-only inspection.
+  for (const [key, child] of Object.entries(value as Record<string, unknown>)) {
+    const normalizedKey = key.toLowerCase();
+    if (["delete", "rename", "remove", "unlink", "move"].includes(normalizedKey)) return true;
+    if (["action", "operation", "op"].includes(normalizedKey) && typeof child === "string") {
+      if (["delete", "rename", "remove", "unlink", "move", "rm", "mv"].includes(child.toLowerCase())) return true;
+    }
+    if (hasDeleteOrRenameOperation(child)) return true;
+  }
 
-Planning workflow:
-1. Explore first: inspect relevant files, symbols, configs, tests, and docs. Do not make evidence-free plans.
-2. Capture findings in the plan file as you go; do not wait until the end.
-3. Ask only user-answerable questions. Never ask what you can discover by reading code.
-4. Converge when the plan names exact files/functions to change, existing utilities to reuse, validation commands, risks, and rollback notes.
-5. Call ExitPlanMode when the plan is ready. Do not ask for approval in plain text.
+  return false;
+}
 
-Plan file format:
-# Plan: <short name>
-
-## Goal
-One paragraph describing done.
-
-## Evidence
-- \`path/to/file\`: what you verified
-
-## Assumptions / Decisions
-- Record clarified requirements and tradeoffs.
-
-## Critical Files
-- \`path/to/file\`: why it matters
-
-## Tasks
-### Task 1: <component>
-- [ ] Concrete 5-15 minute implementation step with exact names/paths
-- [ ] Concrete validation or test step
-- [ ] Commit: \`type(scope): message\`
-
-## Verification
-- Specific commands/checks to run.
-
-## Risks / Rollback
-- Risks, compatibility notes, and how to back out.
-
-Quality bar:
-- Zero placeholders: no TBD, "as needed", or vague "update config" steps.
-- A developer should be able to execute the plan without architectural guessing.`;
+function isCustomContextMessage(message: unknown, customType: string): boolean {
+  return !!message && typeof message === "object" && (message as { customType?: unknown }).customType === customType;
 }
 
 export default function blazedPlanMode(pi: ExtensionAPI): void {
-  let state: PlanState = createInitialState();
-  let executionMode = false;
-  let todoItems: TodoItem[] = [];
-  let lastCommandCtx: ExtensionCommandContext | null = null;
+  let state: PlanModeState = createInitialState();
 
   function ensurePlan(ctx: ExtensionContext): string {
     if (!state.planFilePath) {
       const generated = generateUniquePlanPath(ctx.cwd);
-      state.planSlug = generated.slug;
       state.planFilePath = generated.path;
+      state.planSlug = generated.slug;
       writePlan(generated.path, "");
     }
     return state.planFilePath;
   }
 
   function persistState(): void {
-    pi.appendEntry(STATE_ENTRY, {
-      ...state,
-      executionMode,
-      todoItems,
-    });
+    pi.appendEntry(STATE_ENTRY, state);
+  }
+
+  function planModeToolNames(): string[] {
+    const available = new Set(pi.getAllTools().map((tool) => tool.name));
+    return PLAN_TOOL_NAMES.filter((name) => available.has(name));
+  }
+
+  function setPlanModeTools(): void {
+    pi.setActiveTools(planModeToolNames());
+  }
+
+  function restorePreviousTools(): void {
+    const available = new Set(pi.getAllTools().map((tool) => tool.name));
+    const previous = state.previousToolNames?.filter((name) => available.has(name));
+    pi.setActiveTools(previous && previous.length > 0 ? previous : [...available]);
+    state.previousToolNames = null;
   }
 
   function updateUI(ctx: ExtensionContext): void {
     if (!ctx.hasUI) return;
-
     if (state.active) {
       ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("warning", "⏸ plan"));
       ctx.ui.setWidget(WIDGET_KEY, [
@@ -158,162 +120,96 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
       ]);
       return;
     }
-
-    if (executionMode && todoItems.length > 0) {
-      const completed = todoItems.filter((item) => item.completed).length;
-      ctx.ui.setStatus(STATUS_KEY, ctx.ui.theme.fg("accent", `📋 ${completed}/${todoItems.length}`));
-      ctx.ui.setWidget(
-        WIDGET_KEY,
-        todoItems.map((item) =>
-          item.completed
-            ? ctx.ui.theme.fg("success", "☑ ") + ctx.ui.theme.fg("muted", ctx.ui.theme.strikethrough(item.text))
-            : `${ctx.ui.theme.fg("muted", "☐ ")}${item.text}`,
-        ),
-      );
-      return;
-    }
-
     ctx.ui.setStatus(STATUS_KEY, undefined);
     ctx.ui.setWidget(WIDGET_KEY, undefined);
   }
 
-  function activatePlanMode(ctx: ExtensionContext): string {
+  function enterPlanMode(ctx: ExtensionContext, _task?: string): string {
+    if (!state.active) state.previousToolNames = pi.getActiveTools();
     const planPath = ensurePlan(ctx);
     state.active = true;
-    state.lastTransition = "entered";
-    executionMode = false;
-    todoItems = [];
+    state.pendingFreshImplementation = null;
+    setPlanModeTools();
     persistState();
     updateUI(ctx);
     return planPath;
   }
 
-  function deactivatePlanMode(ctx: ExtensionContext, transition: "approved" | "cancelled" | null): void {
+  function exitPlanMode(ctx: ExtensionContext, reason: "approved" | "cancelled"): void {
     state.active = false;
-    state.lastTransition = transition;
-    state.hasExitedPlanModeInSession = transition === "approved" || state.hasExitedPlanModeInSession;
+    if (reason === "cancelled") state.pendingFreshImplementation = null;
+    restorePreviousTools();
     persistState();
     updateUI(ctx);
   }
 
-  async function approveCurrentPlan(ctx: ExtensionContext, editedDuringReview: boolean, freshSession: boolean): Promise<string> {
-    const planPath = ensurePlan(ctx);
-    const plan = readPlan(planPath) ?? "";
-    state.lastApprovedPlanFilePath = planPath;
-    state.lastTransition = "approved";
-    state.hasExitedPlanModeInSession = true;
-    executionMode = true;
-    todoItems = extractTodoItems(plan);
-    pi.setSessionName(extractPlanTitle(plan));
-    pi.appendEntry(EXECUTE_ENTRY, { planFilePath: planPath, todoItems, freshSession });
-    deactivatePlanMode(ctx, "approved");
-    updateUI(ctx);
-
-    const implementationPrompt = buildImplementationPrompt(plan, planPath);
-    const prefix = editedDuringReview ? "Plan approved after edits." : "Plan approved.";
-
-    if (!freshSession) return `${prefix}\n\n${implementationPrompt}`;
-
-    if (!lastCommandCtx) {
-      return `${prefix}\n\nI could not start a fresh session from this approval context. Run /plan fresh to clear the planning context and implement from the approved plan file.`;
+  function restoreState(ctx: ExtensionContext): void {
+    state = createInitialState();
+    for (const entry of ctx.sessionManager.getEntries().slice().reverse()) {
+      const candidate = entry as StoredStateEntry;
+      if (candidate.type === "custom" && candidate.customType === STATE_ENTRY) {
+        state = sanitizePlanModeState(candidate.data);
+        break;
+      }
     }
 
-    const result = await lastCommandCtx.newSession({
-      parentSession: ctx.sessionManager.getSessionFile(),
-      withSession: async (newCtx) => {
-        await newCtx.sendUserMessage(implementationPrompt);
-      },
-    });
+    if (pi.getFlag("plan") === true) enterPlanMode(ctx);
+    else if (state.active) {
+      ensurePlan(ctx);
+      setPlanModeTools();
+      persistState();
+      updateUI(ctx);
+    } else {
+      updateUI(ctx);
+    }
+  }
 
-    if (result.cancelled) {
-      return `${prefix}\n\nFresh session creation was cancelled. Run /plan fresh later, or implement in this session with:\n\n${implementationPrompt}`;
+  function guardPlanFileWrite(event: { toolName: string; input: Record<string, unknown> }, ctx: ExtensionContext) {
+    const input = event.input as PathInput;
+    if (typeof input.path !== "string") {
+      return { block: true, reason: "Plan mode blocked write/edit without a path." };
     }
 
-    return `${prefix}\n\nStarted a fresh implementation session seeded only with the approved plan.`;
+    const targetPath = resolvePlanTargetPath(input.path, ctx.cwd, state.planFilePath);
+    if (!targetPath || !isPlanFileTarget(input.path, ctx.cwd, state.planFilePath)) {
+      return { block: true, reason: `Plan mode allows writes only to the plan file: ${state.planFilePath}` };
+    }
+
+    if (event.toolName === "edit" && hasDeleteOrRenameOperation(event.input)) {
+      return { block: true, reason: "Plan mode blocks delete/rename-like edit operations." };
+    }
+
+    input.path = targetPath;
   }
 
   async function runApprovalLoop(ctx: ExtensionContext): Promise<string> {
     const planPath = ensurePlan(ctx);
-    let plan = readPlan(planPath) ?? "";
-    if (!plan.trim()) return `No plan found in ${planPath}. Write a plan first, then call ExitPlanMode again.`;
-
-    if (!ctx.hasUI) return approveCurrentPlan(ctx, false, false);
-
-    let editedDuringReview = false;
-    while (true) {
-      ctx.ui.notify(buildPlanReview(plan, planPath), "info");
-      const choice = await ctx.ui.select("How would you like to proceed?", [
-        "✓ Accept — implement here",
-        "↻ Accept — clear context and implement",
-        "✎ Edit plan first",
-        "✗ Reject — give feedback",
-        "⟳ Start over",
-      ]);
-
-      if (!choice) return "Plan review dismissed. Continue refining the plan and call ExitPlanMode when ready.";
-
-      if (choice.startsWith("✓")) return approveCurrentPlan(ctx, editedDuringReview, false);
-      if (choice.startsWith("↻")) return approveCurrentPlan(ctx, editedDuringReview, true);
-
-      if (choice.startsWith("✎")) {
-        const editor = process.env.EDITOR || process.env.VISUAL;
-        if (editor) {
-          try {
-            execSync(`${editor} ${JSON.stringify(planPath)}`, { stdio: "inherit" });
-          } catch {
-            ctx.ui.notify("Editor closed or failed.", "warning");
-          }
-        } else {
-          const edited = await ctx.ui.editor("Edit Plan", plan);
-          if (edited !== undefined) writePlan(planPath, edited);
-        }
-        plan = readPlan(planPath) ?? plan;
-        editedDuringReview = true;
-        continue;
-      }
-
-      if (choice.startsWith("✗")) {
-        const feedback = await ctx.ui.input("What should change?", "Describe what to revise");
-        persistState();
-        return feedback?.trim()
-          ? `Plan rejected. User feedback: ${feedback.trim()}\n\nRevise the plan file and call ExitPlanMode again when ready.`
-          : "Plan rejected. Revise the plan file and call ExitPlanMode again when ready.";
-      }
-
-      if (choice.startsWith("⟳")) {
-        const direction = await ctx.ui.input("New direction?", "Optional focus for the new plan");
-        writePlan(planPath, "");
-        state.lastApprovedPlanFilePath = null;
-        persistState();
-        return direction?.trim()
-          ? `The user discarded the plan. Start over with this focus: ${direction.trim()}\n\nCreate a fresh plan in ${planPath}.`
-          : `The user discarded the plan. Start over and create a fresh plan in ${planPath}.`;
-      }
-    }
+    const plan = readPlan(planPath) ?? "";
+    if (!plan.trim()) return `No plan found in ${planPath}. Write the plan file before calling ExitPlanMode.`;
+    return `Plan file is ready for approval: ${planPath}. Approval handoff will be handled by the plan-mode approval flow.`;
   }
 
   pi.registerFlag("plan", {
-    description: "Start Pi in read-only plan mode",
+    description: "Start Pi in planning mode with file-backed guardrails",
     type: "boolean",
     default: false,
   });
 
   pi.registerCommand("plan", {
-    description: "Plan before implementing. Usage: /plan <task>, /plan open|review|fresh|status|off|resume|clear",
+    description: "Plan before implementing. Usage: /plan <task>, /plan review|status|off|clear",
     handler: async (args, ctx) => {
       const trimmed = args.trim();
-      lastCommandCtx = ctx;
 
       if (trimmed === "off") {
-        deactivatePlanMode(ctx, "cancelled");
+        exitPlanMode(ctx, "cancelled");
         ctx.ui.notify("Plan mode cancelled.", "info");
         return;
       }
 
       if (trimmed === "status") {
-        const content = readPlan(state.planFilePath);
+        const plan = readPlan(state.planFilePath);
         ctx.ui.notify(
-          `Plan mode status\n\nActive: ${state.active ? "yes" : "no"}\nExecuting: ${executionMode ? "yes" : "no"}\nPlan file: ${state.planFilePath ?? "none"}\nApproved plan: ${state.lastApprovedPlanFilePath ?? "none"}\nPlan content: ${content?.trim() ? "present" : "empty/missing"}`,
+          `Plan mode status\n\nActive: ${state.active ? "yes" : "no"}\n${buildPlanFileSummary(plan, state.planFilePath)}\nApproved plan: ${state.lastApprovedPlanFilePath ?? "none"}\nActive tools: ${pi.getActiveTools().join(", ")}`,
           "info",
         );
         return;
@@ -325,52 +221,13 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
         return;
       }
 
-      if (trimmed === "open") {
-        const planPath = ensurePlan(ctx);
-        const editor = process.env.EDITOR || process.env.VISUAL;
-        if (editor) {
-          execSync(`${editor} ${JSON.stringify(planPath)}`, { stdio: "inherit" });
-        } else {
-          const current = readPlan(planPath) ?? "";
-          const edited = await ctx.ui.editor("Edit Plan", current);
-          if (edited !== undefined) writePlan(planPath, edited);
-        }
-        ctx.ui.notify(`Plan saved: ${planPath}`, "info");
-        return;
-      }
-
       if (trimmed === "clear") {
         const planPath = ensurePlan(ctx);
-        if (ctx.hasUI) {
-          const confirmed = await ctx.ui.confirm("Clear plan?", `Erase ${planPath}?`);
-          if (!confirmed) return;
-        }
         writePlan(planPath, "");
         state.lastApprovedPlanFilePath = null;
+        state.pendingFreshImplementation = null;
         persistState();
-        ctx.ui.notify("Plan cleared.", "info");
-        return;
-      }
-
-      if (trimmed === "resume") {
-        const planPath = activatePlanMode(ctx);
-        ctx.ui.notify(`Plan mode resumed. Plan file: ${planPath}`, "info");
-        return;
-      }
-
-      if (trimmed === "fresh") {
-        const planPath = state.lastApprovedPlanFilePath ?? state.planFilePath;
-        const plan = readPlan(planPath);
-        if (!planPath || !plan?.trim()) {
-          ctx.ui.notify("No approved plan is available for a fresh session.", "warning");
-          return;
-        }
-        await ctx.newSession({
-          parentSession: ctx.sessionManager.getSessionFile(),
-          withSession: async (newCtx) => {
-            await newCtx.sendUserMessage(buildImplementationPrompt(plan, planPath));
-          },
-        });
+        ctx.ui.notify(`Plan cleared: ${planPath}`, "info");
         return;
       }
 
@@ -379,31 +236,15 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
           const planPath = ensurePlan(ctx);
           ctx.ui.notify(buildPlanReview(readPlan(planPath) ?? "", planPath), "info");
         } else {
-          const planPath = activatePlanMode(ctx);
+          const planPath = enterPlanMode(ctx);
           ctx.ui.notify(`Plan mode enabled. Plan file: ${planPath}`, "info");
         }
         return;
       }
 
-      const planPath = activatePlanMode(ctx);
+      const planPath = enterPlanMode(ctx, trimmed);
       ctx.ui.notify(`Plan mode enabled. Plan file: ${planPath}`, "info");
       pi.sendUserMessage(buildPlanningPrompt(trimmed, planPath), { deliverAs: "followUp" });
-    },
-  });
-
-  pi.registerCommand("todos", {
-    description: "Show approved plan execution progress",
-    handler: async (_args, ctx) => {
-      if (todoItems.length === 0) {
-        ctx.ui.notify("No tracked approved-plan tasks.", "info");
-        return;
-      }
-      const completed = todoItems.filter((item) => item.completed).length;
-      ctx.ui.notify(
-        `Plan progress ${completed}/${todoItems.length}\n` +
-          todoItems.map((item) => `${item.step}. ${item.completed ? "✓" : "○"} ${item.text}`).join("\n"),
-        "info",
-      );
     },
   });
 
@@ -411,10 +252,10 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     description: "Toggle plan mode",
     handler: async (ctx) => {
       if (state.active) {
-        deactivatePlanMode(ctx, "cancelled");
+        exitPlanMode(ctx, "cancelled");
         ctx.ui.notify("Plan mode disabled.", "info");
       } else {
-        const planPath = activatePlanMode(ctx);
+        const planPath = enterPlanMode(ctx);
         ctx.ui.notify(`Plan mode enabled. Plan file: ${planPath}`, "info");
       }
     },
@@ -423,11 +264,11 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
   pi.registerTool({
     name: "EnterPlanMode",
     label: "Enter Plan Mode",
-    description: "Enter read-only plan mode before implementing a non-trivial task. Requires user approval in UI mode.",
-    promptSnippet: "Enter read-only plan mode and prepare an implementation plan before coding",
+    description: "Enter planning mode with non-mutating guardrails before implementing a non-trivial task.",
+    promptSnippet: "EnterPlanMode starts file-backed planning before coding",
     promptGuidelines: [
-      "For complex or ambiguous work, use EnterPlanMode before editing code.",
-      "In plan mode, write the evolving plan to the plan file and call ExitPlanMode when ready for user approval.",
+      "Use EnterPlanMode before implementation when a task needs planning or user approval.",
+      "After EnterPlanMode succeeds, write the plan file and do not implement until ExitPlanMode approval.",
     ],
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
@@ -437,15 +278,15 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
       if (ctx.hasUI) {
         const approved = await ctx.ui.confirm(
           "Enter Plan Mode?",
-          "The agent wants to switch to read-only planning before implementation. Approve?",
+          "The agent wants to plan before implementing. Approve switching to plan mode?",
         );
         if (!approved) {
-          return { content: [{ type: "text", text: "User declined plan mode. Continue normally." }], details: { approved: false } };
+          return { content: [{ type: "text", text: "User declined EnterPlanMode." }], details: { approved: false } };
         }
       }
-      const planPath = activatePlanMode(ctx);
+      const planPath = enterPlanMode(ctx);
       return {
-        content: [{ type: "text", text: `Plan mode activated. Write the plan to ${planPath}, then call ExitPlanMode for approval.` }],
+        content: [{ type: "text", text: `EnterPlanMode activated. Plan file: ${planPath}. Call ExitPlanMode when the plan is complete.` }],
         details: { approved: true, planFilePath: planPath },
       };
     },
@@ -455,11 +296,11 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     name: "ExitPlanMode",
     label: "Exit Plan Mode",
     description: "Present the current plan for user approval. Use only when the plan file is ready for review.",
-    promptSnippet: "Present the completed plan for approval before implementation",
+    promptSnippet: "ExitPlanMode presents the plan file for approval before implementation",
     promptGuidelines: [
       "Only call ExitPlanMode after writing a complete plan file.",
-      "Do not ask for approval in plain text; use ExitPlanMode.",
-      "If the user rejects the plan, stay in plan mode and revise the plan file.",
+      "Do not ask for plan approval in plain text; call ExitPlanMode.",
+      "If ExitPlanMode returns rejection feedback, stay in plan mode and revise the plan file.",
     ],
     parameters: Type.Object({}),
     async execute(_toolCallId, _params, _signal, _onUpdate, ctx) {
@@ -467,105 +308,68 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
         return { content: [{ type: "text", text: "Not currently in plan mode." }], details: { active: false } };
       }
       const text = await runApprovalLoop(ctx);
-      return { content: [{ type: "text", text }], details: { approved: state.lastTransition === "approved", planFilePath: state.planFilePath } };
+      return { content: [{ type: "text", text }], details: { active: state.active, planFilePath: state.planFilePath } };
     },
   });
 
-  pi.on("tool_call", async (event) => {
+  pi.on("tool_call", async (event, ctx) => {
     if (!state.active) return;
 
+    if (isToolCallEventType("write", event) || isToolCallEventType("edit", event)) {
+      return guardPlanFileWrite(event, ctx);
+    }
+
     if (event.toolName === "bash") {
-      const command = typeof event.input.command === "string" ? event.input.command : "";
-      if (!isSafeReadOnlyCommand(command)) {
-        return { block: true, reason: `Plan mode blocked non-read-only bash command: ${command}` };
+      return { block: true, reason: "Plan mode disables bash instead of pretending a shell allowlist is a sandbox." };
+    }
+
+    if (WRITE_TOOL_NAMES.has(event.toolName)) {
+      return { block: true, reason: `Plan mode blocks mutating tool ${event.toolName}.` };
+    }
+
+    if (event.toolName === "jj_context") {
+      (event.input as { fresh?: unknown }).fresh = false;
+      return;
+    }
+
+    if (event.toolName === "jj_todo") {
+      const input = event.input as JjTodoInput;
+      input.fresh = false;
+      if ((input.action === "create" || input.action === "update") && input.dryRun !== true) {
+        return { block: true, reason: "Plan mode blocks mutating jj_todo actions; use dryRun: true to preview." };
       }
       return;
     }
 
-    if (isToolCallEventType("write", event) || isToolCallEventType("edit", event)) {
-      if (samePath(event.input.path, state.planFilePath)) return;
-      return { block: true, reason: `Plan mode allows writes only to the plan file: ${state.planFilePath}` };
-    }
+    if (PLAN_TOOL_NAMES.includes(event.toolName)) return;
 
-    if (WRITE_TOOLS.has(event.toolName)) {
-      return { block: true, reason: `Plan mode blocks mutating tool ${event.toolName}.` };
-    }
+    return { block: true, reason: `Plan mode blocks tool "${event.toolName}" because it is not explicitly allowed.` };
+  });
 
-    if (event.toolName === "jj_todo") {
-      const input = event.input as { action?: unknown; dryRun?: unknown };
-      const action = input.action;
-      if ((action === "create" || action === "update") && input.dryRun !== true) {
-        return { block: true, reason: "Plan mode blocks mutating jj_todo actions; use dryRun: true to preview." };
-      }
-    }
-
-    if (ALWAYS_SAFE_TOOLS.has(event.toolName)) return;
+  pi.on("context", async (event) => {
+    if (state.active) return;
+    return {
+      messages: event.messages.filter(
+        (message) => !isCustomContextMessage(message, PLAN_CONTEXT_TYPE) && !isCustomContextMessage(message, LEGACY_APPROVED_CONTEXT_TYPE),
+      ),
+    };
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
-    if (state.active) {
-      const planPath = ensurePlan(ctx);
-      const existingPlan = readPlan(planPath);
-      const reentry = state.hasExitedPlanModeInSession;
-      if (reentry) {
-        state.hasExitedPlanModeInSession = false;
-        persistState();
-      }
-      return {
-        message: {
-          customType: "blazed-plan-mode-context",
-          content: buildPlanModeInstructions(planPath, existingPlan, reentry),
-          display: false,
-        },
-        systemPrompt: `${event.systemPrompt}\n\n[PLAN MODE] Read-only planning is active. Use the plan file and call ExitPlanMode for approval before implementation.`,
-      };
-    }
-
-    const planPath = state.lastApprovedPlanFilePath;
-    const plan = readPlan(planPath);
-    if (planPath && plan?.trim()) {
-      return {
-        message: {
-          customType: "blazed-approved-plan-context",
-          content: `[APPROVED PLAN]\nPlan file: ${planPath}\n\n${plan}\n\nIf this plan is relevant and not complete, continue following it.`,
-          display: false,
-        },
-      };
-    }
-  });
-
-  pi.on("turn_end", async (event, ctx) => {
-    if (!executionMode || todoItems.length === 0) return;
-    const count = markCompletedSteps(assistantText(event.message), todoItems);
-    if (count > 0) {
-      persistState();
-      updateUI(ctx);
-    }
-    if (todoItems.every((item) => item.completed)) {
-      executionMode = false;
-      persistState();
-      updateUI(ctx);
-      ctx.ui.notify("Approved plan complete.", "info");
-    }
+    if (!state.active) return;
+    const planPath = ensurePlan(ctx);
+    return {
+      message: {
+        customType: PLAN_CONTEXT_TYPE,
+        content: buildPlanModeInstructions(planPath, readPlan(planPath)),
+        display: false,
+      },
+      systemPrompt: `${event.systemPrompt}\n\n[PLAN MODE] Planning is active. Do not implement. Bash is disabled. Write only the plan file and call ExitPlanMode for approval.`,
+    };
   });
 
   pi.on("session_start", async (_event, ctx) => {
-    state = createInitialState();
-    executionMode = false;
-    todoItems = [];
-
-    for (const entry of ctx.sessionManager.getEntries().slice().reverse()) {
-      const candidate = entry as { type?: string; customType?: string; data?: Partial<PlanState> & { executionMode?: boolean; todoItems?: TodoItem[] } };
-      if (candidate.type === "custom" && candidate.customType === STATE_ENTRY && candidate.data) {
-        state = { ...state, ...candidate.data };
-        executionMode = candidate.data.executionMode ?? false;
-        todoItems = candidate.data.todoItems ?? [];
-        break;
-      }
-    }
-
-    if (pi.getFlag("plan") === true) activatePlanMode(ctx);
-    updateUI(ctx);
+    restoreState(ctx);
   });
 
   pi.on("session_shutdown", async (_event, ctx) => {

--- a/users/profiles/pi/extensions/plan-mode/index.ts
+++ b/users/profiles/pi/extensions/plan-mode/index.ts
@@ -1,4 +1,4 @@
-import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@earendil-works/pi-coding-agent";
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
@@ -42,16 +42,30 @@ const PLAN_TOOL_NAMES = [
 
 const WRITE_TOOL_NAMES = new Set(["write", "edit"]);
 
+const APPROVE_HERE = "Approve — implement here";
+const APPROVE_FRESH = "Approve — fresh session";
+const EDIT_PLAN = "Edit plan";
+const REJECT_REVISE = "Reject — revise";
+const CANCEL_APPROVAL = "Cancel";
+
 type StoredStateEntry = { type?: string; customType?: string; data?: Partial<PlanModeState> };
 type PathInput = { path?: unknown };
 type JjTodoInput = { action?: unknown; dryRun?: unknown; fresh?: unknown };
 
 function buildPlanningPrompt(task: string, planPath: string): string {
-  return `Enter plan mode for this task:\n\n${task}\n\nPlan file: ${planPath}\n\nExplore with non-mutating tools, keep the plan file updated, and call ExitPlanMode only when the plan is ready for approval.`;
+  return `Enter Pi Plan Mode for this task:\n\n${task}\n\nPlan file: ${planPath}\n\nStart by exploring the codebase with non-mutating tools. Keep the plan file self-contained and updated as you learn. Ask the user only for preferences or tradeoff decisions that cannot be discovered from the repository. Do not implement. When the plan is ready, call ExitPlanMode.`;
 }
 
 function buildPlanModeInstructions(planPath: string, existingPlan: string | null): string {
-  return `[PLAN MODE ACTIVE]\nYou are planning only. Do not implement until ExitPlanMode approval completes.\n\nPlan file: ${planPath}\n${existingPlan?.trim() ? `\nCurrent plan content:\n${existingPlan.trim()}\n` : ""}\nRules:\n- Explore first with read-only tools.\n- Write or edit only the plan file above.\n- Bash is disabled in plan mode.\n- Ask the user only for preferences or tradeoffs that cannot be discovered.\n- Keep the plan self-contained and call ExitPlanMode when ready.`;
+  const currentPlan = existingPlan?.trim()
+    ? `\nCurrent plan file content:\n\n${existingPlan.trim()}\n`
+    : "\nThe plan file is empty. Create a self-contained plan before requesting approval.\n";
+
+  return `[PLAN MODE ACTIVE]\nYou are in Pi Plan Mode, a conversation mode for collaborative planning. It is a tool/UI guard, not an OS sandbox. Bash is disabled; do not ask for bash access or claim shell sandboxing.\n\nStrict boundary:\n- Plan only. Do not implement, refactor, run mutating commands, or edit non-plan files.\n- The only writable target is the plan file: ${planPath}\n- Approval must happen through the ExitPlanMode tool. Never ask for approval in plain text.\n\nWorkflow:\n1. Explore first with non-mutating tools: read, grep, find, ls, web/code search, jj_context, and jj_todo dry-run previews.\n2. Ask the user only for preference/tradeoff decisions that exploration cannot answer.\n3. Keep updating the plan file as the source of truth. The plan must be self-contained enough for a fresh implementation session.\n4. Include goal, relevant files, ordered implementation steps, validation, risks, and rollback notes where useful.\n5. When ready, call ExitPlanMode and let the approval flow decide whether to implement here, start fresh, revise, or cancel.\n\nTool notes:\n- write/edit may target only the plan file above. If you mention the basename, it will be redirected to that exact file.\n- jj_context is forced to fresh=false in plan mode.\n- jj_todo create/update is allowed only with dryRun: true and fresh=false.\n- The normal todo tool is not a substitute for the plan file.\n${currentPlan}`;
+}
+
+function buildImplementationPrompt(plan: string, planPath: string): string {
+  return `Implement this approved plan step by step.\n\nPlan file: ${planPath}\n\n${plan.trim()}\n\nPlan mode has been deactivated and normal tools are available again. If progress tracking would help, initialize and maintain the normal todo tool. Do not rely on plan-mode widgets or [DONE:n] markers for extension state. If reality differs from the plan, pause and explain the required adjustment before making broad changes.`;
 }
 
 function buildPlanReview(plan: string, planPath: string): string {
@@ -182,11 +196,91 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     input.path = targetPath;
   }
 
+  async function performFreshHandoff(ctx: ExtensionCommandContext): Promise<void> {
+    const planPath = state.pendingFreshImplementation?.planFilePath ?? state.lastApprovedPlanFilePath;
+    if (!planPath) {
+      ctx.ui.notify("No approved plan is queued for a fresh session.", "warning");
+      return;
+    }
+
+    const plan = readPlan(planPath) ?? "";
+    if (!plan.trim()) {
+      ctx.ui.notify(`Approved plan is empty or missing: ${planPath}`, "error");
+      return;
+    }
+
+    if (state.active) exitPlanMode(ctx, "approved");
+    state.pendingFreshImplementation = null;
+    state.lastApprovedPlanFilePath = planPath;
+    persistState();
+
+    const title = extractPlanTitle(plan);
+    const prompt = buildImplementationPrompt(plan, planPath);
+    const parentSession = ctx.sessionManager.getSessionFile();
+    const result = await ctx.newSession({
+      parentSession,
+      setup: async (sessionManager) => {
+        sessionManager.appendSessionInfo(title);
+      },
+      withSession: async (replacementCtx) => {
+        await replacementCtx.sendUserMessage(prompt);
+      },
+    });
+
+    if (result.cancelled) {
+      ctx.ui.notify("Fresh-session plan handoff was cancelled.", "warning");
+    }
+  }
+
   async function runApprovalLoop(ctx: ExtensionContext): Promise<string> {
     const planPath = ensurePlan(ctx);
     const plan = readPlan(planPath) ?? "";
     if (!plan.trim()) return `No plan found in ${planPath}. Write the plan file before calling ExitPlanMode.`;
-    return `Plan file is ready for approval: ${planPath}. Approval handoff will be handled by the plan-mode approval flow.`;
+    if (!ctx.hasUI) return "ExitPlanMode requires an interactive/RPC UI approval flow; no approval was granted.";
+
+    const title = extractPlanTitle(plan);
+    const choice = await ctx.ui.select(`Review plan: ${title}`, [
+      APPROVE_HERE,
+      APPROVE_FRESH,
+      EDIT_PLAN,
+      REJECT_REVISE,
+      CANCEL_APPROVAL,
+    ]);
+
+    if (choice === APPROVE_HERE) {
+      state.lastApprovedPlanFilePath = planPath;
+      state.pendingFreshImplementation = null;
+      pi.setSessionName(title);
+      exitPlanMode(ctx, "approved");
+      pi.sendUserMessage(buildImplementationPrompt(plan, planPath), { deliverAs: "followUp" });
+      return `Plan approved. Queued implementation in this session for ${planPath}.`;
+    }
+
+    if (choice === APPROVE_FRESH) {
+      state.lastApprovedPlanFilePath = planPath;
+      state.pendingFreshImplementation = { planFilePath: planPath, requestedAt: new Date().toISOString() };
+      exitPlanMode(ctx, "approved");
+      pi.sendUserMessage("/plan fresh", { deliverAs: "followUp" });
+      return `Plan approved. Queued a fresh-session handoff for ${planPath}.`;
+    }
+
+    if (choice === EDIT_PLAN) {
+      const edited = await ctx.ui.editor("Edit plan", plan);
+      if (typeof edited !== "string") return "Plan edit cancelled. Stay in plan mode and call ExitPlanMode when ready.";
+      writePlan(planPath, edited);
+      persistState();
+      return `Plan file updated: ${planPath}. Stay in plan mode, review the update, and call ExitPlanMode again when ready.`;
+    }
+
+    if (choice === REJECT_REVISE) {
+      const feedback = await ctx.ui.editor("Revision feedback for the agent", "");
+      const note = feedback?.trim()
+        ? `\n\nUser revision feedback:\n${feedback.trim()}`
+        : "\n\nNo specific feedback was provided.";
+      return `Plan was not approved. Stay in plan mode, revise the plan file, and call ExitPlanMode again.${note}`;
+    }
+
+    return "Plan approval cancelled. Stay in plan mode and call ExitPlanMode when the plan is ready.";
   }
 
   pi.registerFlag("plan", {
@@ -196,9 +290,14 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
   });
 
   pi.registerCommand("plan", {
-    description: "Plan before implementing. Usage: /plan <task>, /plan review|status|off|clear",
+    description: "Plan before implementing. Usage: /plan <task>, /plan review|status|off|clear|fresh",
     handler: async (args, ctx) => {
       const trimmed = args.trim();
+
+      if (trimmed === "fresh") {
+        await performFreshHandoff(ctx);
+        return;
+      }
 
       if (trimmed === "off") {
         exitPlanMode(ctx, "cancelled");

--- a/users/profiles/pi/extensions/plan-mode/utils.ts
+++ b/users/profiles/pi/extensions/plan-mode/utils.ts
@@ -1,20 +1,19 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { homedir } from "node:os";
-import { basename, join, normalize, resolve } from "node:path";
+import { basename, dirname, join, normalize, resolve } from "node:path";
 
-export interface PlanState {
-  active: boolean;
-  planSlug: string | null;
-  planFilePath: string | null;
-  lastTransition: "entered" | "approved" | "cancelled" | null;
-  lastApprovedPlanFilePath: string | null;
-  hasExitedPlanModeInSession: boolean;
+export interface PendingFreshImplementation {
+  planFilePath: string;
+  requestedAt: string;
 }
 
-export interface TodoItem {
-  step: number;
-  text: string;
-  completed: boolean;
+export interface PlanModeState {
+  active: boolean;
+  planFilePath: string | null;
+  planSlug: string | null;
+  lastApprovedPlanFilePath: string | null;
+  previousToolNames: string[] | null;
+  pendingFreshImplementation: PendingFreshImplementation | null;
 }
 
 const ADJECTIVES = [
@@ -47,89 +46,85 @@ const NOUNS = [
   "wave",
 ];
 
-const MUTATING_PATTERNS = [
-  /\brm\b/i,
-  /\brmdir\b/i,
-  /\bmv\b/i,
-  /\bcp\b/i,
-  /\bmkdir\b/i,
-  /\btouch\b/i,
-  /\bchmod\b/i,
-  /\bchown\b/i,
-  /\bchgrp\b/i,
-  /\bln\b/i,
-  /\btee\b/i,
-  /\btruncate\b/i,
-  /\bdd\b/i,
-  /\bshred\b/i,
-  /\b(bash|sh|zsh|fish|nu|python|python3|node|ruby|perl)\s+-c\b/i,
-  /\bnpm\s+(install|uninstall|update|ci|link|publish)\b/i,
-  /\byarn\s+(add|remove|install|publish)\b/i,
-  /\bpnpm\s+(add|remove|install|publish)\b/i,
-  /\bpip\s+(install|uninstall)\b/i,
-  /\bnix\s+(build|develop|flake\s+update|run|shell|profile|collect-garbage)\b/i,
-  /\bnh\s+(os|home)\s+switch\b/i,
-  /\bapt(-get)?\s+(install|remove|purge|update|upgrade)\b/i,
-  /\bbrew\s+(install|uninstall|upgrade)\b/i,
-  /\bgit\s+(add|commit|push|pull|merge|rebase|reset|checkout|switch|branch\s+-[dD]|stash|cherry-pick|revert|tag|init|clone)\b/i,
-  /\bjj\s+(new|describe|desc|commit|bookmark|git\s+push|git\s+fetch|rebase|squash|split|abandon|restore|undo|operation\s+restore)\b/i,
-  /\bsudo\b/i,
-  /\bsu\b/i,
-  /\bkill\b/i,
-  /\bpkill\b/i,
-  /\bkillall\b/i,
-  /\breboot\b/i,
-  /\bshutdown\b/i,
-  /\bsystemctl\s+(start|stop|restart|enable|disable)\b/i,
-  /\bservice\s+\S+\s+(start|stop|restart)\b/i,
-];
-
-
 export const DEFAULT_PLAN_ROOT = join(homedir(), ".pi", "agent", "plans");
 
-export function createInitialState(): PlanState {
+export function createInitialState(): PlanModeState {
   return {
     active: false,
-    planSlug: null,
     planFilePath: null,
-    lastTransition: null,
+    planSlug: null,
     lastApprovedPlanFilePath: null,
-    hasExitedPlanModeInSession: false,
+    previousToolNames: null,
+    pendingFreshImplementation: null,
+  };
+}
+
+export function sanitizePlanModeState(candidate: Partial<PlanModeState> | null | undefined): PlanModeState {
+  const initial = createInitialState();
+  if (!candidate || typeof candidate !== "object") return initial;
+
+  return {
+    active: candidate.active === true,
+    planFilePath: typeof candidate.planFilePath === "string" ? candidate.planFilePath : null,
+    planSlug: typeof candidate.planSlug === "string" ? candidate.planSlug : null,
+    lastApprovedPlanFilePath:
+      typeof candidate.lastApprovedPlanFilePath === "string" ? candidate.lastApprovedPlanFilePath : null,
+    previousToolNames: Array.isArray(candidate.previousToolNames)
+      ? candidate.previousToolNames.filter((name): name is string => typeof name === "string")
+      : null,
+    pendingFreshImplementation: sanitizePendingFreshImplementation(candidate.pendingFreshImplementation),
+  };
+}
+
+function sanitizePendingFreshImplementation(candidate: unknown): PendingFreshImplementation | null {
+  if (!candidate || typeof candidate !== "object") return null;
+  const value = candidate as Partial<PendingFreshImplementation>;
+  if (typeof value.planFilePath !== "string") return null;
+  return {
+    planFilePath: value.planFilePath,
+    requestedAt: typeof value.requestedAt === "string" ? value.requestedAt : new Date(0).toISOString(),
   };
 }
 
 export function slugify(value: string): string {
-  return value
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "")
-    .slice(0, 48) || "workspace";
+  return (
+    value
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 48) || "workspace"
+  );
 }
 
-export function generateSlug(random: () => number = Math.random): string {
-  const adj = ADJECTIVES[Math.floor(random() * ADJECTIVES.length)];
-  const noun = NOUNS[Math.floor(random() * NOUNS.length)];
+function generateSlug(random: () => number = Math.random): string {
+  const adj = ADJECTIVES[Math.floor(random() * ADJECTIVES.length)] ?? "clear";
+  const noun = NOUNS[Math.floor(random() * NOUNS.length)] ?? "path";
   return `${adj}-${noun}`;
 }
 
-export function ensurePlanDir(cwd: string, root = DEFAULT_PLAN_ROOT): string {
+function ensurePlanDir(cwd: string, root = DEFAULT_PLAN_ROOT): string {
   const dir = join(root, slugify(basename(cwd) || cwd));
   mkdirSync(dir, { recursive: true });
   return dir;
 }
 
-export function generateUniquePlanPath(cwd: string): { slug: string; path: string } {
-  const dir = ensurePlanDir(cwd);
+export function generateUniquePlanPath(
+  cwd: string,
+  root = DEFAULT_PLAN_ROOT,
+  random: () => number = Math.random,
+): { slug: string; path: string } {
+  const dir = ensurePlanDir(cwd, root);
   for (let i = 0; i < 10; i++) {
-    const slug = generateSlug();
+    const slug = generateSlug(random);
     const path = join(dir, `${slug}.md`);
     if (!existsSync(path)) return { slug, path };
   }
-  const slug = `${generateSlug()}-${Date.now()}`;
+
+  const slug = `${generateSlug(random)}-${Date.now()}`;
   return { slug, path: join(dir, `${slug}.md`) };
 }
 
-export function readPlan(path: string | null): string | null {
+export function readPlan(path: string | null | undefined): string | null {
   if (!path) return null;
   try {
     return readFileSync(path, "utf-8");
@@ -139,120 +134,77 @@ export function readPlan(path: string | null): string | null {
 }
 
 export function writePlan(path: string, content: string): void {
-  mkdirSync(resolve(path, ".."), { recursive: true });
+  mkdirSync(dirname(path), { recursive: true });
   writeFileSync(path, content, "utf-8");
 }
 
-export function samePath(a: string | undefined, b: string | null): boolean {
-  if (!a || !b) return false;
-  return normalize(resolve(a)) === normalize(resolve(b));
+export function normalizePlanTitle(title: string | null | undefined): string {
+  const normalized = (title ?? "")
+    .replace(/^#+\s*/, "")
+    .replace(/^Plan:\s*/i, "")
+    .replace(/[\r\n\t]+/g, " ")
+    .replace(/[`*_#[\]()]/g, "")
+    .replace(/\s+/g, " ")
+    .trim();
+
+  return (normalized || "Approved plan").slice(0, 80);
 }
 
-export function isSafeReadOnlyCommand(command: string): boolean {
-  const trimmed = command.trim();
-  if (!trimmed) return false;
+export function extractPlanTitle(content: string | null | undefined): string {
+  if (!content) return "Approved plan";
+  const explicitPlanTitle = content.match(/^#\s+Plan:\s*(.+)$/im)?.[1];
+  if (explicitPlanTitle) return normalizePlanTitle(explicitPlanTitle);
 
-  // Shell parsing is a losing game for an extension. Use a conservative
-  // blacklist for high-confidence mutations, and otherwise rely on the plan-mode
-  // system prompt plus write/edit tool gating. This avoids blocking normal
-  // read-only discovery pipelines (`find | sed | head`, `pi --help`, etc.).
-  if (/`|\$\(/.test(trimmed)) return false;
-  if (hasUnsafeRedirection(trimmed)) return false;
+  const firstHeading = content.match(/^#\s+(.+)$/m)?.[1];
+  if (firstHeading) return normalizePlanTitle(firstHeading);
 
-  const unquoted = stripQuotedStrings(trimmed);
-  return !MUTATING_PATTERNS.some((pattern) => pattern.test(unquoted));
+  const firstLine = content
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .find(Boolean);
+  return normalizePlanTitle(firstLine);
 }
 
-function hasUnsafeRedirection(command: string): boolean {
-  let quote: "'" | '"' | null = null;
+export function resolvePlanTargetPath(
+  targetPath: string | null | undefined,
+  cwd: string,
+  planFilePath: string | null | undefined,
+): string | null {
+  if (!targetPath || !planFilePath) return null;
+  const cleanedTarget = stripPathPrefix(targetPath);
+  const normalizedPlanPath = normalizeAbsolutePath(planFilePath);
 
-  for (let i = 0; i < command.length; i++) {
-    const char = command[i];
-
-    if (quote) {
-      if (char === quote) quote = null;
-      continue;
-    }
-
-    if (char === "'" || char === '"') {
-      quote = char;
-      continue;
-    }
-
-    if (char !== ">") continue;
-
-    const prefix = command.slice(Math.max(0, i - 2), i).trim();
-    const suffix = command.slice(i + 1).trimStart();
-    // Redirecting output to /dev/null is read-only noise suppression.
-    // This covers `>/dev/null`, `1>/dev/null`, `2>/dev/null`, and `2>&1`.
-    if (suffix.startsWith("/dev/null")) continue;
-    if ((prefix === "2" || prefix === "1") && suffix.startsWith("&1")) continue;
-
-    return true;
-  }
-
-  return false;
+  if (basename(cleanedTarget) === basename(normalizedPlanPath)) return normalizedPlanPath;
+  return normalizeAbsolutePath(resolve(cwd, cleanedTarget));
 }
 
-function stripQuotedStrings(command: string): string {
-  let output = "";
-  let quote: "'" | '"' | null = null;
-
-  for (const char of command) {
-    if (quote) {
-      if (char === quote) quote = null;
-      continue;
-    }
-
-    if (char === "'" || char === '"') {
-      quote = char;
-      output += " ";
-      continue;
-    }
-
-    output += char;
-  }
-
-  return output;
+export function isPlanFileTarget(
+  targetPath: string | null | undefined,
+  cwd: string,
+  planFilePath: string | null | undefined,
+): boolean {
+  if (!planFilePath) return false;
+  return resolvePlanTargetPath(targetPath, cwd, planFilePath) === normalizeAbsolutePath(planFilePath);
 }
 
-export function extractPlanTitle(content: string): string {
-  const title = content.match(/^#\s+Plan:\s*(.+)$/im)?.[1]?.trim();
-  return title || "Approved plan";
+export function buildPlanFileSummary(plan: string | null | undefined, planFilePath: string | null | undefined): string {
+  if (!planFilePath) return "Plan file: none";
+  const content = plan ?? "";
+  const trimmed = content.trim();
+  const lineCount = trimmed ? content.split(/\r?\n/).length : 0;
+
+  return [
+    `Plan file: ${planFilePath}`,
+    `Title: ${extractPlanTitle(content)}`,
+    `Status: ${trimmed ? "present" : "empty or missing"}`,
+    `Size: ${content.length} chars, ${lineCount} lines`,
+  ].join("\n");
 }
 
-export function extractTodoItems(content: string): TodoItem[] {
-  const items: TodoItem[] = [];
-  const taskLines = content.match(/^\s*- \[ \]\s+(.+)$/gim) ?? [];
-  for (const line of taskLines) {
-    const text = line.replace(/^\s*- \[ \]\s+/, "").trim();
-    if (text.length > 3) items.push({ step: items.length + 1, text: truncate(text), completed: false });
-  }
-
-  if (items.length > 0) return items;
-
-  const numbered = content.match(/^\s*\d+[.)]\s+(.+)$/gm) ?? [];
-  for (const line of numbered) {
-    const text = line.replace(/^\s*\d+[.)]\s+/, "").trim();
-    if (text.length > 3) items.push({ step: items.length + 1, text: truncate(text), completed: false });
-  }
-  return items;
+function stripPathPrefix(path: string): string {
+  return path.startsWith("@") ? path.slice(1) : path;
 }
 
-export function markCompletedSteps(text: string, items: TodoItem[]): number {
-  let count = 0;
-  for (const match of text.matchAll(/\[DONE:(\d+)\]/gi)) {
-    const step = Number(match[1]);
-    const item = items.find((candidate) => candidate.step === step);
-    if (item && !item.completed) {
-      item.completed = true;
-      count++;
-    }
-  }
-  return count;
-}
-
-function truncate(text: string): string {
-  const cleaned = text.replace(/`([^`]+)`/g, "$1").replace(/\s+/g, " ").trim();
-  return cleaned.length > 90 ? `${cleaned.slice(0, 87)}...` : cleaned;
+function normalizeAbsolutePath(path: string): string {
+  return normalize(resolve(path));
 }

--- a/users/profiles/pi/extensions/plan-mode/utils.ts
+++ b/users/profiles/pi/extensions/plan-mode/utils.ts
@@ -1,0 +1,258 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { basename, join, normalize, resolve } from "node:path";
+
+export interface PlanState {
+  active: boolean;
+  planSlug: string | null;
+  planFilePath: string | null;
+  lastTransition: "entered" | "approved" | "cancelled" | null;
+  lastApprovedPlanFilePath: string | null;
+  hasExitedPlanModeInSession: boolean;
+}
+
+export interface TodoItem {
+  step: number;
+  text: string;
+  completed: boolean;
+}
+
+const ADJECTIVES = [
+  "bold",
+  "calm",
+  "clear",
+  "deep",
+  "fine",
+  "keen",
+  "lean",
+  "safe",
+  "sharp",
+  "steady",
+  "tidy",
+  "wise",
+];
+
+const NOUNS = [
+  "bear",
+  "bird",
+  "bolt",
+  "core",
+  "dawn",
+  "field",
+  "forge",
+  "harbor",
+  "map",
+  "path",
+  "root",
+  "wave",
+];
+
+const MUTATING_PATTERNS = [
+  /\brm\b/i,
+  /\brmdir\b/i,
+  /\bmv\b/i,
+  /\bcp\b/i,
+  /\bmkdir\b/i,
+  /\btouch\b/i,
+  /\bchmod\b/i,
+  /\bchown\b/i,
+  /\bchgrp\b/i,
+  /\bln\b/i,
+  /\btee\b/i,
+  /\btruncate\b/i,
+  /\bdd\b/i,
+  /\bshred\b/i,
+  /\b(bash|sh|zsh|fish|nu|python|python3|node|ruby|perl)\s+-c\b/i,
+  /\bnpm\s+(install|uninstall|update|ci|link|publish)\b/i,
+  /\byarn\s+(add|remove|install|publish)\b/i,
+  /\bpnpm\s+(add|remove|install|publish)\b/i,
+  /\bpip\s+(install|uninstall)\b/i,
+  /\bnix\s+(build|develop|flake\s+update|run|shell|profile|collect-garbage)\b/i,
+  /\bnh\s+(os|home)\s+switch\b/i,
+  /\bapt(-get)?\s+(install|remove|purge|update|upgrade)\b/i,
+  /\bbrew\s+(install|uninstall|upgrade)\b/i,
+  /\bgit\s+(add|commit|push|pull|merge|rebase|reset|checkout|switch|branch\s+-[dD]|stash|cherry-pick|revert|tag|init|clone)\b/i,
+  /\bjj\s+(new|describe|desc|commit|bookmark|git\s+push|git\s+fetch|rebase|squash|split|abandon|restore|undo|operation\s+restore)\b/i,
+  /\bsudo\b/i,
+  /\bsu\b/i,
+  /\bkill\b/i,
+  /\bpkill\b/i,
+  /\bkillall\b/i,
+  /\breboot\b/i,
+  /\bshutdown\b/i,
+  /\bsystemctl\s+(start|stop|restart|enable|disable)\b/i,
+  /\bservice\s+\S+\s+(start|stop|restart)\b/i,
+];
+
+
+export const DEFAULT_PLAN_ROOT = join(homedir(), ".pi", "agent", "plans");
+
+export function createInitialState(): PlanState {
+  return {
+    active: false,
+    planSlug: null,
+    planFilePath: null,
+    lastTransition: null,
+    lastApprovedPlanFilePath: null,
+    hasExitedPlanModeInSession: false,
+  };
+}
+
+export function slugify(value: string): string {
+  return value
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 48) || "workspace";
+}
+
+export function generateSlug(random: () => number = Math.random): string {
+  const adj = ADJECTIVES[Math.floor(random() * ADJECTIVES.length)];
+  const noun = NOUNS[Math.floor(random() * NOUNS.length)];
+  return `${adj}-${noun}`;
+}
+
+export function ensurePlanDir(cwd: string, root = DEFAULT_PLAN_ROOT): string {
+  const dir = join(root, slugify(basename(cwd) || cwd));
+  mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+export function generateUniquePlanPath(cwd: string): { slug: string; path: string } {
+  const dir = ensurePlanDir(cwd);
+  for (let i = 0; i < 10; i++) {
+    const slug = generateSlug();
+    const path = join(dir, `${slug}.md`);
+    if (!existsSync(path)) return { slug, path };
+  }
+  const slug = `${generateSlug()}-${Date.now()}`;
+  return { slug, path: join(dir, `${slug}.md`) };
+}
+
+export function readPlan(path: string | null): string | null {
+  if (!path) return null;
+  try {
+    return readFileSync(path, "utf-8");
+  } catch {
+    return null;
+  }
+}
+
+export function writePlan(path: string, content: string): void {
+  mkdirSync(resolve(path, ".."), { recursive: true });
+  writeFileSync(path, content, "utf-8");
+}
+
+export function samePath(a: string | undefined, b: string | null): boolean {
+  if (!a || !b) return false;
+  return normalize(resolve(a)) === normalize(resolve(b));
+}
+
+export function isSafeReadOnlyCommand(command: string): boolean {
+  const trimmed = command.trim();
+  if (!trimmed) return false;
+
+  // Shell parsing is a losing game for an extension. Use a conservative
+  // blacklist for high-confidence mutations, and otherwise rely on the plan-mode
+  // system prompt plus write/edit tool gating. This avoids blocking normal
+  // read-only discovery pipelines (`find | sed | head`, `pi --help`, etc.).
+  if (/`|\$\(/.test(trimmed)) return false;
+  if (hasUnsafeRedirection(trimmed)) return false;
+
+  const unquoted = stripQuotedStrings(trimmed);
+  return !MUTATING_PATTERNS.some((pattern) => pattern.test(unquoted));
+}
+
+function hasUnsafeRedirection(command: string): boolean {
+  let quote: "'" | '"' | null = null;
+
+  for (let i = 0; i < command.length; i++) {
+    const char = command[i];
+
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      continue;
+    }
+
+    if (char !== ">") continue;
+
+    const prefix = command.slice(Math.max(0, i - 2), i).trim();
+    const suffix = command.slice(i + 1).trimStart();
+    // Redirecting output to /dev/null is read-only noise suppression.
+    // This covers `>/dev/null`, `1>/dev/null`, `2>/dev/null`, and `2>&1`.
+    if (suffix.startsWith("/dev/null")) continue;
+    if ((prefix === "2" || prefix === "1") && suffix.startsWith("&1")) continue;
+
+    return true;
+  }
+
+  return false;
+}
+
+function stripQuotedStrings(command: string): string {
+  let output = "";
+  let quote: "'" | '"' | null = null;
+
+  for (const char of command) {
+    if (quote) {
+      if (char === quote) quote = null;
+      continue;
+    }
+
+    if (char === "'" || char === '"') {
+      quote = char;
+      output += " ";
+      continue;
+    }
+
+    output += char;
+  }
+
+  return output;
+}
+
+export function extractPlanTitle(content: string): string {
+  const title = content.match(/^#\s+Plan:\s*(.+)$/im)?.[1]?.trim();
+  return title || "Approved plan";
+}
+
+export function extractTodoItems(content: string): TodoItem[] {
+  const items: TodoItem[] = [];
+  const taskLines = content.match(/^\s*- \[ \]\s+(.+)$/gim) ?? [];
+  for (const line of taskLines) {
+    const text = line.replace(/^\s*- \[ \]\s+/, "").trim();
+    if (text.length > 3) items.push({ step: items.length + 1, text: truncate(text), completed: false });
+  }
+
+  if (items.length > 0) return items;
+
+  const numbered = content.match(/^\s*\d+[.)]\s+(.+)$/gm) ?? [];
+  for (const line of numbered) {
+    const text = line.replace(/^\s*\d+[.)]\s+/, "").trim();
+    if (text.length > 3) items.push({ step: items.length + 1, text: truncate(text), completed: false });
+  }
+  return items;
+}
+
+export function markCompletedSteps(text: string, items: TodoItem[]): number {
+  let count = 0;
+  for (const match of text.matchAll(/\[DONE:(\d+)\]/gi)) {
+    const step = Number(match[1]);
+    const item = items.find((candidate) => candidate.step === step);
+    if (item && !item.completed) {
+      item.completed = true;
+      count++;
+    }
+  }
+  return count;
+}
+
+function truncate(text: string): string {
+  const cleaned = text.replace(/`([^`]+)`/g, "$1").replace(/\s+/g, " ").trim();
+  return cleaned.length > 90 ? `${cleaned.slice(0, 87)}...` : cleaned;
+}

--- a/users/profiles/pi/skills/jj-todo/SKILL.md
+++ b/users/profiles/pi/skills/jj-todo/SKILL.md
@@ -413,6 +413,8 @@ Use the `jj_todo` Pi tool for routine mechanical operations when it is available
 - `action: "update"` — safely change a revision's `[task:*]` flag
 - `action: "check"` — summarize task counts, conflicts, and suspicious state like multiple WIP tasks
 
+For `action: "create"` and `action: "update"`, pass `dryRun: true` to preview the exact `jj` command and resulting task metadata without mutating JJ history. Dry-run previews default to `fresh: false` / `--ignore-working-copy`; set `fresh: true` only when you intentionally want JJ to snapshot before the preview. Plan mode permits only these `dryRun: true` create/update previews, not real mutations.
+
 The tool is for compact, structured TODO mechanics only. Keep planning, task DAG design,
 dependency judgment, and done/not-done decisions in this skill's workflow. Use `jj` via
 `bash` for full graph inspection, rebases, splits, merges, and unusual mutations.


### PR DESCRIPTION
## Summary
- add a local Pi plan-mode extension with file-backed planning, approval flow, and fresh-session implementation handoff
- add `jj_todo` dry-run previews for create/update actions without mutating JJ history
- allow plan mode to call `jj_todo` create/update only with `dryRun: true`

## Validation
- `PI_OFFLINE=1 pi --no-extensions -e users/profiles/pi/extensions/plan-mode --list-models`
- `PI_OFFLINE=1 pi --no-extensions -e users/profiles/pi/extensions/jj-todo --list-models`
- `node --check users/profiles/pi/extensions/plan-mode/index.ts`
- `node --check users/profiles/pi/extensions/plan-mode/utils.ts`
- `node --check users/profiles/pi/extensions/jj-todo/index.ts`