### PR TITLE
feat(pi): dynamic-workflows extension + scrollable plan review + async footer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 .devenv
 .direnv
 result
+.pi/workflows/runs/
 nix-repl.nix
 wifi-networks
 cached-iso.iso

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -127,24 +127,45 @@ let
     };
   };
 
-  # pi-web-access config (~/.pi/web-search.json — directly under ~/.pi, NOT
-  # ~/.pi/agent). Non-secret settings only; the Exa API key is supplied via env
-  # (agenix → jail), which the package treats as overriding this file, so the
-  # secret never lands in the Nix store.
   webSearch = {
     provider = "exa";
     allowBrowserCookies = false; # keep it pure-HTTP; never spawn Chromium
-    # Autonomous agent: skip the interactive "curator" review UI and its extra
-    # summarization step. "none" returns raw results straight to the agent (which
-    # summarizes them itself). This also avoids needing a Gemini/Anthropic key for
-    # searchModel/summaryModel — so those are deliberately left unset, keeping Exa
-    # the only required key.
     workflow = "none";
+  };
+
+  acornVendor =
+    let
+      src = pkgs.fetchurl {
+        url = "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz";
+        hash = "sha256-i63KCtwCuJgHx/mlMMLNULQLqrFK3nr1O3BPGYqr4R4=";
+      };
+    in
+    pkgs.runCommand "acorn-8.16.0-vendor" { } ''
+      tar -xzf ${src} package/dist/acorn.mjs package/LICENSE
+      install -Dm444 package/dist/acorn.mjs $out/acorn.mjs
+      install -Dm444 package/LICENSE $out/ACORN-LICENSE
+    '';
+
+  piExtensions = pkgs.runCommand "pi-extensions" { } ''
+    cp -r ${./extensions}/. $out
+    chmod -R u+w $out
+    install -Dm444 ${acornVendor}/acorn.mjs $out/dynamic-workflows/vendor/acorn.mjs
+    install -Dm444 ${acornVendor}/ACORN-LICENSE $out/dynamic-workflows/vendor/ACORN-LICENSE
+  '';
+
+  piWithExa = pkgs.symlinkJoin {
+    name = "pi-with-exa";
+    paths = [ pi ];
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+    postBuild = ''
+      wrapProgram $out/bin/pi \
+        --run 'if [ -z "''${EXA_API_KEY:-}" ] && [ -r /run/agenix/exa-api-key ]; then export EXA_API_KEY="$(< /run/agenix/exa-api-key)"; fi'
+    '';
   };
 in
 {
   home.packages = [
-    pi
+    piWithExa
     agent-browser
   ];
 
@@ -153,8 +174,9 @@ in
     source = ./skills;
     recursive = true;
   };
+
   home.file.".pi/agent/extensions" = {
-    source = ./extensions;
+    source = piExtensions;
     recursive = true;
   };
 

--- a/users/profiles/pi/extensions/dynamic-workflows/index.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/index.ts
@@ -1,0 +1,61 @@
+import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import {
+  createWorkflowStorage,
+  createWorkflowTool,
+  initProfiler,
+  installAutoWorkflow,
+  installResultDelivery,
+  installTaskPanel,
+  installWorkflowEditor,
+  registerAllSavedWorkflows,
+  registerBuiltinWorkflows,
+  registerWorkflowCommands,
+  WorkflowManager,
+} from "./src/index.ts";
+
+export default function extension(pi: ExtensionAPI) {
+  // Single manager/storage shared by the workflow tool and the /workflows command,
+  // so background runs started by the tool are reachable from the command.
+  const cwd = process.cwd();
+  // Opt-in freeze diagnostics: `PI_WF_PROFILE=1 pi` logs event-loop stalls and
+  // slow sections to .pi/workflows/profile.log. No-op when unset.
+  initProfiler(cwd);
+  const storage = createWorkflowStorage(cwd);
+  const manager = new WorkflowManager({ cwd, loadSavedWorkflow: (name) => storage.load(name)?.script });
+
+  const workflowTool = createWorkflowTool({ cwd, manager, storage });
+  pi.registerTool(workflowTool);
+  registerWorkflowCommands(pi, manager, { storage, cwd });
+  registerBuiltinWorkflows(pi, { cwd });
+  registerAllSavedWorkflows(pi, cwd, storage);
+  // Deliver a background run's result into the conversation when it finishes.
+  installResultDelivery(pi, manager);
+  // Opt-in auto-workflow toggle (`/auto-workflow off|suggest|force`, default off).
+  // Returns a controller the workflows-mode input hook consults each submit.
+  const auto = installAutoWorkflow(pi);
+  // "Workflows mode": type `workflow(s)` to arm a forced workflow (animated),
+  // Backspace right after the word disarms it. Registers the `input` hook now;
+  // the editor itself is installed once the UI is available (session_start).
+  let editorInstalled = false;
+  let taskPanelInstalled = false;
+
+  pi.on("session_start", (_event: unknown, ctx: ExtensionContext) => {
+    const active = pi.getActiveTools();
+    if (!active.includes(workflowTool.name)) {
+      pi.setActiveTools([...active, workflowTool.name]);
+    }
+    // Tell the manager the session's main model so "explore" agents auto-tier
+    // down to a lighter same-family sibling (e.g. Claude → Haiku).
+    manager.setMainModel(ctx.model ? `${ctx.model.provider}/${ctx.model.id}` : undefined);
+    // Live "workflows running" panel below the input. Install once (like the
+    // editor) so we don't re-register the widget + manager listeners each session.
+    if (!taskPanelInstalled) {
+      installTaskPanel(pi, manager, ctx.ui, { storage, cwd });
+      taskPanelInstalled = true;
+    }
+    if (!editorInstalled) {
+      installWorkflowEditor(pi, ctx.ui, { auto });
+      editorInstalled = true;
+    }
+  });
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/adversarial-review.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/adversarial-review.ts
@@ -1,0 +1,73 @@
+/**
+ * Adversarial review mode for workflows.
+ * Agents cross-check each other's findings for higher quality results.
+ */
+
+export interface AdversarialReviewConfig {
+  /** Number of independent reviewers per finding. */
+  reviewerCount: number;
+  /** Whether to filter out findings that don't survive cross-checking. */
+  filterContested: boolean;
+  /** Minimum agreement threshold (0-1). */
+  agreementThreshold: number;
+}
+
+/**
+ * Generate an adversarial-review workflow. The script is static and reads its
+ * inputs from `args` (task/reviewers/threshold) — no string interpolation.
+ *
+ * Each finding is judged independently by N reviewers who are told to REFUTE it;
+ * a finding survives only when the share of reviewers calling it real meets the
+ * agreement threshold.
+ */
+export function generateAdversarialReviewWorkflow(): string {
+  return `export const meta = {
+  name: 'adversarial_review',
+  description: 'Adversarial review: findings cross-checked by independent skeptics',
+  phases: [
+    { title: 'Investigate' },
+    { title: 'Refute' },
+    { title: 'Consensus' },
+  ],
+}
+
+const task = (args && args.task) || ''
+const reviewers = (args && args.reviewers) || 2
+const threshold = (args && args.threshold) || 0.5
+
+phase('Investigate')
+const investigation = await agent(
+  'Investigate the following and list concrete, individually-checkable findings:\\n' + task,
+  { label: 'investigate', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'string' } } }, required: ['findings'] } }
+)
+const findings = investigation.findings || []
+
+phase('Refute')
+const judged = await parallel(findings.map((f, i) => () =>
+  parallel(Array.from({ length: reviewers }, (_, r) => () =>
+    agent(
+      'You are a skeptical reviewer. Try to REFUTE this finding for the task below. ' +
+      'Default to real=false when uncertain. Investigate with the available tools if needed.\\n\\n' +
+      'TASK: ' + task + '\\nFINDING: ' + f,
+      { label: 'refute ' + (i + 1) + '.' + (r + 1), schema: { type: 'object', properties: { real: { type: 'boolean' }, reason: { type: 'string' } }, required: ['real'] } }
+    )
+  )).then((votes) => {
+    const valid = votes.filter(Boolean)
+    const realCount = valid.filter((v) => v && v.real).length
+    const ratio = valid.length ? realCount / valid.length : 0
+    return { finding: f, realVotes: realCount, totalVotes: valid.length, survives: ratio >= threshold }
+  })
+))
+
+const survivors = judged.filter((j) => j && j.survives)
+
+phase('Consensus')
+const report = await agent(
+  'Write a final review report. Include ONLY the findings that survived adversarial review (listed below), ' +
+  'each with a short justification. Note how many were discarded.\\n\\n' +
+  'SURVIVING FINDINGS JSON:\\n' + JSON.stringify(survivors),
+  { label: 'consensus' }
+)
+
+return { total: findings.length, survivors, report }`;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/adversarial-review.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/adversarial-review.ts
@@ -40,7 +40,22 @@ const investigation = await agent(
   'Investigate the following and list concrete, individually-checkable findings:\\n' + task,
   { label: 'investigate', schema: { type: 'object', properties: { findings: { type: 'array', items: { type: 'string' } } }, required: ['findings'] } }
 )
-const findings = investigation.findings || []
+const findings = (investigation && investigation.findings) || []
+
+// Nothing concrete to review — return a clear, visible message instead of an
+// empty/thin report (which reads as "the command did nothing"). This also covers
+// a failed investigate agent (investigation === null).
+if (findings.length === 0) {
+  return {
+    total: 0,
+    survivors: [],
+    report:
+      'No checkable findings were produced, so there was nothing to adversarially review.\\n\\n' +
+      'Tip: give a concrete target the reviewers can investigate with their tools (bash/read/grep) — ' +
+      'e.g. a specific file or directory to audit, or a single factual claim. These agents have no web access.\\n\\n' +
+      'TASK: ' + task,
+  }
+}
 
 phase('Refute')
 const judged = await parallel(findings.map((f, i) => () =>

--- a/users/profiles/pi/extensions/dynamic-workflows/src/agent.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/agent.ts
@@ -1,0 +1,286 @@
+import { join } from "node:path";
+import type { AssistantMessage, Model, TextContent } from "@earendil-works/pi-ai";
+import {
+  AuthStorage,
+  type CreateAgentSessionOptions,
+  createAgentSession,
+  createCodingTools,
+  DefaultResourceLoader,
+  getAgentDir,
+  ModelRegistry,
+  SessionManager,
+  SettingsManager,
+  type ToolDefinition,
+} from "@earendil-works/pi-coding-agent";
+import type { Static, TSchema } from "typebox";
+import { profile } from "./profiler.ts";
+import { createStructuredOutputTool, type StructuredOutputCapture } from "./structured-output.ts";
+
+/**
+ * Shared resource loaders, one per (cwd, agentDir), reused across ALL subagents.
+ *
+ * Without this, createAgentSession() builds a fresh DefaultResourceLoader and
+ * reload()s it on EVERY subagent spawn — which re-discovers and jiti-compiles
+ * every user extension (a ~1.5s synchronous block per agent that froze the TUI),
+ * and would re-register this very extension (incl. the workflow tool) inside each
+ * subagent. Subagents don't need the user's extensions, so we load with
+ * `noExtensions: true` and share one reloaded instance per directory.
+ */
+const sharedLoaders = new Map<string, Promise<DefaultResourceLoader>>();
+function getSharedResourceLoader(cwd: string, agentDir: string): Promise<DefaultResourceLoader> {
+  const key = `${cwd}\u0000${agentDir}`;
+  let loader = sharedLoaders.get(key);
+  if (!loader) {
+    loader = (async () => {
+      const instance = new DefaultResourceLoader({
+        cwd,
+        agentDir,
+        settingsManager: SettingsManager.create(cwd, agentDir),
+        noExtensions: true,
+      });
+      await instance.reload();
+      return instance;
+    })();
+    sharedLoaders.set(key, loader);
+  }
+  return loader;
+}
+
+export interface WorkflowAgentOptions {
+  cwd?: string;
+  /** Extra tools available to the subagent in addition to the structured output tool. */
+  tools?: ToolDefinition[];
+  /** Override any createAgentSession option (model, authStorage, resourceLoader, etc.). */
+  session?: Partial<CreateAgentSessionOptions>;
+  /** Extra system guidance prepended to every subagent task. */
+  instructions?: string;
+}
+
+/**
+ * List the user's currently available models (those with auth configured) as
+ * `provider/modelId` specs. Used to tell the workflow author which models it may
+ * route agents to. Best-effort: returns [] if the registry can't be built.
+ */
+export function listAvailableModelSpecs(): string[] {
+  try {
+    const dir = getAgentDir();
+    const auth = AuthStorage.create(join(dir, "auth.json"));
+    const registry = ModelRegistry.create(auth, join(dir, "models.json"));
+    return registry.getAvailable().map((m) => `${m.provider}/${m.id}`);
+  } catch {
+    return [];
+  }
+}
+
+/** Real token/cost usage for a single subagent run, read from the SDK session. */
+export interface AgentUsage {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+  cost: number;
+}
+
+export interface AgentRunOptions<TSchemaDef extends TSchema | undefined = undefined> {
+  label?: string;
+  schema?: TSchemaDef;
+  tools?: ToolDefinition[];
+  instructions?: string;
+  signal?: AbortSignal;
+  /**
+   * Called once with this subagent's real usage, read from the session right
+   * before disposal. Fires on both the success and error paths so partial
+   * usage is never lost. `total === 0` means the provider reported no usage.
+   */
+  onUsage?: (usage: AgentUsage) => void;
+  /**
+   * Model spec for this subagent: either `provider/modelId` (unambiguous) or a
+   * bare `modelId`. When it can't be resolved, the session default is used and
+   * a warning is logged. When omitted, the session default applies.
+   */
+  model?: string;
+  /** Called with the resolved model id once known (for display/telemetry). */
+  onModelResolved?: (modelId: string) => void;
+  /** Run this agent in a different working directory (e.g. an isolated worktree). */
+  cwd?: string;
+}
+
+export type AgentRunResult<TSchemaDef extends TSchema | undefined> = TSchemaDef extends TSchema
+  ? Static<TSchemaDef>
+  : string;
+
+export class WorkflowAgent {
+  private readonly cwd: string;
+  private readonly baseTools: ToolDefinition[];
+  private readonly sessionOptions: Partial<CreateAgentSessionOptions>;
+  private readonly instructions?: string;
+  /** Lazily built once; shares the SDK's agentDir/auth so resolved models are authed. */
+  private registry?: ModelRegistry;
+
+  constructor(options: WorkflowAgentOptions = {}) {
+    this.cwd = options.cwd ?? process.cwd();
+    this.baseTools = options.tools ?? createCodingTools(this.cwd);
+    this.sessionOptions = options.session ?? {};
+    this.instructions = options.instructions;
+  }
+
+  private getRegistry(): ModelRegistry {
+    if (!this.registry) {
+      const dir = getAgentDir();
+      // Same agentDir/auth files createAgentSession uses by default, so a model
+      // resolved here carries valid credentials.
+      const auth = AuthStorage.create(join(dir, "auth.json"));
+      this.registry = ModelRegistry.create(auth, join(dir, "models.json"));
+    }
+    return this.registry;
+  }
+
+  /**
+   * Resolve a model spec to a Model. Accepts `provider/modelId` (unambiguous)
+   * or a bare `modelId` (prefers auth-configured models, then any known model).
+   * Returns undefined when nothing matches.
+   */
+  private resolveModel(spec: string): Model<any> | undefined {
+    const registry = this.getRegistry();
+    const slash = spec.indexOf("/");
+    if (slash > 0) {
+      return registry.find(spec.slice(0, slash), spec.slice(slash + 1));
+    }
+    return registry.getAvailable().find((m) => m.id === spec) ?? registry.getAll().find((m) => m.id === spec);
+  }
+
+  async run<TSchemaDef extends TSchema | undefined = undefined>(
+    prompt: string,
+    options: AgentRunOptions<TSchemaDef> = {},
+  ): Promise<AgentRunResult<TSchemaDef>> {
+    const capture: StructuredOutputCapture<any> = { called: false, value: undefined };
+    // Per-call cwd (e.g. a worktree) needs coding tools bound to that directory,
+    // since tools capture their cwd at construction and can't be relocated.
+    const runCwd = options.cwd ?? this.cwd;
+    const baseTools = runCwd === this.cwd ? this.baseTools : createCodingTools(runCwd);
+    const customTools: ToolDefinition[] = [...baseTools, ...(options.tools ?? [])];
+
+    if (options.schema) {
+      customTools.push(createStructuredOutputTool({ schema: options.schema, capture }) as unknown as ToolDefinition);
+    }
+
+    // Resolve a requested model spec to a Model object. A given-but-unresolved
+    // spec falls back to the session default (with a warning) rather than failing.
+    let resolvedModel: Model<any> | undefined;
+    if (options.model) {
+      resolvedModel = this.resolveModel(options.model);
+      if (resolvedModel) {
+        options.onModelResolved?.(`${resolvedModel.provider}/${resolvedModel.id}`);
+      } else {
+        console.warn(`[workflow] model "${options.model}" not found; using session default`);
+      }
+    }
+
+    const agentDir = getAgentDir();
+    // Reuse one shared, extension-free resource loader so createAgentSession does
+    // not re-discover + jiti-compile all user extensions on every subagent spawn.
+    const resourceLoader = await profile("agent:resourceLoader", () =>
+      getSharedResourceLoader(this.cwd, agentDir),
+    );
+    const { session } = await createAgentSession({
+      cwd: runCwd,
+      agentDir,
+      sessionManager: SessionManager.inMemory(),
+      // Pre-built loader (above) — passing it makes createAgentSession skip its
+      // own DefaultResourceLoader construction + reload() entirely.
+      resourceLoader,
+      // Use real SettingsManager to inherit user's default provider/model settings.
+      // SettingsManager.inMemory() doesn't load ~/.pi/settings.json, so subagents
+      // would fall back to the first available model (e.g. openai-codex) which may
+      // not have valid auth, causing silent empty responses.
+      settingsManager: SettingsManager.create(this.cwd, agentDir),
+      customTools,
+      ...this.sessionOptions,
+      // Per-call model wins over any sessionOptions.model.
+      ...(resolvedModel ? { model: resolvedModel } : {}),
+    });
+
+    let removeAbortListener: (() => void) | undefined;
+    try {
+      if (options.signal?.aborted) throw new Error("Subagent was aborted");
+      if (options.signal) {
+        const onAbort = () => void session.abort();
+        options.signal.addEventListener("abort", onAbort, { once: true });
+        removeAbortListener = () => options.signal?.removeEventListener("abort", onAbort);
+      }
+
+      await profile(`agent:prompt:${options.label ?? "?"}`, () =>
+        session.prompt(this.buildPrompt(prompt, options as AgentRunOptions<any>, Boolean(options.schema))),
+      );
+      if (options.signal?.aborted) throw new Error("Subagent was aborted");
+
+      if (options.schema) {
+        if (!capture.called) {
+          throw new Error("Subagent finished without calling structured_output");
+        }
+        return capture.value as AgentRunResult<TSchemaDef>;
+      }
+
+      return this.lastAssistantText(session.messages) as AgentRunResult<TSchemaDef>;
+    } finally {
+      removeAbortListener?.();
+      // Read real usage before disposing — dispose tears down the session state.
+      if (options.onUsage) {
+        try {
+          const { tokens, cost } = profile(`agent:stats:${options.label ?? "?"}`, () => session.getSessionStats());
+          options.onUsage({
+            input: tokens.input,
+            output: tokens.output,
+            cacheRead: tokens.cacheRead,
+            cacheWrite: tokens.cacheWrite,
+            total: tokens.total,
+            cost,
+          });
+        } catch {
+          // Usage is best-effort; never let stats failure mask the real result/error.
+        }
+      }
+      // Await teardown: dispose() may be async, and a fire-and-forget call could
+      // leak the session's handles under a wide fan-out. profile() passes the
+      // promise through, so timing stays accurate.
+      await profile(`agent:dispose:${options.label ?? "?"}`, () => session.dispose());
+    }
+  }
+
+  private buildPrompt(prompt: string, options: AgentRunOptions<any>, structured: boolean): string {
+    const parts = [
+      this.instructions,
+      options.instructions,
+      options.label ? `Task label: ${options.label}` : undefined,
+      prompt,
+    ].filter(Boolean);
+
+    if (structured) {
+      parts.push(
+        [
+          "Final output contract:",
+          "- Your final action MUST be a structured_output tool call.",
+          "- The structured_output arguments are the return value of this subagent.",
+          "- Do not emit a prose final answer instead of structured_output.",
+          "- If you need to inspect files or run commands first, do so, then call structured_output exactly once.",
+        ].join("\n"),
+      );
+    }
+
+    return parts.join("\n\n");
+  }
+
+  private lastAssistantText(messages: unknown[]): string {
+    for (let i = messages.length - 1; i >= 0; i--) {
+      const message = messages[i] as Partial<AssistantMessage> | undefined;
+      if (message?.role !== "assistant" || !Array.isArray(message.content)) continue;
+      const text = message.content
+        .filter((part): part is TextContent => part.type === "text")
+        .map((part) => part.text)
+        .join("");
+      if (text.trim()) return text;
+    }
+    return "";
+  }
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/auto-workflow.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/auto-workflow.ts
@@ -1,0 +1,227 @@
+/**
+ * Auto-workflow mode (ultracode equivalent).
+ * Automatically decides when to use workflows based on task complexity.
+ *
+ * Wired in via an opt-in `/auto-workflow off|suggest|force` toggle (default off):
+ * `installAutoWorkflow` registers the command and returns a controller that the
+ * workflows-mode input hook (workflow-editor.ts) consults on each submit, using
+ * `evaluateAutoWorkflow` to decide whether to nudge or force a workflow.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+
+export interface AutoWorkflowConfig {
+  /** Enable auto-workflow mode. */
+  enabled: boolean;
+  /** Minimum number of subtasks to trigger a workflow. */
+  minSubtasks: number;
+  /** Keywords that suggest workflow usage. */
+  triggerKeywords: string[];
+  /** Maximum complexity score before auto-triggering. */
+  complexityThreshold: number;
+}
+
+const DEFAULT_CONFIG: AutoWorkflowConfig = {
+  enabled: false,
+  minSubtasks: 3,
+  triggerKeywords: [
+    "workflow",
+    "parallel",
+    "fan-out",
+    "audit",
+    "migrate",
+    "review",
+    "research",
+    "analyze all",
+    "check every",
+    "sweep",
+    "batch",
+    "bulk",
+  ],
+  complexityThreshold: 7,
+};
+
+/**
+ * Analyze a task description and determine if it should use a workflow.
+ */
+export function shouldUseWorkflow(
+  taskDescription: string,
+  config: Partial<AutoWorkflowConfig> = { enabled: true },
+): { useWorkflow: boolean; confidence: number; reason: string } {
+  const cfg = { ...DEFAULT_CONFIG, ...config };
+
+  if (!cfg.enabled) {
+    return { useWorkflow: false, confidence: 0, reason: "Auto-workflow disabled" };
+  }
+
+  const lower = taskDescription.toLowerCase();
+
+  // Check for explicit workflow keywords
+  const keywordMatches = cfg.triggerKeywords.filter((kw) => lower.includes(kw));
+  if (keywordMatches.length > 0) {
+    return {
+      useWorkflow: true,
+      confidence: Math.min(0.5 + keywordMatches.length * 0.15, 1),
+      reason: `Matched keywords: ${keywordMatches.join(", ")}`,
+    };
+  }
+
+  // Analyze complexity indicators
+  const complexityIndicators = [
+    { pattern: /\b(all|every|each|entire|whole)\b/i, weight: 2 },
+    { pattern: /\b(files?|directories|folders?|modules?|components?|endpoints?)\b/i, weight: 1.5 },
+    { pattern: /\b(parallel|concurrent|simultaneously)\b/i, weight: 2 },
+    { pattern: /\b(review|audit|check|verify|validate)\b/i, weight: 1 },
+    { pattern: /\b(migrate|refactor|update|modify|change)\b/i, weight: 1.5 },
+    { pattern: /\b(research|investigate|analyze|compare)\b/i, weight: 1 },
+    { pattern: /\d+\s*(files?|items?|tasks?|components?)/i, weight: 2 },
+    { pattern: /\b(across|throughout|cross-cutting)\b/i, weight: 1.5 },
+  ];
+
+  let complexityScore = 0;
+  for (const indicator of complexityIndicators) {
+    if (indicator.pattern.test(taskDescription)) {
+      complexityScore += indicator.weight;
+    }
+  }
+
+  // Estimate subtask count
+  const subtaskIndicators = [
+    /\bfirst\b/gi,
+    /\bthen\b/gi,
+    /\bfinally\b/gi,
+    /\bafter\b/gi,
+    /\bnext\b/gi,
+    /\balso\b/gi,
+    /\bstep \d/gi,
+  ];
+
+  let estimatedSubtasks = 1;
+  for (const pattern of subtaskIndicators) {
+    const matches = taskDescription.match(pattern);
+    if (matches) estimatedSubtasks += matches.length;
+  }
+
+  if (complexityScore >= cfg.complexityThreshold || estimatedSubtasks >= cfg.minSubtasks) {
+    return {
+      useWorkflow: true,
+      confidence: Math.min(complexityScore / 10, 1),
+      reason: `Complexity score: ${complexityScore}, estimated subtasks: ${estimatedSubtasks}`,
+    };
+  }
+
+  return {
+    useWorkflow: false,
+    confidence: 0.3,
+    reason: `Below threshold (complexity: ${complexityScore}, subtasks: ${estimatedSubtasks})`,
+  };
+}
+
+/**
+ * Generate a workflow script suggestion from a task description.
+ *
+ * The task text is embedded via JSON.stringify (a safe double-quoted JS string
+ * literal that handles quotes/backslashes/newlines), never via fragile manual
+ * single-quote escaping — so a task with `'`, `\`, or a newline can't break or
+ * inject into the generated script.
+ */
+export function suggestWorkflowScript(taskDescription: string): string {
+  const descLit = JSON.stringify(taskDescription.slice(0, 100));
+  const taskLit = JSON.stringify(taskDescription.slice(0, 80));
+  return `export const meta = {
+  name: 'auto_generated',
+  description: ${descLit},
+  phases: [
+    { title: 'Analyze' },
+    { title: 'Execute' },
+    { title: 'Verify' },
+  ],
+};
+
+phase('Analyze');
+const analysis = await agent(
+  'Analyze this task and break it into subtasks: ' + ${taskLit},
+  { label: 'task analysis' }
+);
+
+phase('Execute');
+const results = await parallel([
+  () => agent('Execute subtask 1 based on: ' + analysis, { label: 'subtask-1' }),
+  // Add more subtasks as needed
+]);
+
+phase('Verify');
+const verification = await agent(
+  'Verify these results are correct: ' + JSON.stringify(results),
+  { label: 'verification' }
+);
+
+return { analysis, results, verification };`;
+}
+
+/** Auto-workflow runtime mode, toggled by the `/auto-workflow` command. */
+export type AutoWorkflowMode = "off" | "suggest" | "force";
+
+/** Live view of the auto-workflow mode, shared with the workflows-mode input hook. */
+export interface AutoWorkflowController {
+  getMode(): AutoWorkflowMode;
+  setMode(mode: AutoWorkflowMode): void;
+}
+
+/** Result of evaluating a submitted message against the current auto-workflow mode. */
+export interface AutoWorkflowDecision {
+  action: "none" | "suggest" | "force";
+  reason?: string;
+  /** Starter script for "force"; the caller composes it into the forced prompt. */
+  skeleton?: string;
+}
+
+/**
+ * Minimum shouldUseWorkflow confidence to auto-FORCE a workflow. "suggest" fires
+ * on any positive detection; forcing is held to a higher bar so borderline
+ * messages only get a nudge, never a silent rewrite.
+ */
+const AUTO_FORCE_MIN_CONFIDENCE = 0.6;
+
+/**
+ * Decide what auto-workflow should do for a submitted message. Pure (no UI): the
+ * caller acts on the result. Returns "none" when off, empty, or not detected.
+ */
+export function evaluateAutoWorkflow(text: string, mode: AutoWorkflowMode): AutoWorkflowDecision {
+  if (mode === "off" || !text.trim()) return { action: "none" };
+  const decision = shouldUseWorkflow(text);
+  if (!decision.useWorkflow) return { action: "none" };
+  if (mode === "force" && decision.confidence >= AUTO_FORCE_MIN_CONFIDENCE) {
+    return { action: "force", reason: decision.reason, skeleton: suggestWorkflowScript(text) };
+  }
+  return { action: "suggest", reason: decision.reason };
+}
+
+/**
+ * Register the `/auto-workflow [off|suggest|force|status]` command (mirrors
+ * `/footer`) and return a controller the workflows-mode input hook reads on each
+ * submit. Default mode is "off", so nothing changes until the user opts in.
+ */
+export function installAutoWorkflow(pi: ExtensionAPI): AutoWorkflowController {
+  let mode: AutoWorkflowMode = "off";
+  pi.registerCommand("auto-workflow", {
+    description: "Auto-detect workflow-worthy messages. Usage: /auto-workflow [off|suggest|force|status]",
+    handler: async (args: string, ctx: ExtensionCommandContext) => {
+      const sub = args.trim().toLowerCase() || "status";
+      if (sub === "status") {
+        ctx.ui.notify(`auto-workflow: ${mode}`, "info");
+      } else if (sub === "off" || sub === "suggest" || sub === "force") {
+        mode = sub;
+        ctx.ui.notify(`auto-workflow: ${mode}`, "info");
+      } else {
+        ctx.ui.notify(`auto-workflow: unknown "${sub}". Use off|suggest|force|status.`, "warning");
+      }
+    },
+  });
+  return {
+    getMode: () => mode,
+    setMode: (m: AutoWorkflowMode) => {
+      mode = m;
+    },
+  };
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/builtin-commands.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/builtin-commands.ts
@@ -41,7 +41,14 @@ function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
 function reportText(result: WorkflowRunResult): string {
   const r = result.result as { report?: unknown } | undefined;
   if (r && typeof r.report === "string" && r.report.trim()) return r.report;
-  return JSON.stringify(result.result, null, 2);
+  // No usable report (e.g. every agent failed and degraded to null). Lead with a
+  // plain-language line so the message never looks like the command "did nothing",
+  // then include the raw result for debugging.
+  return `The workflow finished but produced no report. This usually means its agents returned no usable output.\n\n${JSON.stringify(
+    result.result,
+    null,
+    2,
+  )}`;
 }
 
 export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string }): void {

--- a/users/profiles/pi/extensions/dynamic-workflows/src/builtin-commands.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/builtin-commands.ts
@@ -1,0 +1,98 @@
+/**
+ * Bundled workflow commands: `/deep-research` and `/adversarial-review`.
+ * They run a generated workflow script and print the final report.
+ */
+
+import { appendFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { createCodingTools, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { generateAdversarialReviewWorkflow } from "./adversarial-review.ts";
+import { WORKFLOW_RUNS_DIR } from "./config.ts";
+import { generateDeepResearchWorkflow } from "./deep-research.ts";
+import { createWebTools } from "./web-tools.ts";
+import { runWorkflow, type WorkflowRunResult } from "./workflow.ts";
+
+/**
+ * Append-only breadcrumb so you can confirm which search backend ran:
+ *   tail -f .pi/workflows/runs/web-search.log
+ * Lives under the (git-ignored) runs dir; best-effort, never throws into a tool.
+ */
+function webSearchBreadcrumb(cwd: string): (message: string) => void {
+  const dir = join(cwd, WORKFLOW_RUNS_DIR);
+  const file = join(dir, "web-search.log");
+  return (message: string) => {
+    try {
+      mkdirSync(dir, { recursive: true });
+      appendFileSync(file, `${new Date().toISOString()} ${message}\n`);
+    } catch {
+      // Diagnostics only — never let a logging failure affect the search.
+    }
+  };
+}
+
+function alreadyRegistered(pi: ExtensionAPI, name: string): boolean {
+  try {
+    return (pi.getCommands?.() ?? []).some((c: { name: string }) => c.name === name);
+  } catch {
+    return false;
+  }
+}
+
+function reportText(result: WorkflowRunResult): string {
+  const r = result.result as { report?: unknown } | undefined;
+  if (r && typeof r.report === "string" && r.report.trim()) return r.report;
+  return JSON.stringify(result.result, null, 2);
+}
+
+export function registerBuiltinWorkflows(pi: ExtensionAPI, opts: { cwd: string }): void {
+  const cwd = opts.cwd;
+
+  if (!alreadyRegistered(pi, "deep-research")) {
+    pi.registerCommand("deep-research", {
+      description: "Research a question across the web with cross-checked sources",
+      async handler(args: string, ctx: ExtensionCommandContext) {
+        const question = args.trim();
+        if (!question) return ctx.ui.notify("Usage: /deep-research <question>", "warning");
+        ctx.ui.notify("Researching — running web searches across several angles…", "info");
+        try {
+          const result = await runWorkflow(generateDeepResearchWorkflow(), {
+            cwd,
+            args: { question },
+            // Research agents need real web access on top of the coding tools.
+            tools: [...createCodingTools(cwd), ...createWebTools({ log: webSearchBreadcrumb(cwd) })],
+            onPhase: (title) => ctx.ui.setStatus("deep-research", `research: ${title}`),
+          });
+          ctx.ui.setStatus("deep-research", undefined);
+          await pi.sendMessage({ customType: "deep-research", content: reportText(result), display: true });
+        } catch (error) {
+          ctx.ui.setStatus("deep-research", undefined);
+          ctx.ui.notify(`deep-research failed: ${error instanceof Error ? error.message : error}`, "error");
+        }
+      },
+    });
+  }
+
+  if (!alreadyRegistered(pi, "adversarial-review")) {
+    pi.registerCommand("adversarial-review", {
+      description: "Investigate a task, then cross-check each finding with skeptical reviewers",
+      async handler(args: string, ctx: ExtensionCommandContext) {
+        const task = args.trim();
+        if (!task) return ctx.ui.notify("Usage: /adversarial-review <task or question>", "warning");
+        ctx.ui.notify("Reviewing — investigating then refuting each finding…", "info");
+        try {
+          const result = await runWorkflow(generateAdversarialReviewWorkflow(), {
+            cwd,
+            args: { task },
+            tools: createCodingTools(cwd),
+            onPhase: (title) => ctx.ui.setStatus("adversarial-review", `review: ${title}`),
+          });
+          ctx.ui.setStatus("adversarial-review", undefined);
+          await pi.sendMessage({ customType: "adversarial-review", content: reportText(result), display: true });
+        } catch (error) {
+          ctx.ui.setStatus("adversarial-review", undefined);
+          ctx.ui.notify(`adversarial-review failed: ${error instanceof Error ? error.message : error}`, "error");
+        }
+      },
+    });
+  }
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/config.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/config.ts
@@ -1,0 +1,38 @@
+/**
+ * Configuration constants for pi-dynamic-workflows.
+ */
+
+/** Maximum number of agents allowed per workflow run. */
+export const MAX_AGENTS_PER_RUN = 1000;
+
+/** Default timeout for a single agent in milliseconds (5 minutes). */
+export const DEFAULT_AGENT_TIMEOUT_MS = 5 * 60 * 1000;
+
+/**
+ * Maximum concurrent agents. Subagents run in-process on Pi's single event loop
+ * (shared with the interactive TUI), so a high cap makes the UI lag while a wide
+ * fan-out streams. 6 keeps real parallelism while staying responsive; the
+ * network-bound agents still overlap. Raise it for headless/background runs.
+ */
+export const MAX_CONCURRENCY = 6;
+
+/** Default token budget if none specified. */
+export const DEFAULT_TOKEN_BUDGET = null;
+
+/**
+ * Max wall-clock for a workflow script's SYNCHRONOUS evaluation, enforced via a
+ * `vm` timeout. This bounds only the script's sync prefix (up to its first
+ * `await`) — which is exactly the freeze case: a synchronous infinite loop
+ * before any await would otherwise block the TUI event loop. Async
+ * orchestration time (awaiting agents) is unbounded by this.
+ */
+export const WORKFLOW_SYNC_TIMEOUT_MS = 10_000;
+
+/** Directory for persisting workflow run state. */
+export const WORKFLOW_RUNS_DIR = ".pi/workflows/runs";
+
+/** Directory for saved workflow commands. */
+export const WORKFLOW_SAVED_DIR = ".pi/workflows/saved";
+
+/** User-level saved workflows directory. */
+export const USER_WORKFLOW_SAVED_DIR = "~/.pi/workflows/saved";

--- a/users/profiles/pi/extensions/dynamic-workflows/src/deep-research.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/deep-research.ts
@@ -39,7 +39,18 @@ const plan = await agent(
   '\\n\\nProduce ' + angles + ' diverse, specific search queries that together cover the question from different angles.',
   { label: 'plan queries', schema: { type: 'object', properties: { queries: { type: 'array', items: { type: 'string' } } }, required: ['queries'] } }
 )
-const queries = (plan.queries || []).slice(0, angles)
+const queries = ((plan && plan.queries) || []).slice(0, angles)
+
+if (queries.length === 0) {
+  return {
+    question,
+    queries: [],
+    supported: [],
+    report:
+      'Could not produce any search queries for this question, so no research was run.\\n\\n' +
+      'Tip: try rephrasing into a more concrete, factual question.\\n\\nQUESTION: ' + question,
+  }
+}
 
 phase('Gather')
 const gathered = await parallel(queries.map((q, i) => () =>

--- a/users/profiles/pi/extensions/dynamic-workflows/src/deep-research.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/deep-research.ts
@@ -1,0 +1,73 @@
+/**
+ * Deep research workflow.
+ * Built-in workflow for comprehensive research across multiple sources.
+ */
+
+export interface DeepResearchConfig {
+  /** Number of distinct search angles/queries to explore. */
+  angles: number;
+  /** Minimum distinct sources required for a claim to survive cross-checking. */
+  minSupport: number;
+}
+
+/**
+ * Generate a deep-research workflow that uses the real web_search/web_fetch tools.
+ *
+ * The script is static and reads its inputs from `args` (question/angles/minSupport),
+ * so the question is never string-interpolated into source — no escaping hazards.
+ * Inject the web tools at run time via the agent's `tools` option.
+ */
+export function generateDeepResearchWorkflow(): string {
+  return `export const meta = {
+  name: 'deep_research',
+  description: 'Deep research with real web search and cross-checked claims',
+  phases: [
+    { title: 'Queries' },
+    { title: 'Gather' },
+    { title: 'Verify' },
+    { title: 'Report' },
+  ],
+}
+
+const question = (args && args.question) || ''
+const angles = (args && args.angles) || 4
+const minSupport = (args && args.minSupport) || 2
+
+phase('Queries')
+const plan = await agent(
+  'You are planning web research for this question:\\n' + question +
+  '\\n\\nProduce ' + angles + ' diverse, specific search queries that together cover the question from different angles.',
+  { label: 'plan queries', schema: { type: 'object', properties: { queries: { type: 'array', items: { type: 'string' } } }, required: ['queries'] } }
+)
+const queries = (plan.queries || []).slice(0, angles)
+
+phase('Gather')
+const gathered = await parallel(queries.map((q, i) => () =>
+  agent(
+    'Research this query using the web_search and web_fetch tools.\\nQuery: ' + q +
+    '\\n\\nSteps: (1) call web_search with the query; (2) web_fetch the 2 most relevant result URLs; ' +
+    '(3) extract concrete, verifiable factual claims, each tagged with the exact source URL it came from. ' +
+    'Do NOT invent sources or claims — report only what the fetched pages actually say.',
+    { label: 'research ' + (i + 1), schema: { type: 'object', properties: { sources: { type: 'array', items: { type: 'object', properties: { url: { type: 'string' }, claims: { type: 'array', items: { type: 'string' } } }, required: ['url', 'claims'] } } }, required: ['sources'] } }
+  )
+))
+const allSources = gathered.filter(Boolean).flatMap((g) => (g && g.sources) || [])
+
+phase('Verify')
+const verdict = await agent(
+  'Cross-check these research sources. Group claims that assert the same fact across different source URLs. ' +
+  'Keep a claim only if it is supported by at least ' + minSupport + ' distinct source URLs OR by one clearly authoritative source. ' +
+  'Discard claims found in a single weak source or that conflict with others.\\n\\nSOURCES JSON:\\n' + JSON.stringify(allSources),
+  { label: 'cross-check', schema: { type: 'object', properties: { supported: { type: 'array', items: { type: 'object', properties: { claim: { type: 'string' }, sources: { type: 'array', items: { type: 'string' } } }, required: ['claim', 'sources'] } }, discarded: { type: 'array', items: { type: 'string' } } }, required: ['supported'] } }
+)
+
+phase('Report')
+const report = await agent(
+  'Write a concise, well-structured research report that answers the question using ONLY the supported claims below. ' +
+  'Cite source URLs inline next to each claim. If the evidence is thin, say so explicitly.\\n\\n' +
+  'QUESTION: ' + question + '\\n\\nSUPPORTED CLAIMS JSON:\\n' + JSON.stringify((verdict && verdict.supported) || []),
+  { label: 'write report' }
+)
+
+return { question, queries, supported: (verdict && verdict.supported) || [], report }`;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/display.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/display.ts
@@ -1,0 +1,241 @@
+import type { ExtensionContext } from "@earendil-works/pi-coding-agent";
+import type { WorkflowMeta } from "./workflow.ts";
+
+export type WorkflowAgentStatus = "queued" | "running" | "done" | "error" | "skipped";
+
+export interface WorkflowAgentSnapshot {
+  id: number;
+  label: string;
+  phase?: string;
+  prompt: string;
+  status: WorkflowAgentStatus;
+  resultPreview?: string;
+  error?: string;
+  /** Tokens used by this agent. */
+  tokens?: number;
+  /** The model this agent ran on (provider/id), when known. */
+  model?: string;
+}
+
+export interface WorkflowSnapshot {
+  name: string;
+  description?: string;
+  phases: string[];
+  currentPhase?: string;
+  logs: string[];
+  agents: WorkflowAgentSnapshot[];
+  agentCount: number;
+  runningCount: number;
+  doneCount: number;
+  errorCount: number;
+  durationMs?: number;
+  result?: unknown;
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost?: number;
+  };
+  runId?: string;
+}
+
+export interface WorkflowDisplay {
+  update(snapshot: WorkflowSnapshot): void;
+  complete(snapshot: WorkflowSnapshot): void;
+  clear(): void;
+}
+
+export interface WorkflowDisplayOptions {
+  key?: string;
+  placement?: "aboveEditor" | "belowEditor";
+  maxAgents?: number;
+  maxLogs?: number;
+  showStatus?: boolean;
+  showResultPreviews?: boolean;
+}
+
+export function createWorkflowSnapshot(meta: WorkflowMeta): WorkflowSnapshot {
+  return {
+    name: meta.name,
+    description: meta.description,
+    phases: meta.phases?.map((phase) => phase.title) ?? [],
+    logs: [],
+    agents: [],
+    agentCount: 0,
+    runningCount: 0,
+    doneCount: 0,
+    errorCount: 0,
+  };
+}
+
+export function recomputeWorkflowSnapshot(snapshot: WorkflowSnapshot): WorkflowSnapshot {
+  const runningCount = snapshot.agents.filter((agent) => agent.status === "running").length;
+  const doneCount = snapshot.agents.filter((agent) => agent.status === "done").length;
+  const errorCount = snapshot.agents.filter((agent) => agent.status === "error").length;
+  return { ...snapshot, agentCount: snapshot.agents.length, runningCount, doneCount, errorCount };
+}
+
+export function createWidgetWorkflowDisplay(
+  ctx: Pick<ExtensionContext, "ui" | "hasUI">,
+  options: WorkflowDisplayOptions = {},
+): WorkflowDisplay {
+  const key = options.key ?? "workflow";
+  const placement = options.placement ?? "belowEditor";
+  const showStatus = options.showStatus ?? false;
+
+  const render = (snapshot: WorkflowSnapshot, completed = false) => {
+    if (!ctx.hasUI) return;
+    if (showStatus) ctx.ui.setStatus(key, statusLine(snapshot, completed));
+    ctx.ui.setWidget(key, renderWorkflowLines(snapshot, options), { placement });
+  };
+
+  return {
+    update(snapshot) {
+      render(snapshot, false);
+    },
+    complete(snapshot) {
+      render(snapshot, true);
+    },
+    clear() {
+      if (!ctx.hasUI) return;
+      if (showStatus) ctx.ui.setStatus(key, undefined);
+      ctx.ui.setWidget(key, undefined);
+    },
+  };
+}
+
+export function createToolUpdateWorkflowDisplay(
+  onUpdate: ((result: { content: Array<{ type: "text"; text: string }>; details: unknown }) => void) | undefined,
+  ctx?: Pick<ExtensionContext, "ui" | "hasUI">,
+  options: WorkflowDisplayOptions & { streamToolUpdates?: boolean } = {},
+): WorkflowDisplay {
+  const widget = ctx ? createWidgetWorkflowDisplay(ctx, options) : undefined;
+  const streamToolUpdates = options.streamToolUpdates ?? !ctx?.hasUI;
+
+  const emit = (snapshot: WorkflowSnapshot, completed = false) => {
+    if (streamToolUpdates) {
+      onUpdate?.({
+        content: [{ type: "text", text: renderWorkflowText(snapshot, completed) }],
+        details: snapshot,
+      });
+    }
+    if (completed) widget?.complete(snapshot);
+    else widget?.update(snapshot);
+  };
+
+  return {
+    update(snapshot) {
+      emit(snapshot, false);
+    },
+    complete(snapshot) {
+      emit(snapshot, true);
+    },
+    clear() {
+      widget?.clear();
+    },
+  };
+}
+
+export function renderWorkflowLines(snapshot: WorkflowSnapshot, options: WorkflowDisplayOptions = {}): string[] {
+  const maxAgents = options.maxAgents ?? 8;
+  const maxLogs = options.maxLogs ?? 2;
+  const showResultPreviews = options.showResultPreviews ?? false;
+  const state =
+    snapshot.errorCount > 0
+      ? `, ${snapshot.errorCount} errors`
+      : snapshot.runningCount > 0
+        ? `, ${snapshot.runningCount} running`
+        : "";
+  // Build header with token info (and cost when the provider reports it)
+  const usage = snapshot.tokenUsage;
+  const costInfo = usage?.cost ? ` · $${usage.cost.toFixed(4)}` : "";
+  const tokenInfo = usage ? ` · ${usage.total.toLocaleString()} tokens${costInfo}` : "";
+  const lines = [
+    `◆ Workflow: ${snapshot.name} (${snapshot.doneCount}/${snapshot.agentCount} done${state}${tokenInfo})`,
+  ];
+
+  const phaseNames = snapshot.phases.length
+    ? snapshot.phases
+    : unique(snapshot.agents.map((agent) => agent.phase).filter(Boolean) as string[]);
+  const rendered = new Set<WorkflowAgentSnapshot>();
+
+  for (const phase of phaseNames) {
+    const agents = snapshot.agents.filter((agent) => agent.phase === phase);
+    for (const agent of agents) rendered.add(agent);
+    const done = agents.filter((agent) => agent.status === "done").length;
+    const running = agents.filter((agent) => agent.status === "running").length;
+    const errors = agents.filter((agent) => agent.status === "error").length;
+    const skipped = agents.filter((agent) => agent.status === "skipped").length;
+    const complete = agents.length > 0 && done + errors + skipped === agents.length;
+    const marker = running > 0 || (!complete && snapshot.currentPhase === phase) ? "▶" : complete ? "✓" : " ";
+    lines.push(
+      `  ${marker} ${phase} ${done}/${agents.length}${running ? ` · ${running} running` : ""}${errors ? ` · ${errors} errors` : ""}${skipped ? ` · ${skipped} skipped` : ""}`,
+    );
+
+    const visibleAgents = agents.slice(-maxAgents);
+    for (const agent of visibleAgents) {
+      const order = `#${agent.id}`;
+      const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
+      const agentTokens = agent.tokens ? ` [${agent.tokens.toLocaleString()} tok]` : "";
+      lines.push(`    ${order} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+    }
+    if (agents.length > visibleAgents.length)
+      lines.push(`    … ${agents.length - visibleAgents.length} earlier agents`);
+  }
+
+  const unphased = snapshot.agents.filter((agent) => !rendered.has(agent));
+  if (unphased.length) {
+    lines.push("  Unphased");
+    for (const agent of unphased.slice(-maxAgents)) {
+      const result = showResultPreviews && agent.resultPreview ? ` — ${agent.resultPreview}` : "";
+      const agentTokens = agent.tokens ? ` [${agent.tokens.toLocaleString()} tok]` : "";
+      lines.push(`    #${agent.id} ${statusIcon(agent.status)} ${shorten(agent.label, 48)}${agentTokens}${result}`);
+    }
+  }
+
+  for (const log of snapshot.logs.slice(-maxLogs)) lines.push(`  log: ${log}`);
+
+  return lines;
+}
+
+export function renderWorkflowText(snapshot: WorkflowSnapshot, completed = false): string {
+  const header = completed ? "Workflow completed" : "Workflow running";
+  return [header, ...renderWorkflowLines(snapshot)].join("\n");
+}
+
+function statusLine(snapshot: WorkflowSnapshot, completed: boolean): string {
+  if (completed) return `workflow ✓ ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount}`;
+  if (snapshot.runningCount > 0)
+    return `workflow ${snapshot.name}: ${snapshot.runningCount} running, ${snapshot.doneCount}/${snapshot.agentCount} done`;
+  return `workflow ${snapshot.name}: ${snapshot.doneCount}/${snapshot.agentCount} done`;
+}
+
+function statusIcon(status: WorkflowAgentStatus): string {
+  switch (status) {
+    case "queued":
+      return "○";
+    case "running":
+      return "●";
+    case "done":
+      return "✓";
+    case "error":
+      return "✗";
+    case "skipped":
+      return "-";
+  }
+}
+
+function unique(values: string[]): string[] {
+  return [...new Set(values)];
+}
+
+function shorten(value: string, max: number): string {
+  const text = value.replace(/\s+/g, " ").trim();
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}
+
+export function preview(value: unknown, max = 80): string {
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (!text) return "";
+  return text.length > max ? `${text.slice(0, max - 1)}…` : text;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/errors.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/errors.ts
@@ -1,0 +1,85 @@
+/**
+ * Workflow-specific error types.
+ */
+
+export enum WorkflowErrorCode {
+  /** Agent exceeded timeout. */
+  AGENT_TIMEOUT = "AGENT_TIMEOUT",
+  /** Workflow was aborted by user. */
+  WORKFLOW_ABORTED = "WORKFLOW_ABORTED",
+  /** Agent limit exceeded. */
+  AGENT_LIMIT_EXCEEDED = "AGENT_LIMIT_EXCEEDED",
+  /** Token budget exhausted. */
+  TOKEN_BUDGET_EXHAUSTED = "TOKEN_BUDGET_EXHAUSTED",
+  /** Script validation failed. */
+  SCRIPT_VALIDATION_ERROR = "SCRIPT_VALIDATION_ERROR",
+  /** Agent execution failed. */
+  AGENT_EXECUTION_ERROR = "AGENT_EXECUTION_ERROR",
+  /** Run state persistence failed. */
+  PERSISTENCE_ERROR = "PERSISTENCE_ERROR",
+  /** Unknown error. */
+  UNKNOWN = "UNKNOWN",
+}
+
+export class WorkflowError extends Error {
+  readonly code: WorkflowErrorCode;
+  readonly recoverable: boolean;
+  readonly agentLabel?: string;
+  readonly details?: unknown;
+
+  constructor(
+    message: string,
+    code: WorkflowErrorCode,
+    options: { recoverable?: boolean; agentLabel?: string; details?: unknown } = {},
+  ) {
+    super(message);
+    this.name = "WorkflowError";
+    this.code = code;
+    this.recoverable = options.recoverable ?? false;
+    this.agentLabel = options.agentLabel;
+    this.details = options.details;
+  }
+}
+
+export function isWorkflowError(error: unknown): error is WorkflowError {
+  return error instanceof WorkflowError;
+}
+
+export function isAbortError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /\babort(?:ed)?\b/i.test(error.message);
+}
+
+export function isTimeoutError(error: unknown): boolean {
+  if (!(error instanceof Error)) return false;
+  return /\btimeout\b/i.test(error.message) || error.name === "TimeoutError";
+}
+
+/**
+ * Wrap an unknown error into a WorkflowError with appropriate classification.
+ */
+export function wrapError(error: unknown, context?: { agentLabel?: string }): WorkflowError {
+  if (isWorkflowError(error)) return error;
+
+  if (isAbortError(error)) {
+    return new WorkflowError(
+      error instanceof Error ? error.message : "Workflow was aborted",
+      WorkflowErrorCode.WORKFLOW_ABORTED,
+      { recoverable: true },
+    );
+  }
+
+  if (isTimeoutError(error)) {
+    return new WorkflowError(
+      error instanceof Error ? error.message : "Agent timed out",
+      WorkflowErrorCode.AGENT_TIMEOUT,
+      { recoverable: true, agentLabel: context?.agentLabel },
+    );
+  }
+
+  return new WorkflowError(
+    error instanceof Error ? error.message : String(error),
+    WorkflowErrorCode.AGENT_EXECUTION_ERROR,
+    { recoverable: true, agentLabel: context?.agentLabel, details: error },
+  );
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/fs-safety.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/fs-safety.ts
@@ -1,0 +1,40 @@
+/**
+ * Filesystem-safety helpers for persisted workflow files.
+ *
+ * Saved-workflow names (which can originate from a workflow's `meta.name`) and
+ * run IDs are interpolated into filenames. Without validation, a `../` name
+ * could read/write/delete JSON outside the intended directory. These guards
+ * reject unsafe names and assert that a resolved path stays under its base dir.
+ */
+
+import { resolve, sep } from "node:path";
+import { WorkflowError, WorkflowErrorCode } from "./errors.ts";
+
+/** A single path segment: starts alphanumeric, then alphanumerics/`._-`, no `..`, ≤128 chars. */
+const SAFE_NAME = /^[A-Za-z0-9][A-Za-z0-9._-]*$/;
+
+/** Validate a name/ID used as a filename. Throws (non-recoverable) when unsafe. */
+export function assertSafeName(name: string): string {
+  if (typeof name !== "string" || name.length === 0 || name.length > 128 || name.includes("..") || !SAFE_NAME.test(name)) {
+    throw new WorkflowError(
+      `unsafe workflow name/id: ${JSON.stringify(name)}`,
+      WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+      { recoverable: false },
+    );
+  }
+  return name;
+}
+
+/** Assert that `fullPath` resolves to a location inside `baseDir`. Returns the resolved path. */
+export function assertInside(baseDir: string, fullPath: string): string {
+  const base = resolve(baseDir);
+  const full = resolve(fullPath);
+  if (full !== base && !full.startsWith(base + sep)) {
+    throw new WorkflowError(
+      `path escapes ${base}: ${full}`,
+      WorkflowErrorCode.PERSISTENCE_ERROR,
+      { recoverable: false },
+    );
+  }
+  return full;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/index.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/index.ts
@@ -1,0 +1,89 @@
+export type { AdversarialReviewConfig } from "./adversarial-review.ts";
+export { generateAdversarialReviewWorkflow } from "./adversarial-review.ts";
+export type { AgentRunOptions, AgentRunResult, WorkflowAgentOptions } from "./agent.ts";
+export { listAvailableModelSpecs, WorkflowAgent } from "./agent.ts";
+export { initProfiler, profile, profileLog } from "./profiler.ts";
+export type { AutoWorkflowConfig, AutoWorkflowController, AutoWorkflowDecision, AutoWorkflowMode } from "./auto-workflow.ts";
+export { evaluateAutoWorkflow, installAutoWorkflow, shouldUseWorkflow, suggestWorkflowScript } from "./auto-workflow.ts";
+export { registerBuiltinWorkflows } from "./builtin-commands.ts";
+export * from "./config.ts";
+export type { DeepResearchConfig } from "./deep-research.ts";
+export { generateDeepResearchWorkflow } from "./deep-research.ts";
+export type {
+  WorkflowAgentSnapshot,
+  WorkflowAgentStatus,
+  WorkflowDisplay,
+  WorkflowDisplayOptions,
+  WorkflowSnapshot,
+} from "./display.ts";
+export {
+  createToolUpdateWorkflowDisplay,
+  createWidgetWorkflowDisplay,
+  createWorkflowSnapshot,
+  preview,
+  recomputeWorkflowSnapshot,
+  renderWorkflowLines,
+  renderWorkflowText,
+} from "./display.ts";
+export {
+  isAbortError,
+  isTimeoutError,
+  isWorkflowError,
+  WorkflowError,
+  WorkflowErrorCode,
+  wrapError,
+} from "./errors.ts";
+export type { WorkflowLogger, WorkflowLoggerOptions } from "./logger.ts";
+export { createWorkflowLogger } from "./logger.ts";
+export type { ModelRoute, ModelRoutingConfig } from "./model-routing.ts";
+export { buildModelRoutingInstructions, parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.ts";
+export type { PersistedRunState, RunPersistence, RunStatus } from "./run-persistence.ts";
+export { createRunPersistence, generateRunId } from "./run-persistence.ts";
+export {
+  parseCommandArgs,
+  registerAllSavedWorkflows,
+  registerSavedWorkflow,
+} from "./saved-commands.ts";
+export type { StructuredOutputCapture, StructuredOutputToolOptions } from "./structured-output.ts";
+export { createStructuredOutputTool } from "./structured-output.ts";
+export { installResultDelivery, installTaskPanel, type TaskPanelOptions } from "./task-panel.ts";
+export { createWebFetchTool, createWebSearchTool, createWebTools } from "./web-tools.ts";
+export type {
+  AgentOptions,
+  JournalEntry,
+  SharedRuntime,
+  WorkflowMeta,
+  WorkflowMetaPhase,
+  WorkflowRunOptions,
+  WorkflowRunResult,
+} from "./workflow.ts";
+export { parseWorkflowScript, runWorkflow } from "./workflow.ts";
+export { registerWorkflowCommands } from "./workflow-commands.ts";
+export {
+  buildForcedWorkflowPrompt,
+  colorizeWorkflow,
+  endsWithTrigger,
+  hasTrigger,
+  installWorkflowEditor,
+  RAINBOW,
+  tokenizeAnsi,
+  WorkflowEditor,
+  type WorkflowModeState,
+} from "./workflow-editor.ts";
+export type { ManagedRun, WorkflowManagerOptions } from "./workflow-manager.ts";
+export { WorkflowManager } from "./workflow-manager.ts";
+export type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.ts";
+export { createWorkflowStorage } from "./workflow-saved.ts";
+export type { WorkflowToolInput, WorkflowToolOptions } from "./workflow-tool.ts";
+export { backgroundStartedText, createWorkflowTool } from "./workflow-tool.ts";
+export {
+  keyToAction,
+  type NavAction,
+  NavigatorModel,
+  NavigatorState,
+  openWorkflowNavigator,
+  renderNavigator,
+  type ViewKind,
+} from "./workflow-ui.ts";
+export type { Worktree } from "./worktree.ts";
+export { createWorktree, removeWorktree } from "./worktree.ts";

--- a/users/profiles/pi/extensions/dynamic-workflows/src/logger.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/logger.ts
@@ -1,8 +1,12 @@
 /**
  * Workflow logger with file persistence.
+ *
+ * All disk I/O is serialized on a single async write chain (mirroring
+ * profiler.ts) so log()/warn()/error() never block the TUI event loop —
+ * synchronous fs writes here would freeze Pi on every log line.
  */
 
-import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { appendFile, mkdir, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { WORKFLOW_RUNS_DIR } from "./config.ts";
 
@@ -30,21 +34,28 @@ export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): Workf
   const persistLogs = options.persist ?? true;
   const cwd = options.cwd ?? process.cwd();
   const runId = options.runId ?? `run-${Date.now()}`;
-  let logFile: string | null = null;
+  const logFile = persistLogs ? join(cwd, WORKFLOW_RUNS_DIR, `${runId}.log`) : null;
+
+  // Serialized I/O chain: starts with a one-time async mkdir, then every write
+  // is appended to the tail. Each step swallows its own error so a single failed
+  // write can never reject the chain or block a later one.
+  let writeChain: Promise<void> = logFile
+    ? mkdir(join(cwd, WORKFLOW_RUNS_DIR), { recursive: true }).then(
+        () => {},
+        () => {},
+      )
+    : Promise.resolve();
+
+  const queue = (op: () => Promise<unknown>): void => {
+    writeChain = writeChain.then(() => op().then(() => {}, () => {}));
+  };
 
   const write = (level: string, message: string) => {
     const timestamp = new Date().toISOString();
     const entry = `[${timestamp}] [${level}] ${message}`;
     logs.push(entry);
     options.onLog?.(message);
-
-    if (persistLogs && logFile) {
-      try {
-        appendFileSync(logFile, `${entry}\n`);
-      } catch {
-        // Silent fail for log persistence
-      }
-    }
+    if (logFile) queue(() => appendFile(logFile, `${entry}\n`));
   };
 
   const logger: WorkflowLogger = {
@@ -61,29 +72,15 @@ export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): Workf
       return [...logs];
     },
     persist() {
-      if (!persistLogs) return null;
-      try {
-        const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
-        mkdirSync(runsDir, { recursive: true });
-        logFile = join(runsDir, `${runId}.log`);
-        writeFileSync(logFile, `${logs.join("\n")}\n`);
-        return logFile;
-      } catch {
-        return null;
-      }
+      if (!logFile) return null;
+      // Snapshot the buffer now (matches the old sync semantics) and queue the
+      // full rewrite. The path is deterministic, so we return it synchronously
+      // while the write drains on the chain.
+      const snapshot = `${logs.join("\n")}\n`;
+      queue(() => writeFile(logFile, snapshot));
+      return logFile;
     },
   };
-
-  // Initialize log file if persisting
-  if (persistLogs) {
-    try {
-      const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
-      mkdirSync(runsDir, { recursive: true });
-      logFile = join(runsDir, `${runId}.log`);
-    } catch {
-      // Silent fail
-    }
-  }
 
   return logger;
 }

--- a/users/profiles/pi/extensions/dynamic-workflows/src/logger.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/logger.ts
@@ -1,0 +1,89 @@
+/**
+ * Workflow logger with file persistence.
+ */
+
+import { appendFileSync, mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { WORKFLOW_RUNS_DIR } from "./config.ts";
+
+export interface WorkflowLogger {
+  log(message: string): void;
+  error(message: string): void;
+  warn(message: string): void;
+  getLogs(): string[];
+  persist(): string | null;
+}
+
+export interface WorkflowLoggerOptions {
+  /** Run ID for persistence. */
+  runId?: string;
+  /** Working directory for file paths. */
+  cwd?: string;
+  /** Whether to persist logs to disk. */
+  persist?: boolean;
+  /** Callback for each log entry. */
+  onLog?: (message: string) => void;
+}
+
+export function createWorkflowLogger(options: WorkflowLoggerOptions = {}): WorkflowLogger {
+  const logs: string[] = [];
+  const persistLogs = options.persist ?? true;
+  const cwd = options.cwd ?? process.cwd();
+  const runId = options.runId ?? `run-${Date.now()}`;
+  let logFile: string | null = null;
+
+  const write = (level: string, message: string) => {
+    const timestamp = new Date().toISOString();
+    const entry = `[${timestamp}] [${level}] ${message}`;
+    logs.push(entry);
+    options.onLog?.(message);
+
+    if (persistLogs && logFile) {
+      try {
+        appendFileSync(logFile, `${entry}\n`);
+      } catch {
+        // Silent fail for log persistence
+      }
+    }
+  };
+
+  const logger: WorkflowLogger = {
+    log(message: string) {
+      write("INFO", message);
+    },
+    error(message: string) {
+      write("ERROR", message);
+    },
+    warn(message: string) {
+      write("WARN", message);
+    },
+    getLogs() {
+      return [...logs];
+    },
+    persist() {
+      if (!persistLogs) return null;
+      try {
+        const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+        mkdirSync(runsDir, { recursive: true });
+        logFile = join(runsDir, `${runId}.log`);
+        writeFileSync(logFile, `${logs.join("\n")}\n`);
+        return logFile;
+      } catch {
+        return null;
+      }
+    },
+  };
+
+  // Initialize log file if persisting
+  if (persistLogs) {
+    try {
+      const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+      mkdirSync(runsDir, { recursive: true });
+      logFile = join(runsDir, `${runId}.log`);
+    } catch {
+      // Silent fail
+    }
+  }
+
+  return logger;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/model-routing.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/model-routing.ts
@@ -1,0 +1,80 @@
+/**
+ * Per-stage model routing for workflows.
+ * Allows different phases to use different models.
+ */
+
+export interface ModelRoute {
+  /** Phase name pattern (regex or exact match). */
+  phasePattern: string;
+  /** Model to use for this phase. */
+  model: string;
+  /** Whether to use regex matching. */
+  useRegex?: boolean;
+}
+
+export interface ModelRoutingConfig {
+  /** Default model for all phases. */
+  defaultModel?: string;
+  /** Per-phase model overrides. */
+  routes: ModelRoute[];
+}
+
+/**
+ * Resolve which model to use for a given phase.
+ */
+export function resolveModelForPhase(phase: string | undefined, config: ModelRoutingConfig): string | undefined {
+  if (!phase || !config.routes.length) {
+    return config.defaultModel;
+  }
+
+  for (const route of config.routes) {
+    if (route.useRegex) {
+      try {
+        const regex = new RegExp(route.phasePattern, "i");
+        if (regex.test(phase)) {
+          return route.model;
+        }
+      } catch {
+        // Invalid regex, skip
+      }
+    } else {
+      if (phase.toLowerCase().includes(route.phasePattern.toLowerCase())) {
+        return route.model;
+      }
+    }
+  }
+
+  return config.defaultModel;
+}
+
+/**
+ * Build model routing instructions for a workflow agent.
+ */
+export function buildModelRoutingInstructions(
+  phase: string | undefined,
+  config: ModelRoutingConfig,
+): string | undefined {
+  const model = resolveModelForPhase(phase, config);
+  if (!model) return undefined;
+  return `Use model: ${model}`;
+}
+
+/**
+ * Parse model routing from workflow meta phases.
+ */
+export function parseModelRoutingFromMeta(phases?: Array<{ title: string; model?: string }>): ModelRoutingConfig {
+  const routes: ModelRoute[] = [];
+
+  if (phases) {
+    for (const phase of phases) {
+      if (phase.model) {
+        routes.push({
+          phasePattern: phase.title,
+          model: phase.model,
+        });
+      }
+    }
+  }
+
+  return { routes };
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/panel-box.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/panel-box.ts
@@ -1,0 +1,61 @@
+/**
+ * Panel framing for legibility over terminal background images / transparency.
+ *
+ * A border alone is not enough when the terminal has a wallpaper — the gaps
+ * between glyphs still show through. So every line (border AND content) gets an
+ * opaque background fill; the frame uses the theme's border colour. Width-aware
+ * via pi-tui's ANSI-safe helpers, so existing per-token styling inside `lines`
+ * is preserved.
+ *
+ * Defensive by design: `theme.bg`/`theme.fg` throw on color names a theme does
+ * not define, and this runs inside the TUI render timer — an uncaught throw
+ * there crashes Pi. So any styling failure falls back to the raw lines.
+ */
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+export interface FramePanelOptions {
+  /** When set, the panel fills this exact viewport width. Omit to size to content. */
+  width?: number;
+  /** Upper bound when sizing to content (e.g. the viewport width). */
+  maxWidth?: number;
+  /** Optional title row, drawn bold/accent above a divider. */
+  title?: string;
+}
+
+const PAD = 1; // spaces between the border and the content
+// A background role that pi's Theme.bg actually registers (cardBg/pageBg/infoBg
+// exist in theme JSON but are NOT exposed via Theme.bg). selectedBg is used by
+// pi core itself, so every theme provides it.
+const PANEL_BG = "selectedBg";
+
+export function framePanel(lines: string[], theme: Theme, opts: FramePanelOptions = {}): string[] {
+  try {
+    const fill = (s: string) => theme.bg(PANEL_BG, s);
+    const edge = (s: string) => theme.bg(PANEL_BG, theme.fg("border", s));
+
+    const viewport = opts.width ?? opts.maxWidth ?? 80;
+    const hardMax = Math.max(8, viewport - 2 - PAD * 2);
+    const contentWidth = opts.width
+      ? hardMax
+      : Math.min(hardMax, Math.max(1, visibleWidth(opts.title ?? ""), ...lines.map(visibleWidth)));
+
+    const inner = contentWidth + PAD * 2;
+    const pad = " ".repeat(PAD);
+    const row = (body: string) =>
+      edge("│") + fill(pad + truncateToWidth(body, contentWidth, "…", true) + pad) + edge("│");
+
+    const out = [edge(`╭${"─".repeat(inner)}╮`)];
+    if (opts.title) {
+      out.push(row(theme.bold(theme.fg("accent", opts.title))));
+      out.push(edge(`├${"─".repeat(inner)}┤`));
+    }
+    for (const line of lines) out.push(row(line));
+    out.push(edge(`╰${"─".repeat(inner)}╯`));
+    return out;
+  } catch {
+    // Never let a render-time styling error take down the TUI.
+    return lines;
+  }
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/profiler.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/profiler.ts
@@ -1,0 +1,101 @@
+/**
+ * Opt-in, low-overhead profiler for diagnosing UI freezes during workflow runs.
+ *
+ * Enable with `PI_WF_PROFILE=1 pi` (tune the slow threshold with
+ * `PI_WF_PROFILE_SLOW_MS`, default 20). When off, every export here is a no-op
+ * with effectively zero cost, so it is safe to leave the call sites in place.
+ *
+ * It does two things:
+ *  1. An event-loop STALL watcher (perf_hooks): a timer that should fire every
+ *     250ms; when it fires late, the loop was blocked — we log the drift and the
+ *     label of the section that was running, which pinpoints the culprit.
+ *  2. `profile(label, fn)`: times a sync or async section and logs it when it
+ *     exceeds the slow threshold.
+ *
+ * Output is appended (async, never blocking) to `.pi/workflows/profile.log`.
+ * For a full flame chart instead, see PROFILING.md (node --cpu-prof).
+ */
+
+import { appendFile } from "node:fs/promises";
+import { join } from "node:path";
+import { monitorEventLoopDelay, performance } from "node:perf_hooks";
+
+const RAW = process.env.PI_WF_PROFILE;
+const ENABLED = !!RAW && RAW !== "0" && RAW !== "false";
+const SLOW_MS = Number(process.env.PI_WF_PROFILE_SLOW_MS ?? 20);
+
+let logPath: string | null = null;
+let writeChain: Promise<void> = Promise.resolve();
+let current: string | undefined; // label of the section currently executing
+
+function write(line: string): void {
+  if (!ENABLED || !logPath) return;
+  const ts = new Date().toISOString();
+  writeChain = writeChain.then(() => appendFile(logPath as string, `[${ts}] ${line}\n`).catch(() => {}));
+}
+
+/** Manual log line into the profile file. */
+export function profileLog(line: string): void {
+  write(line);
+}
+
+/** Set up the stall watcher and log destination. Idempotent; no-op when disabled. */
+export function initProfiler(cwd: string): void {
+  if (!ENABLED || logPath) return;
+  logPath = join(cwd, ".pi", "workflows", "profile.log");
+
+  const hist = monitorEventLoopDelay({ resolution: 10 });
+  hist.enable();
+
+  const INTERVAL = 250;
+  let last = performance.now();
+  const timer = setInterval(() => {
+    const now = performance.now();
+    const drift = now - last - INTERVAL;
+    last = now;
+    if (drift > SLOW_MS) {
+      write(`event-loop STALL ~${Math.round(drift)}ms during: ${current ?? "(idle/external)"}`);
+    }
+  }, INTERVAL);
+  if (typeof (timer as { unref?: () => void }).unref === "function") {
+    (timer as { unref: () => void }).unref();
+  }
+  write(`profiler enabled — slow>${SLOW_MS}ms, pid=${process.pid}, cwd=${cwd}`);
+}
+
+/**
+ * Time a section. Returns whatever `fn` returns (awaiting thenables). Logs when
+ * the section exceeds SLOW_MS. When disabled, calls `fn` directly with no cost.
+ */
+export function profile<T>(label: string, fn: () => T): T {
+  if (!ENABLED) return fn();
+  const start = performance.now();
+  const prev = current;
+  current = label;
+  const done = () => {
+    current = prev;
+    const ms = performance.now() - start;
+    if (ms > SLOW_MS) write(`${label} ${ms.toFixed(1)}ms`);
+  };
+  try {
+    const out = fn();
+    if (out && typeof (out as { then?: unknown }).then === "function") {
+      return (out as unknown as Promise<unknown>).then(
+        (v) => {
+          done();
+          return v;
+        },
+        (e) => {
+          done();
+          throw e;
+        },
+      ) as unknown as T;
+    }
+    done();
+    return out;
+  } catch (e) {
+    current = prev;
+    write(`${label} THREW after ${(performance.now() - start).toFixed(1)}ms`);
+    throw e;
+  }
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/run-persistence.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/run-persistence.ts
@@ -3,7 +3,7 @@
  */
 
 import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
-import { rename, unlink, writeFile } from "node:fs/promises";
+import { unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { WORKFLOW_RUNS_DIR } from "./config.ts";
 import { assertInside, assertSafeName } from "./fs-safety.ts";
@@ -96,10 +96,23 @@ export function createRunPersistence(cwd: string): RunPersistence {
   let tmpSeq = 0;
   const tmpPath = (path: string) => `${path}.${process.pid}.${tmpSeq++}.tmp`;
 
-  const writeAtomicSync = (path: string, data: string) => {
+  // Per-run write ordering. atomicity guarantees a non-torn file, but NOT that the
+  // newest intent wins: a debounced async write chained before a terminal save()
+  // could rename stale data on top of it (e.g. `running` over `completed`). Every
+  // write takes a monotonic seq when its snapshot is captured; a write commits only
+  // if its seq is still the newest for that runId. The async path commits with
+  // renameSync (synchronous), so a durable save() can't slip in during an await
+  // between the staleness re-check and the rename.
+  let writeSeq = 0;
+  const committedSeq = new Map<string, number>();
+  const isStale = (runId: string, seq: number) => seq <= (committedSeq.get(runId) ?? -1);
+
+  const writeAtomicSync = (runId: string, seq: number, path: string, data: string) => {
+    if (isStale(runId, seq)) return;
     const tmp = tmpPath(path);
     try {
       writeFileSync(tmp, data);
+      committedSeq.set(runId, seq);
       renameSync(tmp, path);
     } catch (err) {
       try {
@@ -111,11 +124,20 @@ export function createRunPersistence(cwd: string): RunPersistence {
     }
   };
 
-  const writeAtomic = async (path: string, data: string) => {
+  const writeAtomic = async (runId: string, seq: number, path: string, data: string) => {
+    if (isStale(runId, seq)) return;
     const tmp = tmpPath(path);
     try {
-      await writeFile(tmp, data);
-      await rename(tmp, path);
+      await writeFile(tmp, data); // the expensive part stays off the event loop
+      // A durable save() may have committed a newer seq while we were writing the
+      // temp; drop ours instead of clobbering it. The check + renameSync below run
+      // without an intervening await, so no save() can interleave between them.
+      if (isStale(runId, seq)) {
+        await unlink(tmp).catch(() => {});
+        return;
+      }
+      committedSeq.set(runId, seq);
+      renameSync(tmp, path);
     } catch {
       await unlink(tmp).catch(() => {});
     }
@@ -142,7 +164,7 @@ export function createRunPersistence(cwd: string): RunPersistence {
       cancelPending(state.runId);
       ensureDir();
       state.updatedAt = new Date().toISOString();
-      writeAtomicSync(runPath(state.runId), JSON.stringify(state));
+      writeAtomicSync(state.runId, ++writeSeq, runPath(state.runId), JSON.stringify(state));
     },
 
     scheduleSave(state: PersistedRunState) {
@@ -155,7 +177,12 @@ export function createRunPersistence(cwd: string): RunPersistence {
         pending.delete(state.runId);
         ensureDir();
         latest.updatedAt = new Date().toISOString();
-        writeChain = writeChain.then(() => writeAtomic(runPath(latest.runId), JSON.stringify(latest)));
+        // Capture the snapshot + its seq now; the chained write may run much later.
+        const rid = latest.runId;
+        const seq = ++writeSeq;
+        const path = runPath(rid);
+        const data = JSON.stringify(latest);
+        writeChain = writeChain.then(() => writeAtomic(rid, seq, path, data));
       }, PERSIST_DEBOUNCE_MS);
       // Don't keep the process alive just for a pending progress write.
       if (typeof (timer as { unref?: () => void }).unref === "function") {
@@ -194,6 +221,8 @@ export function createRunPersistence(cwd: string): RunPersistence {
     },
 
     delete(runId: string): boolean {
+      cancelPending(runId);
+      committedSeq.delete(runId);
       try {
         const path = runPath(runId);
         if (existsSync(path)) {

--- a/users/profiles/pi/extensions/dynamic-workflows/src/run-persistence.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/run-persistence.ts
@@ -2,8 +2,8 @@
  * Workflow run state persistence for pause/resume support.
  */
 
-import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
-import { writeFile } from "node:fs/promises";
+import { existsSync, mkdirSync, readdirSync, readFileSync, renameSync, unlinkSync, writeFileSync } from "node:fs";
+import { rename, unlink, writeFile } from "node:fs/promises";
 import { join } from "node:path";
 import { WORKFLOW_RUNS_DIR } from "./config.ts";
 import { assertInside, assertSafeName } from "./fs-safety.ts";
@@ -88,6 +88,39 @@ export function createRunPersistence(cwd: string): RunPersistence {
   // under runsDir, so an externally-supplied runId can't escape via `../`.
   const runPath = (runId: string) => assertInside(runsDir, join(runsDir, `${assertSafeName(runId)}.json`));
 
+  // Atomic write: a crash mid-write must never leave a truncated `${runId}.json`
+  // (which list() would drop and load() would silently discard). Write a uniquely
+  // named temp in the same dir, then rename into place (atomic on POSIX). The temp
+  // ends in `.tmp`, so list()'s `.json` filter ignores any orphan. The pid+seq
+  // suffix keeps a sync save() and an in-flight async write from sharing a temp.
+  let tmpSeq = 0;
+  const tmpPath = (path: string) => `${path}.${process.pid}.${tmpSeq++}.tmp`;
+
+  const writeAtomicSync = (path: string, data: string) => {
+    const tmp = tmpPath(path);
+    try {
+      writeFileSync(tmp, data);
+      renameSync(tmp, path);
+    } catch (err) {
+      try {
+        if (existsSync(tmp)) unlinkSync(tmp);
+      } catch {
+        // best-effort temp cleanup
+      }
+      throw err;
+    }
+  };
+
+  const writeAtomic = async (path: string, data: string) => {
+    const tmp = tmpPath(path);
+    try {
+      await writeFile(tmp, data);
+      await rename(tmp, path);
+    } catch {
+      await unlink(tmp).catch(() => {});
+    }
+  };
+
   // Debounced async-write state for scheduleSave(). One pending state + one timer
   // per run; writes are serialized through a chain so they never interleave.
   const pending = new Map<string, PersistedRunState>();
@@ -109,7 +142,7 @@ export function createRunPersistence(cwd: string): RunPersistence {
       cancelPending(state.runId);
       ensureDir();
       state.updatedAt = new Date().toISOString();
-      writeFileSync(runPath(state.runId), JSON.stringify(state));
+      writeAtomicSync(runPath(state.runId), JSON.stringify(state));
     },
 
     scheduleSave(state: PersistedRunState) {
@@ -122,9 +155,7 @@ export function createRunPersistence(cwd: string): RunPersistence {
         pending.delete(state.runId);
         ensureDir();
         latest.updatedAt = new Date().toISOString();
-        writeChain = writeChain.then(() =>
-          writeFile(runPath(latest.runId), JSON.stringify(latest)).catch(() => {}),
-        );
+        writeChain = writeChain.then(() => writeAtomic(runPath(latest.runId), JSON.stringify(latest)));
       }, PERSIST_DEBOUNCE_MS);
       // Don't keep the process alive just for a pending progress write.
       if (typeof (timer as { unref?: () => void }).unref === "function") {

--- a/users/profiles/pi/extensions/dynamic-workflows/src/run-persistence.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/run-persistence.ts
@@ -1,0 +1,191 @@
+/**
+ * Workflow run state persistence for pause/resume support.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { writeFile } from "node:fs/promises";
+import { join } from "node:path";
+import { WORKFLOW_RUNS_DIR } from "./config.ts";
+import { assertInside, assertSafeName } from "./fs-safety.ts";
+
+/**
+ * Hot-path writes (one per agent completion) are coalesced over this window and
+ * written asynchronously, so a wide fan-out doesn't block Pi's TUI event loop
+ * with synchronous disk I/O. Terminal states use `save()` (sync, durable).
+ */
+const PERSIST_DEBOUNCE_MS = 250;
+
+export type RunStatus = "pending" | "running" | "paused" | "completed" | "failed" | "aborted";
+
+export interface PersistedAgentState {
+  id: number;
+  label: string;
+  phase?: string;
+  prompt: string;
+  status: "queued" | "running" | "done" | "error" | "skipped";
+  result?: unknown;
+  error?: string;
+  startedAt?: string;
+  endedAt?: string;
+  /** The model this agent ran on (provider/id), when known. */
+  model?: string;
+}
+
+export interface PersistedRunState {
+  runId: string;
+  workflowName: string;
+  script: string;
+  args?: unknown;
+  status: RunStatus;
+  phases: string[];
+  currentPhase?: string;
+  agents: PersistedAgentState[];
+  logs: string[];
+  result?: unknown;
+  startedAt: string;
+  updatedAt: string;
+  completedAt?: string;
+  durationMs?: number;
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+  };
+  /** Cached agent results for resume, keyed by deterministic call index. */
+  journal?: Array<{ index: number; hash: string; result: unknown }>;
+}
+
+export interface RunPersistence {
+  /** Save current run state immediately and synchronously (durable across exit). */
+  save(state: PersistedRunState): void;
+  /**
+   * Coalesced, asynchronous save for the hot path (per-agent progress). Multiple
+   * calls within PERSIST_DEBOUNCE_MS collapse into one non-blocking write. Pass
+   * the latest full state each time; the most recent wins. A subsequent `save()`
+   * supersedes any pending scheduled write for the same run.
+   */
+  scheduleSave(state: PersistedRunState): void;
+  /** Load a persisted run by ID. */
+  load(runId: string): PersistedRunState | null;
+  /** List all persisted runs. */
+  list(): PersistedRunState[];
+  /** Delete a persisted run. */
+  delete(runId: string): boolean;
+  /** Get runs directory path. */
+  getRunsDir(): string;
+}
+
+export function createRunPersistence(cwd: string): RunPersistence {
+  const runsDir = join(cwd, WORKFLOW_RUNS_DIR);
+
+  const ensureDir = () => {
+    if (!existsSync(runsDir)) {
+      mkdirSync(runsDir, { recursive: true });
+    }
+  };
+
+  // Validate the ID (generateRunId() output passes) and confirm the path stays
+  // under runsDir, so an externally-supplied runId can't escape via `../`.
+  const runPath = (runId: string) => assertInside(runsDir, join(runsDir, `${assertSafeName(runId)}.json`));
+
+  // Debounced async-write state for scheduleSave(). One pending state + one timer
+  // per run; writes are serialized through a chain so they never interleave.
+  const pending = new Map<string, PersistedRunState>();
+  const timers = new Map<string, ReturnType<typeof setTimeout>>();
+  let writeChain: Promise<void> = Promise.resolve();
+
+  const cancelPending = (runId: string) => {
+    const timer = timers.get(runId);
+    if (timer) {
+      clearTimeout(timer);
+      timers.delete(runId);
+    }
+    pending.delete(runId);
+  };
+
+  return {
+    save(state: PersistedRunState) {
+      // A durable write supersedes any pending debounced write for this run.
+      cancelPending(state.runId);
+      ensureDir();
+      state.updatedAt = new Date().toISOString();
+      writeFileSync(runPath(state.runId), JSON.stringify(state));
+    },
+
+    scheduleSave(state: PersistedRunState) {
+      pending.set(state.runId, state);
+      if (timers.has(state.runId)) return;
+      const timer = setTimeout(() => {
+        timers.delete(state.runId);
+        const latest = pending.get(state.runId);
+        if (!latest) return;
+        pending.delete(state.runId);
+        ensureDir();
+        latest.updatedAt = new Date().toISOString();
+        writeChain = writeChain.then(() =>
+          writeFile(runPath(latest.runId), JSON.stringify(latest)).catch(() => {}),
+        );
+      }, PERSIST_DEBOUNCE_MS);
+      // Don't keep the process alive just for a pending progress write.
+      if (typeof (timer as { unref?: () => void }).unref === "function") {
+        (timer as { unref: () => void }).unref();
+      }
+      timers.set(state.runId, timer);
+    },
+
+    load(runId: string): PersistedRunState | null {
+      try {
+        const path = runPath(runId);
+        if (!existsSync(path)) return null;
+        return JSON.parse(readFileSync(path, "utf-8")) as PersistedRunState;
+      } catch {
+        return null;
+      }
+    },
+
+    list(): PersistedRunState[] {
+      ensureDir();
+      try {
+        const files = readdirSync(runsDir).filter((f) => f.endsWith(".json"));
+        const runs: PersistedRunState[] = [];
+        for (const file of files) {
+          try {
+            const state = JSON.parse(readFileSync(join(runsDir, file), "utf-8")) as PersistedRunState;
+            runs.push(state);
+          } catch {
+            // Skip corrupted files
+          }
+        }
+        return runs.sort((a, b) => new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime());
+      } catch {
+        return [];
+      }
+    },
+
+    delete(runId: string): boolean {
+      try {
+        const path = runPath(runId);
+        if (existsSync(path)) {
+          unlinkSync(path);
+          return true;
+        }
+        return false;
+      } catch {
+        return false;
+      }
+    },
+
+    getRunsDir(): string {
+      return runsDir;
+    },
+  };
+}
+
+/**
+ * Generate a unique run ID.
+ */
+export function generateRunId(): string {
+  const timestamp = Date.now().toString(36);
+  const random = Math.random().toString(36).slice(2, 8);
+  return `${timestamp}-${random}`;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/saved-commands.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/saved-commands.ts
@@ -1,0 +1,71 @@
+/**
+ * Saved workflows as `/<name>` slash commands. Each saved workflow becomes a
+ * command that runs its script, passing parsed arguments through as `args`.
+ */
+
+import { createCodingTools, type ExtensionAPI, type ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { runWorkflow, type WorkflowRunResult } from "./workflow.ts";
+import type { SavedWorkflow, WorkflowStorage } from "./workflow-saved.ts";
+
+function isRegistered(pi: ExtensionAPI, name: string): boolean {
+  try {
+    return (pi.getCommands?.() ?? []).some((c: { name: string }) => c.name === name);
+  } catch {
+    return false;
+  }
+}
+
+function reportText(result: WorkflowRunResult): string {
+  const r = result.result as { report?: unknown } | undefined;
+  if (r && typeof r.report === "string" && r.report.trim()) return r.report;
+  return JSON.stringify(result.result, null, 2);
+}
+
+/**
+ * Parse a command argument string into an `args` object for the script.
+ * Supports `key=value` tokens; everything else collects into `_` (and `_raw`).
+ * Declared parameter defaults fill in missing keys.
+ */
+export function parseCommandArgs(raw: string, parameters?: SavedWorkflow["parameters"]): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  const positional: string[] = [];
+  for (const tok of raw.trim().split(/\s+/).filter(Boolean)) {
+    const eq = tok.indexOf("=");
+    if (eq > 0) out[tok.slice(0, eq)] = tok.slice(eq + 1);
+    else positional.push(tok);
+  }
+  out._ = positional.join(" ");
+  out._raw = raw.trim();
+  for (const [key, spec] of Object.entries(parameters ?? {})) {
+    if (out[key] === undefined && spec.default !== undefined) out[key] = spec.default;
+  }
+  return out;
+}
+
+/** Register one saved workflow as a `/<name>` command (idempotent). */
+export function registerSavedWorkflow(pi: ExtensionAPI, cwd: string, wf: SavedWorkflow): void {
+  if (isRegistered(pi, wf.name)) return;
+  pi.registerCommand(wf.name, {
+    description: wf.description || `Saved workflow: ${wf.name}`,
+    async handler(args: string, ctx: ExtensionCommandContext) {
+      try {
+        const result = await runWorkflow(wf.script, {
+          cwd,
+          args: parseCommandArgs(args, wf.parameters),
+          tools: createCodingTools(cwd),
+          onPhase: (title) => ctx.ui.setStatus(`wf:${wf.name}`, `${wf.name}: ${title}`),
+        });
+        ctx.ui.setStatus(`wf:${wf.name}`, undefined);
+        await pi.sendMessage({ customType: `workflow:${wf.name}`, content: reportText(result), display: true });
+      } catch (error) {
+        ctx.ui.setStatus(`wf:${wf.name}`, undefined);
+        ctx.ui.notify(`/${wf.name} failed: ${error instanceof Error ? error.message : error}`, "error");
+      }
+    },
+  });
+}
+
+/** Register every saved workflow found in storage. */
+export function registerAllSavedWorkflows(pi: ExtensionAPI, cwd: string, storage: WorkflowStorage): void {
+  for (const wf of storage.list()) registerSavedWorkflow(pi, cwd, wf);
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/structured-output.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/structured-output.ts
@@ -1,0 +1,47 @@
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import type { Static, TSchema } from "typebox";
+
+export interface StructuredOutputCapture<T = unknown> {
+  value: T | undefined;
+  called: boolean;
+}
+
+export interface StructuredOutputToolOptions<TSchemaDef extends TSchema> {
+  schema: TSchemaDef;
+  capture: StructuredOutputCapture<Static<TSchemaDef>>;
+  name?: string;
+}
+
+/**
+ * Create a terminating tool that captures validated params as the subagent result.
+ *
+ * Pi validates `params` against `schema` before execute() is called. Returning
+ * `terminate: true` lets the subagent finish on this tool call without paying for
+ * an extra assistant follow-up turn.
+ */
+export function createStructuredOutputTool<TSchemaDef extends TSchema>({
+  schema,
+  capture,
+  name = "structured_output",
+}: StructuredOutputToolOptions<TSchemaDef>): ToolDefinition<TSchemaDef, Static<TSchemaDef>> {
+  return defineTool({
+    name,
+    label: "Structured Output",
+    description: "Return the final machine-readable result for this subagent task.",
+    promptSnippet: "Return final machine-readable output",
+    promptGuidelines: [
+      `${name} is the final answer channel for this task; call ${name} exactly once when done.`,
+      `Do not write a prose final answer after calling ${name}.`,
+    ],
+    parameters: schema,
+    async execute(_toolCallId, params) {
+      capture.value = params;
+      capture.called = true;
+      return {
+        content: [{ type: "text", text: "Structured output received." }],
+        details: params,
+        terminate: true,
+      };
+    },
+  });
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/task-panel.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/task-panel.ts
@@ -1,0 +1,123 @@
+/**
+ * Background-run UX, mirroring Claude Code:
+ *  - A live task panel below the input lists in-progress runs while you keep working.
+ *    It is informational; run /workflows to open the full navigator.
+ *  - When a background run finishes, its result is delivered back into the
+ *    conversation so the paused task continues with the outcome.
+ */
+
+import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { framePanel } from "./panel-box.ts";
+import { profile } from "./profiler.ts";
+import type { ManagedRun, WorkflowManager } from "./workflow-manager.ts";
+import type { WorkflowStorage } from "./workflow-saved.ts";
+
+const RUN_EVENTS = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
+
+export interface TaskPanelOptions {
+  storage?: WorkflowStorage;
+  cwd?: string;
+}
+
+function deliverText(run: ManagedRun): string {
+  const r = run.result?.result as { report?: unknown } | undefined;
+  const body =
+    r && typeof r.report === "string" && r.report.trim() ? r.report : JSON.stringify(run.result?.result, null, 2);
+  const tokens = run.result?.tokenUsage ? ` · ${run.result.tokenUsage.total.toLocaleString()} tokens` : "";
+  const agents = run.result?.agentCount ?? run.snapshot.agentCount;
+  return [
+    `✓ Background workflow "${run.snapshot.name}" finished (${agents} agents${tokens}).`,
+    "Continue helping the user based on this result.",
+    "",
+    body,
+  ].join("\n");
+}
+
+/**
+ * When a background run finishes (or fails), deliver its result back into the
+ * conversation AND continue the turn so the assistant can act on it — without
+ * blocking the user meanwhile:
+ *
+ *  - `triggerTurn: true` starts a fresh turn when the agent is idle, feeding the
+ *    result to the model so the paused conversation continues.
+ *  - `deliverAs: "followUp"` means that if the user is busy in another turn, the
+ *    result is queued and picked up after that turn finishes — never interrupting.
+ *
+ * Set up once per extension; idempotent via an internal guard.
+ */
+export function installResultDelivery(pi: ExtensionAPI, manager: WorkflowManager): void {
+  if ((manager as unknown as { __deliveryInstalled?: boolean }).__deliveryInstalled) return;
+  (manager as unknown as { __deliveryInstalled?: boolean }).__deliveryInstalled = true;
+
+  const deliver = (content: string) => {
+    void pi.sendMessage(
+      { customType: "workflow-result", content, display: true },
+      { triggerTurn: true, deliverAs: "followUp" },
+    );
+  };
+
+  manager.on("complete", ({ runId }: { runId: string }) => {
+    const run = manager.getRun(runId);
+    // Only background/resumed runs are delivered: a foreground (sync) run already
+    // returns its result inline as the tool result, so re-delivering would dup it.
+    if (run?.background) deliver(deliverText(run));
+  });
+  manager.on("error", ({ runId, error }: { runId: string; error?: { message?: string } }) => {
+    if (!manager.getRun(runId)?.background) return;
+    deliver(`✗ Background workflow ${runId} failed: ${error?.message ?? "unknown error"}`);
+  });
+}
+
+/**
+ * Build the framed live panel. Returns [] when nothing is running so the widget
+ * collapses. The frame is background-filled (see panel-box) so it stays readable
+ * over a terminal wallpaper; `width` is the viewport width from Component.render.
+ */
+function renderPanel(manager: WorkflowManager, theme: Theme, width: number): string[] {
+  // Serve from the in-memory runs map (listActiveRuns) — NOT listRuns(), which
+  // does readdirSync + a readFileSync per run file on every render and would block
+  // the TUI event loop during a wide fan-out.
+  const active = manager.listActiveRuns();
+  if (!active.length) return [];
+  const rows = active.map((r) => {
+    const agents = r.snapshot.agents;
+    const done = agents.filter((a) => a.status === "done").length;
+    const icon = r.status === "paused" ? theme.fg("warning", "⏸") : theme.fg("accent", "◆");
+    const phase = r.snapshot.currentPhase ? theme.fg("dim", ` · ${r.snapshot.currentPhase}`) : "";
+    return `${icon} ${r.snapshot.name}  ${done}/${agents.length} agents${phase}`;
+  });
+  rows.push(theme.fg("dim", "run /workflows to open"));
+  return framePanel(rows, theme, { title: `Workflows running (${active.length})`, maxWidth: width });
+}
+
+/**
+ * Install the live "workflows running" panel below the editor. Re-rendered on
+ * every manager event. Informational only — the user opens the navigator with
+ * /workflows. (`_pi`/`_opts` are kept for signature stability.)
+ */
+export function installTaskPanel(
+  _pi: ExtensionAPI,
+  manager: WorkflowManager,
+  ui: ExtensionUIContext,
+  _opts: TaskPanelOptions = {},
+): void {
+  ui.setWidget(
+    "workflow-tasks",
+    (tui: TUI, theme: Theme) => {
+      const onEvent = () => tui.requestRender();
+      for (const ev of RUN_EVENTS) manager.on(ev, onEvent);
+      // Purely informational: it lists running runs and re-renders on events. To
+      // open the navigator, the user runs /workflows (the panel takes no input).
+      const comp: Component & { dispose?(): void } = {
+        render: (width: number) => profile("render:taskpanel", () => renderPanel(manager, theme, width)),
+        invalidate: () => {},
+        dispose: () => {
+          for (const ev of RUN_EVENTS) manager.off(ev, onEvent);
+        },
+      };
+      return comp;
+    },
+    { placement: "belowEditor" },
+  );
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/task-panel.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/task-panel.ts
@@ -75,20 +75,27 @@ export function installResultDelivery(pi: ExtensionAPI, manager: WorkflowManager
  * over a terminal wallpaper; `width` is the viewport width from Component.render.
  */
 function renderPanel(manager: WorkflowManager, theme: Theme, width: number): string[] {
-  // Serve from the in-memory runs map (listActiveRuns) — NOT listRuns(), which
-  // does readdirSync + a readFileSync per run file on every render and would block
-  // the TUI event loop during a wide fan-out.
-  const active = manager.listActiveRuns();
-  if (!active.length) return [];
-  const rows = active.map((r) => {
-    const agents = r.snapshot.agents;
-    const done = agents.filter((a) => a.status === "done").length;
-    const icon = r.status === "paused" ? theme.fg("warning", "⏸") : theme.fg("accent", "◆");
-    const phase = r.snapshot.currentPhase ? theme.fg("dim", ` · ${r.snapshot.currentPhase}`) : "";
-    return `${icon} ${r.snapshot.name}  ${done}/${agents.length} agents${phase}`;
-  });
-  rows.push(theme.fg("dim", "run /workflows to open"));
-  return framePanel(rows, theme, { title: `Workflows running (${active.length})`, maxWidth: width });
+  // This runs in the TUI render timer: an uncaught throw (e.g. theme.fg on an
+  // unregistered role) would crash Pi, so the whole build — not just framePanel —
+  // degrades to an empty panel on failure.
+  try {
+    // Serve from the in-memory runs map (listActiveRuns) — NOT listRuns(), which
+    // does readdirSync + a readFileSync per run file on every render and would block
+    // the TUI event loop during a wide fan-out.
+    const active = manager.listActiveRuns();
+    if (!active.length) return [];
+    const rows = active.map((r) => {
+      const agents = r.snapshot.agents;
+      const done = agents.filter((a) => a.status === "done").length;
+      const icon = r.status === "paused" ? theme.fg("warning", "⏸") : theme.fg("accent", "◆");
+      const phase = r.snapshot.currentPhase ? theme.fg("dim", ` · ${r.snapshot.currentPhase}`) : "";
+      return `${icon} ${r.snapshot.name}  ${done}/${agents.length} agents${phase}`;
+    });
+    rows.push(theme.fg("dim", "run /workflows to open"));
+    return framePanel(rows, theme, { title: `Workflows running (${active.length})`, maxWidth: width });
+  } catch {
+    return [];
+  }
 }
 
 /**

--- a/users/profiles/pi/extensions/dynamic-workflows/src/web-tools.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/web-tools.ts
@@ -1,0 +1,217 @@
+/**
+ * Real web tools for research workflows. These execute in the extension host
+ * process (which has network access), not in a subagent sandbox, so they perform
+ * genuine HTTP requests via Node's fetch.
+ *
+ * - web_search: Exa (api.exa.ai) when an EXA_API_KEY / ~/.pi/web-search.json key
+ *   is configured (the same key the pi-web-access extension uses), else a
+ *   best-effort Bing HTML scrape. Returns result {url, title}.
+ * - web_fetch:  fetch a URL and return readable text (HTML stripped, truncated)
+ *
+ * Subagents run extension-free (agent.ts noExtensions), so they can't reach the
+ * pi-web-access tools; this reuses its key/endpoint without loading it.
+ */
+
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Type } from "typebox";
+
+const UA =
+  "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
+
+async function fetchText(url: string, timeoutMs = 15000): Promise<{ status: number; body: string }> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch(url, { headers: { "user-agent": UA }, signal: controller.signal, redirect: "follow" });
+    return { status: res.status, body: await res.text() };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<script[\s\S]*?<\/script>/gi, " ")
+    .replace(/<style[\s\S]*?<\/style>/gi, " ")
+    .replace(/<\/(p|div|li|h[1-6]|tr|br)>/gi, "\n")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&amp;/g, "&")
+    .replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">")
+    .replace(/&#39;|&apos;/g, "'")
+    .replace(/&quot;/g, '"')
+    .replace(/[ \t]+/g, " ")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+function parseBingResults(html: string, limit: number): Array<{ url: string; title: string }> {
+  const out: Array<{ url: string; title: string }> = [];
+  const seen = new Set<string>();
+  for (const m of html.matchAll(/<h2[^>]*>\s*<a[^>]+href="(https?:\/\/[^"]+)"[^>]*>([\s\S]*?)<\/a>/g)) {
+    const url = m[1];
+    if (/\.bing\.com|go\.microsoft\.com/.test(url) || seen.has(url)) continue;
+    seen.add(url);
+    out.push({ url, title: m[2].replace(/<[^>]+>/g, "").trim() });
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+/**
+ * Exa API key, from the same sources pi-web-access reads: the EXA_API_KEY env
+ * var, else ~/.pi/web-search.json's `exaApiKey`. Read on demand (cheap, and these
+ * tools run in the host, not the TUI render path).
+ */
+function getExaApiKey(): string | undefined {
+  const fromEnv = process.env.EXA_API_KEY?.trim();
+  if (fromEnv) return fromEnv;
+  try {
+    const path = join(homedir(), ".pi", "web-search.json");
+    if (existsSync(path)) {
+      const cfg = JSON.parse(readFileSync(path, "utf-8")) as { exaApiKey?: unknown };
+      if (typeof cfg.exaApiKey === "string" && cfg.exaApiKey.trim()) return cfg.exaApiKey.trim();
+    }
+  } catch {
+    // Malformed/unreadable config -> behave as if no key (fall back to Bing).
+  }
+  return undefined;
+}
+
+/** Search via Exa's REST API. Throws on transport/HTTP error so the caller can fall back. */
+async function searchExa(
+  apiKey: string,
+  query: string,
+  limit: number,
+  timeoutMs = 15000,
+): Promise<Array<{ url: string; title: string }>> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  try {
+    const res = await fetch("https://api.exa.ai/search", {
+      method: "POST",
+      headers: { "x-api-key": apiKey, "content-type": "application/json" },
+      body: JSON.stringify({ query, type: "auto", numResults: limit, contents: { highlights: true } }),
+      signal: controller.signal,
+    });
+    if (!res.ok) throw new Error(`Exa API ${res.status}: ${(await res.text()).slice(0, 200)}`);
+    const data = (await res.json()) as { results?: Array<{ url?: string; title?: string }> };
+    const out: Array<{ url: string; title: string }> = [];
+    for (const r of data.results ?? []) {
+      if (!r?.url) continue;
+      out.push({ url: r.url, title: (r.title || r.url).trim() });
+    }
+    return out;
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+async function searchBing(query: string, limit: number): Promise<Array<{ url: string; title: string }>> {
+  const { body } = await fetchText(`https://www.bing.com/search?q=${encodeURIComponent(query)}`);
+  return parseBingResults(body, limit);
+}
+
+const formatResults = (results: Array<{ url: string; title: string }>): string =>
+  results.map((r, i) => `${i + 1}. ${r.title}\n   ${r.url}`).join("\n");
+
+/** Optional hooks for the web tools. `log` records which search backend ran. */
+export interface WebToolsOptions {
+  log?: (message: string) => void;
+  maxChars?: number;
+}
+
+/** A tool that searches the web and returns result URLs + titles (Exa, else Bing). */
+export function createWebSearchTool(opts: Pick<WebToolsOptions, "log"> = {}): ToolDefinition {
+  return defineTool({
+    name: "web_search",
+    label: "Web Search",
+    description: "Search the web and return a list of result URLs and titles. Use before web_fetch to find sources.",
+    promptSnippet: "Search the web for sources",
+    parameters: Type.Object({
+      query: Type.String({ description: "The search query." }),
+      count: Type.Optional(Type.Number({ description: "Max results (default 6)." })),
+    }),
+    async execute(_id, params: { query: string; count?: number }) {
+      const limit = Math.min(Math.max(params.count ?? 6, 1), 10);
+      const apiKey = getExaApiKey();
+      const breadcrumb = (source: string, n: number | string) =>
+        opts.log?.(`web_search[${source}] ${JSON.stringify(params.query)} → ${n}`);
+
+      // Prefer Exa when configured; on empty/failed Exa, fall back to Bing.
+      if (apiKey) {
+        try {
+          const results = await searchExa(apiKey, params.query, limit);
+          if (results.length) {
+            breadcrumb("exa", results.length);
+            return { content: [{ type: "text", text: formatResults(results) }], details: { results, source: "exa" } };
+          }
+        } catch {
+          // Fall through to Bing rather than hard-failing the search.
+        }
+      }
+
+      try {
+        const results = await searchBing(params.query, limit);
+        breadcrumb("bing", results.length);
+        const text = results.length
+          ? formatResults(results)
+          : "No results parsed. Try a different query or fetch a known URL directly.";
+        return { content: [{ type: "text", text }], details: { results, source: "bing" } };
+      } catch (error) {
+        breadcrumb("none", "failed");
+        return {
+          content: [{ type: "text", text: `web_search failed: ${error instanceof Error ? error.message : error}` }],
+          details: { results: [] as Array<{ url: string; title: string }>, source: "none" },
+        };
+      }
+    },
+  }) as unknown as ToolDefinition;
+}
+
+/** A tool that fetches a URL and returns readable text. */
+export function createWebFetchTool(maxChars = 6000): ToolDefinition {
+  return defineTool({
+    name: "web_fetch",
+    label: "Web Fetch",
+    description: "Fetch a URL and return its readable text content (HTML stripped, truncated).",
+    promptSnippet: "Fetch a URL's text",
+    parameters: Type.Object({
+      url: Type.String({ description: "The absolute URL to fetch." }),
+    }),
+    async execute(_id, params: { url: string }) {
+      try {
+        const { status, body } = await fetchText(params.url);
+        const full = htmlToText(body);
+        const truncated = full.length > maxChars;
+        const text = truncated ? full.slice(0, maxChars) : full;
+        const notice = truncated
+          ? `\n\n[truncated: showing ${maxChars} of ${full.length} chars — fetch a more specific URL/section for the rest]`
+          : "";
+        return {
+          content: [{ type: "text", text: `HTTP ${status} ${params.url}\n\n${text}${notice}` }],
+          details: { status, url: params.url, truncated, totalChars: full.length },
+        };
+      } catch (error) {
+        return {
+          content: [
+            {
+              type: "text",
+              text: `web_fetch failed for ${params.url}: ${error instanceof Error ? error.message : error}`,
+            },
+          ],
+          details: { status: 0, url: params.url },
+        };
+      }
+    },
+  }) as unknown as ToolDefinition;
+}
+
+/** Both web tools, for injecting into a research workflow's agents. */
+export function createWebTools(opts: WebToolsOptions = {}): ToolDefinition[] {
+  return [createWebSearchTool({ log: opts.log }), createWebFetchTool(opts.maxChars)];
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/web-tools.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/web-tools.ts
@@ -21,12 +21,39 @@ import { Type } from "typebox";
 const UA =
   "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36";
 
-async function fetchText(url: string, timeoutMs = 15000): Promise<{ status: number; body: string }> {
+// Hard cap on the bytes we read from any fetched body. Stripped/truncated to
+// `maxChars` afterwards anyway; this bounds memory so a huge or slow-drip
+// response can't be fully buffered into the shared host process (OOM/stall).
+const MAX_FETCH_BYTES = 2 * 1024 * 1024;
+
+async function fetchText(
+  url: string,
+  timeoutMs = 15000,
+  maxBytes = MAX_FETCH_BYTES,
+): Promise<{ status: number; body: string }> {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
   try {
     const res = await fetch(url, { headers: { "user-agent": UA }, signal: controller.signal, redirect: "follow" });
-    return { status: res.status, body: await res.text() };
+    if (!res.body) return { status: res.status, body: await res.text() };
+    // Read incrementally and stop once we've seen maxBytes, so the rest of the
+    // transfer is cancelled rather than buffered.
+    const reader = res.body.getReader();
+    const decoder = new TextDecoder();
+    let body = "";
+    let total = 0;
+    try {
+      while (total < maxBytes) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        total += value.byteLength;
+        body += decoder.decode(value, { stream: true });
+      }
+      body += decoder.decode();
+    } finally {
+      await reader.cancel().catch(() => {});
+    }
+    return { status: res.status, body };
   } finally {
     clearTimeout(timer);
   }

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-commands.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-commands.ts
@@ -1,0 +1,226 @@
+/**
+ * `/workflows` slash command: list, inspect, and control background workflow runs.
+ * Shares the extension's single WorkflowManager so background runs are reachable.
+ */
+
+import type { ExtensionAPI, ExtensionCommandContext } from "@earendil-works/pi-coding-agent";
+import { recomputeWorkflowSnapshot, renderWorkflowText, type WorkflowSnapshot } from "./display.ts";
+import type { PersistedRunState } from "./run-persistence.ts";
+import { registerSavedWorkflow } from "./saved-commands.ts";
+import type { WorkflowManager } from "./workflow-manager.ts";
+import type { WorkflowStorage } from "./workflow-saved.ts";
+import { openWorkflowNavigator } from "./workflow-ui.ts";
+
+const STATUS_ICON: Record<string, string> = {
+  pending: "·",
+  running: "◆",
+  paused: "⏸",
+  completed: "✓",
+  failed: "✗",
+  aborted: "⊘",
+};
+
+const USAGE =
+  "Usage: /workflows [list] | status <id> | watch <id> | stop <id> | pause <id> | resume <id> | rm <id> | save <name> [runId]";
+
+function summarizeRun(run: PersistedRunState): string {
+  const icon = STATUS_ICON[run.status] ?? "?";
+  const done = run.agents.filter((a) => a.status === "done").length;
+  const total = run.agents.length;
+  const tokens = run.tokenUsage ? ` · ${run.tokenUsage.total.toLocaleString()} tok` : "";
+  return `${icon} ${run.runId}  ${run.workflowName} [${run.status}] ${done}/${total} agents${tokens}`;
+}
+
+function oneLineProgress(snapshot: WorkflowSnapshot): string {
+  const total = snapshot.agents.length;
+  const done = snapshot.agents.filter((a) => a.status === "done").length;
+  const running = snapshot.agents.filter((a) => a.status === "running").length;
+  const errs = snapshot.agents.filter((a) => a.status === "error").length;
+  const phase = snapshot.currentPhase ? ` · ${snapshot.currentPhase}` : "";
+  return `◆ ${snapshot.name}: ${done}/${total} done${running ? `, ${running} running` : ""}${
+    errs ? `, ${errs} err` : ""
+  }${phase}`;
+}
+
+/**
+ * Subscribe to a running run's events and stream live progress to the status bar,
+ * printing the final snapshot when it finishes. Non-blocking: returns true if the
+ * run was active and is now being watched, false otherwise. Listeners clean up on
+ * completion so nothing leaks.
+ */
+function watchRun(manager: WorkflowManager, pi: ExtensionAPI, ctx: ExtensionCommandContext, id: string): boolean {
+  const active = manager.getRun(id);
+  if (!active || active.status !== "running") return false;
+
+  const key = `wf:${id}`;
+  const update = () => {
+    const run = manager.getRun(id);
+    if (run) ctx.ui.setStatus(key, oneLineProgress(run.snapshot));
+  };
+  const onEvent = (e: { runId?: string }) => {
+    if (!e || e.runId === id) update();
+  };
+  let settled = false;
+  const progressEvents = ["agentStart", "agentEnd", "phase", "log"];
+  const finalEvents = ["complete", "error", "stopped", "paused"];
+  const finish = (e: { runId?: string }) => {
+    if (e && e.runId !== id) return;
+    if (settled) return;
+    settled = true;
+    for (const ev of progressEvents) manager.off(ev, onEvent);
+    for (const ev of finalEvents) manager.off(ev, finish);
+    ctx.ui.setStatus(key, undefined);
+    const run = manager.getRun(id);
+    if (run) {
+      void pi.sendMessage({
+        customType: "workflows",
+        content: renderWorkflowText(recomputeWorkflowSnapshot(run.snapshot), true),
+        display: true,
+      });
+    }
+  };
+  for (const ev of progressEvents) manager.on(ev, onEvent);
+  for (const ev of finalEvents) manager.on(ev, finish);
+  update();
+  return true;
+}
+
+function renderPersistedStatus(run: PersistedRunState): string {
+  const lines = [`${STATUS_ICON[run.status] ?? "?"} ${run.workflowName} (${run.runId}) — ${run.status}`];
+  if (run.currentPhase) lines.push(`  phase: ${run.currentPhase}`);
+  for (const agent of run.agents) {
+    const icon =
+      agent.status === "done" ? "✓" : agent.status === "error" ? "✗" : agent.status === "running" ? "◆" : "·";
+    lines.push(`  ${icon} ${agent.label}`);
+  }
+  if (run.tokenUsage) lines.push(`  tokens: ${run.tokenUsage.total.toLocaleString()}`);
+  if (run.durationMs) lines.push(`  duration: ${(run.durationMs / 1000).toFixed(1)}s`);
+  return lines.join("\n");
+}
+
+export interface WorkflowCommandOptions {
+  /** Saved-workflow storage, enabling `/workflows save`. */
+  storage?: WorkflowStorage;
+  /** Working directory for saved workflows registered via `save`. */
+  cwd?: string;
+}
+
+/** Register the `/workflows` command against the shared manager. Idempotent. */
+export function registerWorkflowCommands(
+  pi: ExtensionAPI,
+  manager: WorkflowManager,
+  opts: WorkflowCommandOptions = {},
+): void {
+  try {
+    const taken = (pi.getCommands?.() ?? []).some((c: { name: string }) => c.name === "workflows");
+    if (taken) return;
+  } catch {
+    // getCommands may be unavailable in some hosts; fall through and try to register.
+  }
+
+  pi.registerCommand("workflows", {
+    description: "List and control background workflow runs",
+    async handler(args: string, ctx: ExtensionCommandContext) {
+      const parts = args.trim().split(/\s+/).filter(Boolean);
+      const sub = (parts[0] ?? "list").toLowerCase();
+      const id = parts[1];
+      const print = (text: string) => pi.sendMessage({ customType: "workflows", content: text, display: true });
+
+      switch (sub) {
+        case "ui":
+        case "list": {
+          // Interactive navigator when a UI is available; plain text otherwise
+          // (print/RPC mode) or when the user explicitly asks for `list`.
+          if (sub !== "list" && ctx.hasUI) {
+            await openWorkflowNavigator(pi, manager, ctx.ui, { storage: opts.storage, cwd: opts.cwd });
+            return;
+          }
+          if (parts.length === 0 && ctx.hasUI) {
+            await openWorkflowNavigator(pi, manager, ctx.ui, { storage: opts.storage, cwd: opts.cwd });
+            return;
+          }
+          const runs = manager.listRuns();
+          if (!runs.length) {
+            await print("No workflow runs yet. Start one with a background workflow (background: true).");
+            return;
+          }
+          await print(["Workflow runs:", ...runs.map(summarizeRun), "", USAGE].join("\n"));
+          return;
+        }
+        case "watch":
+        case "status": {
+          if (!id) {
+            ctx.ui.notify(USAGE, "warning");
+            return;
+          }
+          // A running run streams live progress to the status bar and prints the
+          // final snapshot when it finishes — no need to re-run the command.
+          if (watchRun(manager, pi, ctx, id)) {
+            ctx.ui.notify(`Watching ${id} — live progress in the status bar; result prints when it finishes.`, "info");
+            return;
+          }
+          const live = manager.getSnapshot(id);
+          if (live) {
+            await print(renderWorkflowText(recomputeWorkflowSnapshot(live), false));
+            return;
+          }
+          const run = manager.listRuns().find((r) => r.runId === id);
+          if (!run) {
+            ctx.ui.notify(`No workflow run "${id}"`, "error");
+            return;
+          }
+          await print(renderPersistedStatus(run));
+          return;
+        }
+        case "stop": {
+          if (!id) return ctx.ui.notify(USAGE, "warning");
+          ctx.ui.notify(
+            manager.stop(id) ? `Stopped ${id}` : `Cannot stop ${id} (not running)`,
+            manager.getRun(id) ? "info" : "warning",
+          );
+          return;
+        }
+        case "pause": {
+          if (!id) return ctx.ui.notify(USAGE, "warning");
+          ctx.ui.notify(manager.pause(id) ? `Paused ${id}` : `Cannot pause ${id} (not running)`, "info");
+          return;
+        }
+        case "resume": {
+          if (!id) return ctx.ui.notify(USAGE, "warning");
+          const ok = await manager.resume(id);
+          ctx.ui.notify(ok ? `Resumed ${id}` : `Resume not available for ${id} yet`, ok ? "info" : "warning");
+          return;
+        }
+        case "rm": {
+          if (!id) return ctx.ui.notify(USAGE, "warning");
+          ctx.ui.notify(manager.deleteRun(id) ? `Removed ${id}` : `No run ${id}`, "info");
+          return;
+        }
+        case "save": {
+          const name = id;
+          if (!name) return ctx.ui.notify("Usage: /workflows save <name> [runId]", "warning");
+          if (!opts.storage) return ctx.ui.notify("Saving is not available (no storage configured)", "error");
+          const runs = manager.listRuns();
+          const runIdArg = parts[2];
+          // Pick the named run, else the most recent run that still has its script.
+          const run = runIdArg ? runs.find((r) => r.runId === runIdArg) : runs.find((r) => r.script);
+          if (!run?.script) {
+            ctx.ui.notify(runIdArg ? `No run ${runIdArg} with a script` : "No saved run to save", "error");
+            return;
+          }
+          const saved = opts.storage.save({
+            name,
+            description: run.workflowName,
+            script: run.script,
+            location: "project",
+          });
+          registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved);
+          ctx.ui.notify(`Saved /${name} (from ${run.runId})`, "info");
+          return;
+        }
+        default:
+          ctx.ui.notify(`Unknown subcommand "${sub}". ${USAGE}`, "warning");
+      }
+    },
+  });
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-commands.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-commands.ts
@@ -208,14 +208,21 @@ export function registerWorkflowCommands(
             ctx.ui.notify(runIdArg ? `No run ${runIdArg} with a script` : "No saved run to save", "error");
             return;
           }
-          const saved = opts.storage.save({
-            name,
-            description: run.workflowName,
-            script: run.script,
-            location: "project",
-          });
-          registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved);
-          ctx.ui.notify(`Saved /${name} (from ${run.runId})`, "info");
+          // storage.save -> assertSafeName throws for names with spaces/special
+          // chars; surface a friendly error instead of an unhandled command throw
+          // (matches the navigator's save path).
+          try {
+            const saved = opts.storage.save({
+              name,
+              description: run.workflowName,
+              script: run.script,
+              location: "project",
+            });
+            registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved);
+            ctx.ui.notify(`Saved /${name} (from ${run.runId})`, "info");
+          } catch (error) {
+            ctx.ui.notify(`Cannot save workflow: ${error instanceof Error ? error.message : error}`, "error");
+          }
           return;
         }
         default:

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-editor.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-editor.ts
@@ -1,0 +1,326 @@
+/**
+ * "Workflows mode" input affordance, à la a smart input box:
+ *
+ *  - While the editor text contains the word `workflow`/`workflows`, those letters
+ *    render as a flowing rainbow, signalling that submitting will engage a workflow.
+ *  - Pressing Backspace immediately after such a word toggles the highlight OFF
+ *    (the word stays, but turns plain white) — a non-destructive "don't run a
+ *    workflow after all". Re-typing a fresh trigger word turns it back on.
+ *  - When the highlight is ON at submit time, the user's message is transformed to
+ *    instruct Pi to actually run the workflow tool.
+ *
+ * Implementation: we replace the core editor with a thin subclass of the exported
+ * `CustomEditor` (which itself extends pi-tui's `Editor`), overriding only
+ * `render()` (to colorize) and `handleInput()` (for the Backspace toggle). All
+ * other editor behavior — history, autocomplete, paste, undo, multiline — is
+ * inherited untouched.
+ */
+
+import { CustomEditor, type ExtensionAPI, type ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { EditorTheme, TUI } from "@earendil-works/pi-tui";
+import { type AutoWorkflowController, evaluateAutoWorkflow } from "./auto-workflow.ts";
+
+// A trigger is `workflow`/`workflows` (substring, case-insensitive) that is NOT
+// immediately preceded by `/` — so a slash command like `/workflows` or `/workflow`
+// is left alone (not colored, not armed).
+/** Matches a trigger anywhere in the text. */
+const TRIGGER = /(?<!\/)workflows?/i;
+/** Global variant for finding every occurrence to colorize. */
+const TRIGGER_G = /(?<!\/)workflows?/gi;
+/** True when the text immediately before the cursor ends with a trigger word. */
+const TRIGGER_AT_END = /(?<!\/)workflows?$/i;
+
+/** 256-color ring cycling through the spectrum — shifted by a tick to "flow". */
+export const RAINBOW = [
+  196, 160, 202, 166, 208, 172, 214, 178, 220, 184, 226, 190, 118, 82, 46, 47, 48, 49, 50, 51, 45, 39, 33, 27, 21, 57,
+  93, 129, 165, 201, 198, 197,
+];
+
+export function hasTrigger(text: string): boolean {
+  return TRIGGER.test(text);
+}
+
+export function endsWithTrigger(textBeforeCursor: string): boolean {
+  return TRIGGER_AT_END.test(textBeforeCursor);
+}
+
+/** Shared, mutable view of whether "workflows mode" is currently armed. */
+export interface WorkflowModeState {
+  active: boolean;
+}
+
+interface AnsiToken {
+  esc?: string;
+  ch?: string;
+}
+
+/**
+ * Split a rendered line into ANSI-escape tokens (passed through verbatim) and
+ * single visible-character tokens. Handles CSI sequences (`\x1b[…m`, e.g. the
+ * cursor's inverse-video) and APC/OSC string sequences (e.g. the zero-width
+ * `CURSOR_MARKER` = `\x1b_pi:c\x07`) so colorization never corrupts them.
+ */
+export function tokenizeAnsi(line: string): AnsiToken[] {
+  const tokens: AnsiToken[] = [];
+  let i = 0;
+  while (i < line.length) {
+    if (line[i] === "\x1b") {
+      let j = i + 1;
+      const next = line[j];
+      if (next === "[") {
+        // CSI: ends at a final byte in 0x40–0x7e.
+        j++;
+        while (j < line.length && !(line[j] >= "@" && line[j] <= "~")) j++;
+        j++;
+      } else if (next === "]" || next === "_" || next === "P" || next === "^") {
+        // String sequence: ends at BEL (\x07) or ST (\x1b\\).
+        j++;
+        while (j < line.length && line[j] !== "\x07" && !(line[j] === "\x1b" && line[j + 1] === "\\")) j++;
+        if (line[j] === "\x07") j++;
+        else if (line[j] === "\x1b") j += 2;
+      } else {
+        j++; // lone ESC + one byte
+      }
+      tokens.push({ esc: line.slice(i, j) });
+      i = j;
+    } else {
+      tokens.push({ ch: line[i] });
+      i++;
+    }
+  }
+  return tokens;
+}
+
+/**
+ * Colorize every `workflow`/`workflows` occurrence in a rendered line with a
+ * flowing rainbow, leaving all ANSI escapes (cursor, markers) intact. Returns the
+ * line unchanged when it contains no trigger.
+ */
+export function colorizeWorkflow(line: string, tick: number, palette: number[] = RAINBOW): string {
+  const tokens = tokenizeAnsi(line);
+  const visible = tokens
+    .filter((t) => t.ch !== undefined)
+    .map((t) => t.ch)
+    .join("");
+  if (!TRIGGER.test(visible)) return line;
+
+  const ranges: Array<[number, number]> = [];
+  TRIGGER_G.lastIndex = 0;
+  for (let m = TRIGGER_G.exec(visible); m; m = TRIGGER_G.exec(visible)) {
+    ranges.push([m.index, m.index + m[0].length]);
+  }
+  const inRange = (idx: number) => ranges.some(([s, e]) => idx >= s && idx < e);
+
+  let out = "";
+  let vi = 0;
+  for (const t of tokens) {
+    if (t.esc !== undefined) {
+      out += t.esc;
+      continue;
+    }
+    if (inRange(vi)) {
+      const color = palette[(vi + tick) % palette.length];
+      // Reset only the foreground (39) afterwards so a surrounding inverse-video
+      // (the cursor) is preserved.
+      out += `\x1b[38;5;${color}m${t.ch}\x1b[39m`;
+    } else {
+      out += t.ch ?? "";
+    }
+    vi++;
+  }
+  return out;
+}
+
+/** Backspace arrives as DEL (0x7f) or BS (0x08) depending on the terminal. */
+function isBackspace(data: string): boolean {
+  return data === "\x7f" || data === "\b";
+}
+
+/**
+ * Editor that paints the trigger words and owns the on/off toggle. Reads/writes
+ * `state.active` so the extension's `input` handler can decide whether to force a
+ * workflow at submit time.
+ */
+export class WorkflowEditor extends CustomEditor {
+  private tick = 0;
+  private timer?: ReturnType<typeof setInterval>;
+  /** Toggled off by Backspace-after-word; re-armed when a fresh trigger appears. */
+  private disabled = false;
+  private wasTriggered = false;
+
+  constructor(
+    tui: TUI,
+    theme: EditorTheme,
+    keybindings: ConstructorParameters<typeof CustomEditor>[2],
+    private readonly modeState: WorkflowModeState,
+  ) {
+    super(tui, theme, keybindings);
+  }
+
+  /** Highlighted/armed: a trigger is present and the user hasn't toggled it off. */
+  isActive(): boolean {
+    return !this.disabled && hasTrigger(this.getText());
+  }
+
+  override handleInput(data: string): void {
+    // First Backspace right after a trigger word disarms (non-destructive).
+    if (isBackspace(data) && this.isActive() && this.cursorAfterTrigger()) {
+      this.disabled = true;
+      this.syncState();
+      this.tui.requestRender();
+      return;
+    }
+    const before = this.getText();
+    super.handleInput(data);
+    const after = this.getText();
+    if (after !== before) {
+      const now = hasTrigger(after);
+      // A freshly typed trigger re-arms a previously disabled box.
+      if (now && !this.wasTriggered) this.disabled = false;
+      this.wasTriggered = now;
+    }
+    this.syncState();
+  }
+
+  override render(width: number): string[] {
+    const lines = super.render(width);
+    // Keep the shared state current even for non-keystroke changes (history
+    // recall, programmatic setText) so the submit hook reads the right value.
+    this.syncState();
+    this.reconcileAnimation();
+    if (!this.isActive() || lines.length === 0) return lines;
+    // First and last lines are the editor's horizontal borders; only the text
+    // lines in between are colorized.
+    return lines.map((ln, i) => (i === 0 || i === lines.length - 1 ? ln : colorizeWorkflow(ln, this.tick)));
+  }
+
+  /** Absolute text before the cursor, used to detect "right after the word". */
+  private cursorAfterTrigger(): boolean {
+    const lines = this.getLines();
+    const { line, col } = this.getCursor();
+    const before = lines.slice(0, line).join("\n") + (line > 0 ? "\n" : "") + (lines[line] ?? "").slice(0, col);
+    return endsWithTrigger(before);
+  }
+
+  private syncState(): void {
+    this.modeState.active = this.isActive();
+  }
+
+  private reconcileAnimation(): void {
+    const shouldRun = this.isActive() && this.focused;
+    if (shouldRun && !this.timer) {
+      this.timer = setInterval(() => {
+        this.tick = (this.tick + 1) % (RAINBOW.length * 6);
+        this.tui.requestRender();
+      }, 90);
+      // Don't keep the process alive for the animation.
+      (this.timer as { unref?: () => void }).unref?.();
+    } else if (!shouldRun && this.timer) {
+      clearInterval(this.timer);
+      this.timer = undefined;
+    }
+  }
+}
+
+/** The directive appended to a submitted message when workflows mode is armed. */
+export function buildForcedWorkflowPrompt(text: string): string {
+  return [
+    text,
+    "",
+    "---",
+    "[workflows mode is ON for this message]",
+    "You MUST handle this request by calling the tool named exactly `workflow` (Pi's",
+    "deterministic JavaScript workflow-orchestration tool from pi-dynamic-workflows).",
+    "Write a workflow script that fans the task out across subagents via",
+    "agent()/parallel()/pipeline().",
+    "",
+    "The ONLY acceptable action is a `workflow` tool call. Do NOT instead:",
+    "- answer directly or in prose,",
+    "- call the `subagent` tool yourself,",
+    "- use any skill or command (e.g. pi-subagents, /code-review, deep-research),",
+    '- or interpret the word "workflow/workflows" loosely as some other parallel/audit approach.',
+    "Even for a small task, wrap it in a minimal `workflow` call with at least one agent().",
+  ].join("\n");
+}
+
+/**
+ * Install the workflows-mode editor and the submit-time forcing hook.
+ * Call once with the UI context (e.g. in `session_start`).
+ */
+/** The exact name of the workflow tool that workflows mode forces. */
+export const WORKFLOW_TOOL_NAME = "workflow";
+
+export function installWorkflowEditor(
+  pi: ExtensionAPI,
+  ui: ExtensionUIContext,
+  opts: { auto?: AutoWorkflowController } = {},
+): WorkflowModeState {
+  const state: WorkflowModeState = { active: false };
+
+  // Capture any editor a prior extension installed so we can restore it on
+  // shutdown rather than permanently clobbering it; warn if we replaced one.
+  const previousFactory = ui.getEditorComponent();
+  ui.setEditorComponent((tui, theme, keybindings) => new WorkflowEditor(tui, theme, keybindings, state));
+  if (previousFactory) {
+    ui.notify("workflows-mode editor replaced an existing custom editor for this session", "warning");
+  }
+  pi.on("session_shutdown", () => ui.setEditorComponent(previousFactory));
+
+  // Active tools saved while a turn is restricted to `workflow`; restored on turn_end.
+  let savedTools: string[] | undefined;
+
+  // Restrict this turn's tools to just `workflow` so the model can't fall back to
+  // the subagent tool, a skill, or a direct answer. Best-effort; restored at turn_end.
+  const restrictToWorkflow = () => {
+    try {
+      if (savedTools === undefined) savedTools = pi.getActiveTools?.();
+      pi.setActiveTools?.([WORKFLOW_TOOL_NAME]);
+    } catch {
+      // Tool restriction is best-effort; the directive still forces the workflow.
+    }
+  };
+
+  // At submit time: a manual arm (rainbow editor) always wins and forces a workflow.
+  // Otherwise, opt-in auto-detection (off by default) may force or merely nudge.
+  pi.on("input", (event: { source?: string; text?: string }) => {
+    if (event.source !== "interactive" || !event.text) return { action: "continue" } as const;
+
+    if (state.active) {
+      state.active = false; // consume the arm for this submission
+      restrictToWorkflow();
+      return { action: "transform", text: buildForcedWorkflowPrompt(event.text) } as const;
+    }
+
+    if (opts.auto) {
+      const decision = evaluateAutoWorkflow(event.text, opts.auto.getMode());
+      if (decision.action === "force") {
+        restrictToWorkflow();
+        ui.notify(`auto-workflow: forcing a workflow (${decision.reason ?? "detected"})`, "info");
+        const skeleton = decision.skeleton ? `\n\nSuggested skeleton (adapt freely):\n${decision.skeleton}` : "";
+        return { action: "transform", text: buildForcedWorkflowPrompt(event.text) + skeleton } as const;
+      }
+      if (decision.action === "suggest") {
+        ui.notify(
+          `auto-workflow: looks like a workflow task (${decision.reason ?? "detected"}) — type 'workflow' in your message to run it as one`,
+          "info",
+        );
+      }
+    }
+
+    return { action: "continue" } as const;
+  });
+
+  // Restore the user's full tool set once the forced turn completes.
+  pi.on("turn_end", () => {
+    if (savedTools === undefined) return;
+    const restore = savedTools;
+    savedTools = undefined;
+    try {
+      pi.setActiveTools?.(restore);
+    } catch {
+      // ignore — nothing we can do if the host rejects the restore
+    }
+  });
+
+  return state;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-manager.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-manager.ts
@@ -1,0 +1,473 @@
+/**
+ * Workflow manager for background execution, pause/resume, and run management.
+ */
+
+import { EventEmitter } from "node:events";
+import type { WorkflowAgent } from "./agent.ts";
+import { preview, type WorkflowSnapshot } from "./display.ts";
+import { WorkflowError, WorkflowErrorCode } from "./errors.ts";
+import { profile } from "./profiler.ts";
+import {
+  createRunPersistence,
+  generateRunId,
+  type PersistedRunState,
+  type RunPersistence,
+  type RunStatus,
+} from "./run-persistence.ts";
+import { type JournalEntry, parseWorkflowScript, runWorkflow, type WorkflowRunResult } from "./workflow.ts";
+
+export interface ManagedRun {
+  runId: string;
+  status: RunStatus;
+  snapshot: WorkflowSnapshot;
+  result?: WorkflowRunResult;
+  error?: WorkflowError;
+  controller: AbortController;
+  startedAt: Date;
+  /** The real script, kept so the run can be resumed. */
+  script: string;
+  args?: unknown;
+  /** Accumulated agent results for resume (deterministic call index -> result). */
+  journal: JournalEntry[];
+  /**
+   * True when the run was started in the background (or resumed) and the caller is
+   * not awaiting its result inline. Only background runs deliver their result back
+   * into the conversation; a foreground sync run already returns it as the tool
+   * result, so re-delivering would duplicate it.
+   */
+  background: boolean;
+}
+
+/** Per-execution options shared by sync, background, and resume runs. */
+export interface ExecOptions {
+  /** Replay these journaled agent results for the unchanged prefix (resume). */
+  resumeJournal?: Map<number, JournalEntry>;
+  /** Cap on total agents for this run. */
+  maxAgents?: number;
+  /** Per-agent timeout in milliseconds. */
+  agentTimeoutMs?: number;
+  /** Host signal (e.g. tool/Esc) that should abort this run when fired. */
+  externalSignal?: AbortSignal;
+  /** Called with the live snapshot on every progress event. */
+  onProgress?: (snapshot: WorkflowSnapshot) => void;
+}
+
+export interface WorkflowManagerOptions {
+  cwd?: string;
+  concurrency?: number;
+  /** Resolve a saved-workflow name to its script, enabling nested `workflow('name')`. */
+  loadSavedWorkflow?: (name: string) => string | undefined;
+  /** Inject a custom agent runner (tests); defaults to a real subagent session. */
+  agent?: Pick<WorkflowAgent, "run">;
+  /** The session's main model (provider/id), for auto-tiering explore agents. */
+  mainModel?: string;
+}
+
+export class WorkflowManager extends EventEmitter {
+  private runs = new Map<string, ManagedRun>();
+  private persistence: RunPersistence;
+  private cwd: string;
+  private concurrency: number;
+  private loadSavedWorkflow?: (name: string) => string | undefined;
+  private agent?: Pick<WorkflowAgent, "run">;
+  /** The session's main model (provider/id), for auto-tiering explore agents. */
+  private mainModel?: string;
+
+  constructor(options: WorkflowManagerOptions = {}) {
+    super();
+    this.cwd = options.cwd ?? process.cwd();
+    this.concurrency = options.concurrency ?? 8;
+    this.loadSavedWorkflow = options.loadSavedWorkflow;
+    this.agent = options.agent;
+    this.mainModel = options.mainModel;
+    this.persistence = createRunPersistence(this.cwd);
+  }
+
+  /** Set the session's main model (provider/id). Used to auto-tier explore agents. */
+  setMainModel(spec: string | undefined): void {
+    this.mainModel = spec;
+  }
+
+  /**
+   * Start a workflow in the background.
+   * Returns immediately with a run ID; the workflow executes asynchronously.
+   */
+  startInBackground(
+    script: string,
+    args?: unknown,
+    exec: ExecOptions = {},
+  ): { runId: string; promise: Promise<WorkflowRunResult> } {
+    const runId = generateRunId();
+    const controller = new AbortController();
+    const parsed = parseWorkflowScript(script);
+
+    const managed: ManagedRun = {
+      runId,
+      status: "running",
+      snapshot: {
+        name: parsed.meta.name,
+        description: parsed.meta.description,
+        phases: parsed.meta.phases?.map((p) => p.title) ?? [],
+        logs: [],
+        agents: [],
+        agentCount: 0,
+        runningCount: 0,
+        doneCount: 0,
+        errorCount: 0,
+      },
+      controller,
+      startedAt: new Date(),
+      script,
+      args,
+      journal: [],
+      background: true,
+    };
+
+    this.runs.set(runId, managed);
+
+    // Persist initial state
+    this.persistence.save({
+      runId,
+      workflowName: parsed.meta.name,
+      script,
+      args,
+      status: "running",
+      phases: managed.snapshot.phases,
+      agents: [],
+      logs: [],
+      startedAt: managed.startedAt.toISOString(),
+      updatedAt: managed.startedAt.toISOString(),
+    });
+
+    // Run workflow asynchronously. Errors are surfaced via the "error" event and
+    // persisted run state; attach a no-op catch so a rejection on this
+    // fire-and-forget promise can't become an unhandled rejection (the returned
+    // promise still rejects for any explicit awaiter).
+    const promise = this.executeRun(managed, script, args, exec);
+    promise.catch(() => {});
+
+    return { runId, promise };
+  }
+
+  /**
+   * Execute a workflow synchronously (blocking) while still tracking it like a
+   * background run, so the `/workflows` navigator and the live task panel see it.
+   * `onProgress` fires on every progress event with the current snapshot, letting
+   * a caller (e.g. the workflow tool) drive its own inline display.
+   */
+  async runSync(script: string, args?: unknown, exec: ExecOptions = {}): Promise<WorkflowRunResult> {
+    const managed = this.createManaged(script, args);
+    this.runs.set(managed.runId, managed);
+    // Persist the initial state immediately so listRuns()/the task panel can see
+    // the run the moment it starts, not only after the first agent journals.
+    this.persistRun(managed);
+    return this.executeRun(managed, script, args, exec);
+  }
+
+  /** Build a fresh managed run with an empty snapshot. */
+  private createManaged(script: string, args?: unknown): ManagedRun {
+    const parsed = parseWorkflowScript(script);
+    return {
+      runId: generateRunId(),
+      status: "running",
+      snapshot: {
+        name: parsed.meta.name,
+        description: parsed.meta.description,
+        phases: parsed.meta.phases?.map((p) => p.title) ?? [],
+        logs: [],
+        agents: [],
+        agentCount: 0,
+        runningCount: 0,
+        doneCount: 0,
+        errorCount: 0,
+      },
+      controller: new AbortController(),
+      startedAt: new Date(),
+      script,
+      args,
+      journal: [],
+      background: false,
+    };
+  }
+
+  private async executeRun(
+    managed: ManagedRun,
+    script: string,
+    args?: unknown,
+    exec: ExecOptions = {},
+  ): Promise<WorkflowRunResult> {
+    const { resumeJournal, maxAgents, agentTimeoutMs, externalSignal, onProgress } = exec;
+    const progress = () => onProgress?.(managed.snapshot);
+    // Let a host abort (e.g. Esc during a blocking tool call) cancel this run.
+    if (externalSignal) {
+      if (externalSignal.aborted) managed.controller.abort();
+      else externalSignal.addEventListener("abort", () => managed.controller.abort(), { once: true });
+    }
+    try {
+      const result = await runWorkflow(script, {
+        cwd: this.cwd,
+        args,
+        agent: this.agent,
+        mainModel: this.mainModel,
+        signal: managed.controller.signal,
+        concurrency: this.concurrency,
+        maxAgents,
+        agentTimeoutMs,
+        loadSavedWorkflow: this.loadSavedWorkflow,
+        resumeJournal,
+        resumeFromRunId: resumeJournal ? managed.runId : undefined,
+        onAgentJournal: (entry) => {
+          // Append (crash-safe-ish): keep the latest entry per index, then persist.
+          // Debounced async write — this fires once per agent completion, so a
+          // wide fan-out must not block the TUI on synchronous disk I/O here.
+          managed.journal = managed.journal.filter((e) => e.index !== entry.index);
+          managed.journal.push(entry);
+          this.persistRun(managed, true);
+        },
+        onLog: (message) => {
+          managed.snapshot.logs.push(message);
+          this.emit("log", { runId: managed.runId, message });
+          progress();
+        },
+        onPhase: (title) => {
+          managed.snapshot.currentPhase = title;
+          if (!managed.snapshot.phases.includes(title)) {
+            managed.snapshot.phases.push(title);
+          }
+          this.emit("phase", { runId: managed.runId, title });
+          progress();
+        },
+        onAgentStart: (event) => {
+          managed.snapshot.agents.push({
+            id: managed.snapshot.agents.length + 1,
+            label: event.label,
+            phase: event.phase,
+            prompt: event.prompt,
+            status: "running",
+            model: event.model,
+          });
+          this.emit("agentStart", { runId: managed.runId, ...event });
+          progress();
+        },
+        onAgentEnd: (event) => {
+          const agent = [...managed.snapshot.agents]
+            .reverse()
+            .find((a) => a.label === event.label && a.status === "running");
+          if (agent) {
+            agent.status = event.result === null ? "error" : "done";
+            agent.resultPreview = profile("manager:preview", () => preview(event.result));
+            agent.tokens = event.tokens;
+            if (event.model) agent.model = event.model;
+          }
+          profile("emit:agentEnd", () => this.emit("agentEnd", { runId: managed.runId, ...event }));
+          progress();
+        },
+        onTokenUsage: (usage) => {
+          managed.snapshot.tokenUsage = usage;
+          this.emit("tokenUsage", { runId: managed.runId, usage });
+          progress();
+        },
+      });
+
+      // Enforce the "must run ≥1 agent" contract for ALL modes (background and
+      // sync). Routing it through the catch below marks the run failed + emits
+      // "error", so a background run can't silently complete with zero agents.
+      if (result.agentCount === 0) {
+        throw new WorkflowError(
+          "workflow scripts must call agent() at least once; this workflow declared phases but ran no subagents",
+          WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+          { recoverable: false },
+        );
+      }
+
+      managed.status = "completed";
+      managed.result = result;
+      this.emit("complete", { runId: managed.runId, result });
+
+      // Persist final state
+      this.persistRun(managed);
+
+      return result;
+    } catch (error) {
+      const workflowError =
+        error instanceof WorkflowError
+          ? error
+          : new WorkflowError(
+              error instanceof Error ? error.message : String(error),
+              WorkflowErrorCode.WORKFLOW_ABORTED,
+              { recoverable: true },
+            );
+
+      // pause()/stop() already set the terminal status and emitted their event
+      // before aborting; don't reclassify the resulting abort as a failure or
+      // emit a duplicate "error" for it.
+      if (managed.status === "paused" || managed.status === "aborted") {
+        managed.error = workflowError;
+      } else {
+        managed.status = managed.controller.signal.aborted ? "aborted" : "failed";
+        managed.error = workflowError;
+        this.emit("error", { runId: managed.runId, error: workflowError });
+      }
+
+      // Persist final state
+      this.persistRun(managed);
+
+      throw workflowError;
+    }
+  }
+
+  private persistRun(managed: ManagedRun, debounce = false) {
+    const state: PersistedRunState = {
+      runId: managed.runId,
+      workflowName: managed.snapshot.name,
+      // Persist the real script + journal so the run can be resumed. Runs live
+      // under .pi/workflows/runs/ — protect via directory permissions, not blanking.
+      script: managed.script,
+      args: managed.args,
+      journal: managed.journal,
+      status: managed.status,
+      phases: managed.snapshot.phases,
+      currentPhase: managed.snapshot.currentPhase,
+      agents: managed.snapshot.agents.map((a) => ({
+        ...a,
+        startedAt: managed.startedAt.toISOString(),
+        endedAt: new Date().toISOString(),
+      })),
+      logs: managed.snapshot.logs,
+      result: managed.result?.result,
+      tokenUsage: managed.snapshot.tokenUsage
+        ? {
+            input: managed.snapshot.tokenUsage.input,
+            output: managed.snapshot.tokenUsage.output,
+            total: managed.snapshot.tokenUsage.total,
+          }
+        : undefined,
+      startedAt: managed.startedAt.toISOString(),
+      updatedAt: new Date().toISOString(),
+      completedAt: managed.status === "completed" ? new Date().toISOString() : undefined,
+      durationMs: managed.result?.durationMs,
+    };
+    // Hot path (per-agent progress) coalesces async; terminal states write sync.
+    if (debounce) this.persistence.scheduleSave(state);
+    else profile("persist:save(sync)", () => this.persistence.save(state));
+  }
+
+  /**
+   * Pause a running workflow.
+   */
+  pause(runId: string): boolean {
+    const managed = this.runs.get(runId);
+    if (managed?.status !== "running") return false;
+
+    managed.controller.abort();
+    managed.status = "paused";
+    this.emit("paused", { runId });
+    this.persistRun(managed);
+    return true;
+  }
+
+  /**
+   * Resume an interrupted run: replay journaled results for the unchanged prefix
+   * and run the rest live. Returns false if there is nothing resumable.
+   */
+  async resume(runId: string): Promise<boolean> {
+    const active = this.runs.get(runId);
+    if (active?.status === "running") return false; // already running
+
+    const persisted = this.persistence.load(runId);
+    if (!persisted?.script || persisted.status === "completed") return false;
+
+    const controller = new AbortController();
+    const managed: ManagedRun = {
+      runId,
+      status: "running",
+      snapshot: {
+        name: persisted.workflowName,
+        phases: persisted.phases ?? [],
+        logs: persisted.logs ?? [],
+        agents: [],
+        agentCount: 0,
+        runningCount: 0,
+        doneCount: 0,
+        errorCount: 0,
+      },
+      controller,
+      startedAt: new Date(),
+      script: persisted.script,
+      args: persisted.args,
+      journal: persisted.journal ?? [],
+      background: true,
+    };
+    this.runs.set(runId, managed);
+
+    const resumeJournal = new Map((persisted.journal ?? []).map((e) => [e.index, e] as const));
+    this.emit("resumed", { runId });
+    // Run in the background; executeRun records status/errors on the managed run.
+    void this.executeRun(managed, persisted.script, persisted.args, { resumeJournal }).catch(() => {});
+    return true;
+  }
+
+  /**
+   * Stop a running workflow.
+   */
+  stop(runId: string): boolean {
+    const managed = this.runs.get(runId);
+    if (!managed || (managed.status !== "running" && managed.status !== "paused")) return false;
+
+    managed.controller.abort();
+    managed.status = "aborted";
+    this.emit("stopped", { runId });
+    this.persistRun(managed);
+    return true;
+  }
+
+  /**
+   * Get status of a specific run.
+   */
+  getRun(runId: string): ManagedRun | undefined {
+    return this.runs.get(runId);
+  }
+
+  /**
+   * List all runs (active + persisted). Reads from disk — for the on-demand
+   * /workflows navigator/commands, NOT the render hot path (see listActiveRuns).
+   */
+  listRuns(): PersistedRunState[] {
+    return this.persistence.list();
+  }
+
+  /**
+   * Active (running/paused) runs from the in-memory map — no disk I/O. The live
+   * task panel renders from this on the TUI hot path; only the /workflows
+   * navigator needs the full on-disk history via listRuns().
+   */
+  listActiveRuns(): ManagedRun[] {
+    const out: ManagedRun[] = [];
+    for (const run of this.runs.values()) {
+      if (run.status === "running" || run.status === "paused") out.push(run);
+    }
+    return out;
+  }
+
+  /**
+   * Get snapshot of a run.
+   */
+  getSnapshot(runId: string): WorkflowSnapshot | null {
+    return this.runs.get(runId)?.snapshot ?? null;
+  }
+
+  /**
+   * Delete a persisted run.
+   */
+  deleteRun(runId: string): boolean {
+    this.runs.delete(runId);
+    return this.persistence.delete(runId);
+  }
+
+  /**
+   * Get the persistence layer (for saving workflows).
+   */
+  getPersistence(): RunPersistence {
+    return this.persistence;
+  }
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-saved.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-saved.ts
@@ -1,0 +1,133 @@
+/**
+ * Save and load reusable workflow commands.
+ */
+
+import { existsSync, mkdirSync, readdirSync, readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+import { USER_WORKFLOW_SAVED_DIR, WORKFLOW_SAVED_DIR } from "./config.ts";
+import { assertInside, assertSafeName } from "./fs-safety.ts";
+
+export interface SavedWorkflow {
+  /** Command name (filename without extension). */
+  name: string;
+  /** Human-readable description. */
+  description: string;
+  /** The workflow script. */
+  script: string;
+  /** Optional parameter schema for parameterized workflows. */
+  parameters?: Record<string, { type: string; description?: string; required?: boolean; default?: unknown }>;
+  /** Where this workflow is saved. */
+  location: "project" | "user";
+  /** Full file path. */
+  path: string;
+  /** When it was saved. */
+  savedAt: string;
+}
+
+export interface WorkflowStorage {
+  /** Save a workflow. */
+  save(workflow: Omit<SavedWorkflow, "path" | "savedAt">, location?: "project" | "user"): SavedWorkflow;
+  /** Load a workflow by name. */
+  load(name: string): SavedWorkflow | null;
+  /** List all saved workflows. */
+  list(): SavedWorkflow[];
+  /** Delete a saved workflow. */
+  delete(name: string, location?: "project" | "user"): boolean;
+}
+
+export function createWorkflowStorage(cwd: string): WorkflowStorage {
+  const projectDir = join(cwd, WORKFLOW_SAVED_DIR);
+  const userDir = USER_WORKFLOW_SAVED_DIR.replace("~", process.env.HOME ?? "");
+
+  const ensureDir = (dir: string) => {
+    if (!existsSync(dir)) {
+      mkdirSync(dir, { recursive: true });
+    }
+  };
+
+  const workflowPath = (name: string, location: "project" | "user") => {
+    const dir = location === "project" ? projectDir : userDir;
+    // Reject `../` names (meta.name can flow in here) and confirm the result
+    // stays inside the saved-workflows dir.
+    return assertInside(dir, join(dir, `${assertSafeName(name)}.json`));
+  };
+
+  const loadFromFile = (path: string, location: "project" | "user"): SavedWorkflow | null => {
+    try {
+      if (!existsSync(path)) return null;
+      const data = JSON.parse(readFileSync(path, "utf-8"));
+      return {
+        ...data,
+        location,
+        path,
+      };
+    } catch {
+      return null;
+    }
+  };
+
+  return {
+    save(workflow, location = "project") {
+      const dir = location === "project" ? projectDir : userDir;
+      ensureDir(dir);
+
+      const path = workflowPath(workflow.name, location);
+      const saved: SavedWorkflow = {
+        ...workflow,
+        location,
+        path,
+        savedAt: new Date().toISOString(),
+      };
+
+      writeFileSync(path, JSON.stringify(saved, null, 2));
+      return saved;
+    },
+
+    load(name: string): SavedWorkflow | null {
+      // Project takes precedence over user
+      const projectPath = workflowPath(name, "project");
+      const project = loadFromFile(projectPath, "project");
+      if (project) return project;
+
+      const userPath = workflowPath(name, "user");
+      return loadFromFile(userPath, "user");
+    },
+
+    list(): SavedWorkflow[] {
+      const workflows: SavedWorkflow[] = [];
+
+      // Load project workflows
+      if (existsSync(projectDir)) {
+        for (const file of readdirSync(projectDir).filter((f) => f.endsWith(".json"))) {
+          const wf = loadFromFile(join(projectDir, file), "project");
+          if (wf) workflows.push(wf);
+        }
+      }
+
+      // Load user workflows
+      if (existsSync(userDir)) {
+        for (const file of readdirSync(userDir).filter((f) => f.endsWith(".json"))) {
+          const wf = loadFromFile(join(userDir, file), "user");
+          if (wf) workflows.push(wf);
+        }
+      }
+
+      return workflows.sort((a, b) => a.name.localeCompare(b.name));
+    },
+
+    delete(name: string, location?: "project" | "user"): boolean {
+      const locations = location ? [location] : (["project", "user"] as const);
+      let deleted = false;
+
+      for (const loc of locations) {
+        const path = workflowPath(name, loc);
+        if (existsSync(path)) {
+          unlinkSync(path);
+          deleted = true;
+        }
+      }
+
+      return deleted;
+    },
+  };
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-tool.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-tool.ts
@@ -1,0 +1,261 @@
+import { defineTool, type ToolDefinition } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { listAvailableModelSpecs } from "./agent.ts";
+import {
+  createToolUpdateWorkflowDisplay,
+  createWorkflowSnapshot,
+  recomputeWorkflowSnapshot,
+  renderWorkflowText,
+  type WorkflowSnapshot,
+} from "./display.ts";
+import { WorkflowError, WorkflowErrorCode } from "./errors.ts";
+import { parseWorkflowScript, type WorkflowRunResult } from "./workflow.ts";
+import { WorkflowManager } from "./workflow-manager.ts";
+import { createWorkflowStorage, type WorkflowStorage } from "./workflow-saved.ts";
+
+/**
+ * Per-agent model-routing policy handed to the workflow author (the model). It
+ * states the rule and lists the user's currently available models, then lets the
+ * author choose each agent's model via opts.model — no hardcoded family mapping.
+ */
+function modelRoutingGuideline(): string {
+  const available = listAvailableModelSpecs();
+  const list = available.length
+    ? `The user's currently available models (route only to these) are: ${available.join(", ")}.`
+    : "Use models the user has configured.";
+  return [
+    "For workflow, decide each agent's model yourself via opts.model, following this policy:",
+    "If the user named a specific model, use exactly that.",
+    "Otherwise, for exploration/search/inventory/gathering agents, pick a model one tier BELOW the main model in the SAME family (e.g. Claude→Haiku, ChatGPT/GPT→a mini, DeepSeek→a lighter/flash variant), choosing the closest match from the available list.",
+    "For analysis/synthesis/judgment/decision/verification agents, omit opts.model so the agent runs on the main model.",
+    "Never route to a model that is not in the available list; if no suitable lighter sibling exists, omit opts.model (use the main model).",
+    list,
+  ].join(" ");
+}
+
+const workflowToolSchema = Type.Object({
+  script: Type.String({
+    description: [
+      "Required raw JavaScript workflow script, with no Markdown fences.",
+      "First statement: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }",
+      "Use phase('Name'), agent(prompt, opts), parallel(arrayOfFunctions), pipeline(items, ...stages), log(message), args, and budget. The workflow must call agent() at least once.",
+      "parallel() requires functions, not promises: await parallel(items.map(item => () => agent(...))).",
+    ].join(" "),
+  }),
+  args: Type.Optional(
+    Type.Any({ description: "Optional JSON value exposed to the workflow script as global `args`." }),
+  ),
+  background: Type.Optional(
+    Type.Boolean({
+      description:
+        "Run the workflow in the background. Default: true — the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when it finishes. Set to false only when you need the result inline in this same turn (the call will block until the workflow completes).",
+    }),
+  ),
+  maxAgents: Type.Optional(
+    Type.Number({
+      description: "Maximum number of agents allowed in this run. Default: 1000.",
+    }),
+  ),
+  agentTimeoutMs: Type.Optional(
+    Type.Number({
+      description: "Timeout per agent in milliseconds. Default: 300000 (5 minutes).",
+    }),
+  ),
+});
+
+export type WorkflowToolInput = {
+  script: string;
+  args?: unknown;
+  background?: boolean;
+  maxAgents?: number;
+  agentTimeoutMs?: number;
+};
+
+export interface WorkflowToolOptions {
+  cwd?: string;
+  concurrency?: number;
+  /** Shared manager so background runs are reachable from the `/workflows` command. */
+  manager?: WorkflowManager;
+  /** Shared saved-workflow storage. */
+  storage?: WorkflowStorage;
+}
+
+export function createWorkflowTool(options: WorkflowToolOptions = {}): ToolDefinition<typeof workflowToolSchema, any> {
+  const storage = options.storage ?? createWorkflowStorage(options.cwd ?? process.cwd());
+  const manager =
+    options.manager ??
+    new WorkflowManager({
+      cwd: options.cwd,
+      concurrency: options.concurrency,
+      loadSavedWorkflow: (name: string) => storage.load(name)?.script,
+    });
+
+  return defineTool({
+    name: "workflow",
+    label: "Workflow",
+    description: [
+      "Execute a deterministic JavaScript workflow that orchestrates multiple subagents with agent(), parallel(), and pipeline().",
+      "script is required raw JavaScript. It must start with export const meta = { name, description, phases? } and must call agent() at least once.",
+    ].join(" "),
+    promptSnippet:
+      "Run a deterministic JavaScript workflow. Required script header: export const meta = { name: 'short_snake_case', description: 'non-empty description', phases: [{ title: 'Phase' }] }.",
+    promptGuidelines: [
+      "Use workflow only when the user explicitly asks for a workflow, workflows, fan-out, or multi-agent orchestration.",
+      "For workflow, always pass one raw JavaScript string in the required script parameter; do not include Markdown fences or prose around the script.",
+      "For workflow, the script's first statement must be `export const meta = { name: 'short_snake_case', description: 'non-empty human description', phases: [{ title: 'Phase name' }] }`; meta.name and meta.description are required non-empty strings.",
+      "For workflow, write plain JavaScript after the meta export. Do not use TypeScript syntax, imports, require(), fs, Date.now(), Math.random(), or new Date().",
+      "For workflow, available globals are agent(prompt, opts), parallel(thunks), pipeline(items, ...stages), phase(title), log(message), args, cwd, process.cwd(), and budget. Every workflow must call agent() at least once; do not use workflow only to declare phases or return a static object.",
+      "For workflow, prefer it for decomposable work: repository inspection, independent research/checks, multi-perspective review, or fan-out/fan-in synthesis. Do not use it for a single quick file read/edit or when ordinary tools are enough.",
+      "For workflow, parallel() takes functions, not promises: use `await parallel(items.map(item => () => agent('...', { label: '...' })))`, never `await parallel(items.map(item => agent(...)))`. Results are returned in input order.",
+      "For workflow, pipeline(items, ...stages) runs each item through stages sequentially, while different items may run concurrently. Each stage receives (previousValue, originalItem, index).",
+      "For workflow, every agent() call should include a unique short label option, 2-5 words, such as { label: 'repo inventory' } or { label: 'source modules' }; unique labels make live status and error reporting readable.",
+      "For workflow, failed agent(), parallel(), or pipeline() branches return null and log the failure unless the workflow is aborted. Check for nulls before synthesizing conclusions.",
+      "For workflow, include a final synthesis/assertion agent when combining multiple subagent results; return a compact JSON-serializable value with ok/verdict plus the important outputs.",
+      "For workflow, if agent() needs machine-readable output, pass a plain JSON Schema via opts.schema; agent() will return the validated object. Use JSON Schema syntax, not TypeScript or TypeBox constructors.",
+      modelRoutingGuideline(),
+      "For workflow, do not assume the parent assistant has repository code context inside subagents; include enough task context and relevant paths in each agent prompt.",
+      "For workflow, runs are background by default: the tool returns immediately with a run ID, the turn ends so the user isn't blocked, and the result is delivered back into the conversation when the run finishes. Pass background: false only when you must use the result inline in this same turn (it will block).",
+      "For workflow, you may call `await workflow('saved-name', argsObject)` to run a saved workflow inline and use its result; nesting is one level deep only, and the global 6-concurrent / 1000-total caps hold across the nesting.",
+    ],
+    parameters: workflowToolSchema,
+    prepareArguments(args) {
+      return normalizeWorkflowToolArgs(args);
+    },
+    async execute(_toolCallId, params, signal, onUpdate, _ctx) {
+      const script = normalizeWorkflowScript(params.script);
+      const parsed = parseWorkflowScript(script);
+
+      // Background execution is the default: return immediately so the turn ends
+      // and the user isn't blocked. The result is delivered back into the
+      // conversation when the run finishes (see installResultDelivery). Only an
+      // explicit `background: false` blocks for the result inline.
+      if (params.background ?? true) {
+        const { runId } = manager.startInBackground(script, params.args, {
+          maxAgents: params.maxAgents,
+          agentTimeoutMs: params.agentTimeoutMs,
+        });
+        return {
+          content: [{ type: "text", text: backgroundStartedText(parsed.meta.name, runId) }],
+          details: { runId, background: true },
+        };
+      }
+
+      // Synchronous execution (blocking) — but routed through the manager so the
+      // run shows up live in the /workflows navigator and the task panel while it
+      // runs, then stays in history afterwards. We still block on the result and
+      // return it inline, so the model gets the full output in the same turn.
+      let snapshot: WorkflowSnapshot = createWorkflowSnapshot(parsed.meta);
+      const display = createToolUpdateWorkflowDisplay(onUpdate, undefined, {
+        key: "workflow",
+        streamToolUpdates: true,
+        maxAgents: 4,
+        maxLogs: 1,
+        showResultPreviews: false,
+      });
+
+      let result: WorkflowRunResult;
+      try {
+        result = await manager.runSync(script, params.args, {
+          maxAgents: params.maxAgents,
+          agentTimeoutMs: params.agentTimeoutMs,
+          externalSignal: signal,
+          onProgress(live) {
+            snapshot = recomputeWorkflowSnapshot(live);
+            display.update(snapshot);
+          },
+        });
+      } catch (error) {
+        if (signal?.aborted || (error instanceof WorkflowError && error.code === WorkflowErrorCode.WORKFLOW_ABORTED)) {
+          for (const agent of snapshot.agents) {
+            if (agent.status === "running") {
+              agent.status = "skipped";
+              agent.error = "aborted";
+            }
+          }
+          snapshot = recomputeWorkflowSnapshot(snapshot);
+          display.complete(snapshot);
+          throw new Error("Workflow was aborted");
+        }
+        throw error;
+      }
+
+      // The ≥1-agent contract is enforced for all modes in WorkflowManager
+      // (runSync rethrows it here), so no separate sync-only check is needed.
+      snapshot.result = result.result;
+      snapshot.durationMs = result.durationMs;
+      snapshot = recomputeWorkflowSnapshot(snapshot);
+      display.complete(snapshot);
+
+      // Format token usage (include cost when the provider reports it)
+      const tokenInfo = result.tokenUsage
+        ? `\n\nToken usage: ${result.tokenUsage.total.toLocaleString()} tokens${
+            result.tokenUsage.cost ? ` ($${result.tokenUsage.cost.toFixed(4)})` : ""
+          }`
+        : "";
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Workflow ${result.meta.name} completed with ${result.agentCount} agent(s).\n\nResult:\n${JSON.stringify(result.result, null, 2)}${tokenInfo}`,
+          },
+        ],
+        details: {
+          ...snapshot,
+          meta: result.meta,
+          phases: result.phases,
+          logs: result.logs,
+          result: result.result,
+          durationMs: result.durationMs,
+          tokenUsage: result.tokenUsage,
+          runId: result.runId,
+        },
+      };
+    },
+    renderCall(_args, theme) {
+      return new Text(theme.fg("toolTitle", theme.bold("workflow")), 0, 0);
+    },
+    renderResult(result, { isPartial }, theme) {
+      const snapshot = result.details as WorkflowSnapshot | undefined;
+      if (snapshot?.name) {
+        return new Text(renderWorkflowText(snapshot, !isPartial), 0, 0);
+      }
+      const text = result.content?.[0];
+      return new Text(text?.type === "text" ? text.text : theme.fg("muted", "workflow"), 0, 0);
+    },
+  });
+}
+
+/**
+ * The tool result returned when a workflow starts in the background. It both
+ * informs the model and tells it to reassure the user: the run continues on its
+ * own and the conversation will resume automatically when it finishes, so the
+ * user can just wait here (or go do something else).
+ */
+export function backgroundStartedText(name: string, runId: string): string {
+  return [
+    `Workflow "${name}" started in the background.`,
+    `Run ID: ${runId}`,
+    "It keeps running on its own. When it finishes, the result is delivered back",
+    "here and the conversation continues automatically — the user does not need to",
+    "do anything. Tell the user they can simply wait here for it to finish (it will",
+    "resume the conversation by itself), or keep chatting / working on other things",
+    "in the meantime; either way the result will come back to this conversation.",
+    `They can also track or cancel it with /workflows status ${runId} or /workflows stop ${runId}.`,
+  ].join("\n");
+}
+
+function normalizeWorkflowToolArgs(args: unknown): WorkflowToolInput {
+  if (!args || typeof args !== "object") throw new Error("workflow requires an object argument with a script string");
+  const value = args as Record<string, unknown>;
+  if (typeof value.script !== "string") throw new Error("workflow requires `script` to be a string");
+  return { ...value, script: normalizeWorkflowScript(value.script) } as WorkflowToolInput;
+}
+
+function normalizeWorkflowScript(script: string): string {
+  let text = script.trim();
+  const fence = text.match(/^```(?:js|javascript)?\s*\n([\s\S]*?)\n```$/i);
+  if (fence) text = fence[1].trim();
+  return text;
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-ui.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-ui.ts
@@ -1,0 +1,533 @@
+/**
+ * Interactive `/workflows` navigator, modeled on Claude Code's view:
+ *
+ *   runs ──enter──▶ phases ──enter──▶ agents ──enter──▶ agent detail
+ *        ◀──esc───        ◀──esc────         ◀──esc────
+ *
+ * Keys: ↑/↓ (or j/k) select · enter/→ drill in · esc/← back (esc at top closes)
+ *       p pause/resume · x stop · r restart · s save · q quit
+ *
+ * The state machine and line rendering are pure and unit-tested; the pi-tui
+ * Component shell (openWorkflowNavigator) wires them to live manager events.
+ */
+
+import type { ExtensionAPI, ExtensionUIContext, Theme } from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { parseKey } from "@earendil-works/pi-tui";
+import { framePanel } from "./panel-box.ts";
+import { profile } from "./profiler.ts";
+import type { WorkflowAgentSnapshot, WorkflowSnapshot } from "./display.ts";
+import type { PersistedRunState } from "./run-persistence.ts";
+import { registerSavedWorkflow } from "./saved-commands.ts";
+import type { WorkflowManager } from "./workflow-manager.ts";
+import type { WorkflowStorage } from "./workflow-saved.ts";
+
+const STATUS_ICON: Record<string, string> = {
+  pending: "·",
+  queued: "·",
+  running: "◆",
+  paused: "⏸",
+  completed: "✓",
+  done: "✓",
+  failed: "✗",
+  error: "✗",
+  aborted: "⊘",
+  skipped: "⊘",
+};
+
+/** Minimal theme surface so rendering is testable without the real Theme class. */
+export interface ThemeLike {
+  fg(color: string, text: string): string;
+  bold(text: string): string;
+}
+
+const PLAIN: ThemeLike = { fg: (_c, t) => t, bold: (t) => t };
+
+export type ViewKind = "runs" | "phases" | "agents" | "detail";
+
+interface RunRow {
+  runId: string;
+  name: string;
+  status: string;
+  done: number;
+  total: number;
+  tokens: number;
+}
+interface PhaseRow {
+  title: string;
+  done: number;
+  total: number;
+  tokens: number;
+}
+interface AgentRow {
+  id: number;
+  label: string;
+  status: string;
+  phase?: string;
+  tokens?: number;
+  model?: string;
+}
+
+/** Short, human-friendly model label: drop the provider prefix for display. */
+function shortModel(model: string | undefined): string | undefined {
+  if (!model) return undefined;
+  const slash = model.indexOf("/");
+  return slash > 0 ? model.slice(slash + 1) : model;
+}
+
+/** Reads run/phase/agent data from the manager, preferring live snapshots. */
+export class NavigatorModel {
+  constructor(private readonly manager: Pick<WorkflowManager, "listRuns" | "getRun">) {}
+
+  private snapshot(runId: string): { snapshot: WorkflowSnapshot; status: string } | undefined {
+    const live = this.manager.getRun(runId);
+    if (live) return { snapshot: live.snapshot, status: live.status };
+    const p = this.manager.listRuns().find((r) => r.runId === runId);
+    if (!p) return undefined;
+    return { snapshot: persistedToSnapshot(p), status: p.status };
+  }
+
+  runs(): RunRow[] {
+    return this.manager.listRuns().map((p) => {
+      const live = this.manager.getRun(p.runId);
+      const agents = (live?.snapshot.agents ?? p.agents) as WorkflowAgentSnapshot[];
+      return {
+        runId: p.runId,
+        name: live?.snapshot.name ?? p.workflowName,
+        status: live?.status ?? p.status,
+        done: agents.filter((a) => a.status === "done").length,
+        total: agents.length,
+        tokens: (live?.snapshot.tokenUsage ?? p.tokenUsage)?.total ?? 0,
+      };
+    });
+  }
+
+  runName(runId: string): string {
+    return this.snapshot(runId)?.snapshot.name ?? runId;
+  }
+
+  runStatus(runId: string): string {
+    return this.snapshot(runId)?.status ?? "unknown";
+  }
+
+  phases(runId: string): PhaseRow[] {
+    const snap = this.snapshot(runId)?.snapshot;
+    if (!snap) return [];
+    const order = snap.phases.length ? [...snap.phases] : [];
+    const byPhase = new Map<string, AgentRow[]>();
+    for (const a of snap.agents) {
+      const key = a.phase ?? "(no phase)";
+      if (!byPhase.has(key)) byPhase.set(key, []);
+      byPhase.get(key)?.push(a);
+      if (!order.includes(key)) order.push(key);
+    }
+    return order.map((title) => {
+      const agents = byPhase.get(title) ?? [];
+      return {
+        title,
+        done: agents.filter((a) => a.status === "done").length,
+        total: agents.length,
+        tokens: agents.reduce((n, a) => n + (a.tokens ?? 0), 0),
+      };
+    });
+  }
+
+  agents(runId: string, phase: string): AgentRow[] {
+    const snap = this.snapshot(runId)?.snapshot;
+    if (!snap) return [];
+    return snap.agents
+      .filter((a) => (a.phase ?? "(no phase)") === phase)
+      .map((a) => ({ id: a.id, label: a.label, status: a.status, phase: a.phase, tokens: a.tokens, model: a.model }));
+  }
+
+  agentDetail(runId: string, agentId: number): WorkflowAgentSnapshot | undefined {
+    return this.snapshot(runId)?.snapshot.agents.find((a) => a.id === agentId);
+  }
+}
+
+function persistedToSnapshot(p: PersistedRunState): WorkflowSnapshot {
+  return {
+    name: p.workflowName,
+    phases: p.phases,
+    currentPhase: p.currentPhase,
+    logs: p.logs,
+    agents: p.agents.map((a) => ({
+      id: a.id,
+      label: a.label,
+      phase: a.phase,
+      prompt: a.prompt,
+      status: a.status,
+      resultPreview:
+        a.result == null ? undefined : String(typeof a.result === "string" ? a.result : JSON.stringify(a.result)),
+      error: a.error,
+      model: a.model,
+    })),
+    agentCount: p.agents.length,
+    runningCount: p.agents.filter((a) => a.status === "running").length,
+    doneCount: p.agents.filter((a) => a.status === "done").length,
+    errorCount: p.agents.filter((a) => a.status === "error").length,
+    tokenUsage: p.tokenUsage ? { ...p.tokenUsage } : undefined,
+    runId: p.runId,
+  };
+}
+
+/** Navigation state machine: a stack of (view, cursor) frames plus detail scroll. */
+export class NavigatorState {
+  private stack: Array<{ kind: ViewKind; cursor: number; runId?: string; phase?: string; agentId?: number }> = [
+    { kind: "runs", cursor: 0 },
+  ];
+  scroll = 0;
+
+  private top() {
+    return this.stack[this.stack.length - 1];
+  }
+  get kind(): ViewKind {
+    return this.top().kind;
+  }
+  get cursor(): number {
+    return this.top().cursor;
+  }
+  get runId(): string | undefined {
+    return this.top().runId;
+  }
+  get phase(): string | undefined {
+    return this.top().phase;
+  }
+  get agentId(): number | undefined {
+    return this.top().agentId;
+  }
+  get depth(): number {
+    return this.stack.length;
+  }
+
+  /** Clamp the cursor to [0, count). */
+  clamp(count: number) {
+    const t = this.top();
+    t.cursor = count <= 0 ? 0 : Math.max(0, Math.min(t.cursor, count - 1));
+  }
+
+  move(delta: number, count: number) {
+    if (this.kind === "detail") {
+      this.scroll = Math.max(0, this.scroll + delta);
+      return;
+    }
+    if (count <= 0) return;
+    const t = this.top();
+    t.cursor = (t.cursor + delta + count) % count;
+  }
+
+  /** Drill into the selected item. Returns true if the view changed. */
+  drill(model: NavigatorModel): boolean {
+    const t = this.top();
+    if (t.kind === "runs") {
+      const runs = model.runs();
+      const run = runs[t.cursor];
+      if (!run) return false;
+      this.stack.push({ kind: "phases", cursor: 0, runId: run.runId });
+      return true;
+    }
+    if (t.kind === "phases" && t.runId) {
+      const phases = model.phases(t.runId);
+      const ph = phases[t.cursor];
+      if (!ph) return false;
+      this.stack.push({ kind: "agents", cursor: 0, runId: t.runId, phase: ph.title });
+      return true;
+    }
+    if (t.kind === "agents" && t.runId && t.phase) {
+      const agents = model.agents(t.runId, t.phase);
+      const ag = agents[t.cursor];
+      if (!ag) return false;
+      this.scroll = 0;
+      this.stack.push({ kind: "detail", cursor: 0, runId: t.runId, phase: t.phase, agentId: ag.id });
+      return true;
+    }
+    return false;
+  }
+
+  /** Pop one level. Returns false when already at the top (caller should close). */
+  back(): boolean {
+    if (this.stack.length <= 1) return false;
+    this.stack.pop();
+    this.scroll = 0;
+    return true;
+  }
+
+  /** The runId the current view acts on (for pause/stop/save). */
+  activeRunId(model: NavigatorModel): string | undefined {
+    if (this.runId) return this.runId;
+    if (this.kind === "runs") return model.runs()[this.cursor]?.runId;
+    return undefined;
+  }
+}
+
+function pad(n: number): string {
+  return n.toLocaleString();
+}
+
+function fmtTokens(t: number): string {
+  return t > 0 ? `${pad(t)} tok` : "";
+}
+
+/** Build the lines for the current view. Pure: depends only on state + model + theme. */
+export function renderNavigator(
+  state: NavigatorState,
+  model: NavigatorModel,
+  width: number,
+  theme: ThemeLike = PLAIN,
+): string[] {
+  const lines: string[] = [];
+  const sel = (i: number, text: string) =>
+    i === state.cursor ? theme.fg("accent", theme.bold(`❯ ${text}`)) : `  ${text}`;
+  const dim = (t: string) => theme.fg("dim", t);
+
+  if (state.kind === "runs") {
+    const runs = model.runs();
+    state.clamp(runs.length);
+    lines.push(theme.bold("Workflows"));
+    if (!runs.length) lines.push(dim("  No runs yet. Start one with a background workflow."));
+    runs.forEach((r, i) => {
+      const icon = STATUS_ICON[r.status] ?? "?";
+      const meta = [`${r.done}/${r.total}`, fmtTokens(r.tokens)].filter(Boolean).join(" · ");
+      lines.push(sel(i, `${icon} ${r.name}  ${dim(`${r.runId} · ${r.status} · ${meta}`)}`));
+    });
+  } else if (state.kind === "phases" && state.runId) {
+    const phases = model.phases(state.runId);
+    state.clamp(phases.length);
+    lines.push(theme.bold(model.runName(state.runId)) + dim(`  (${model.runStatus(state.runId)})`));
+    phases.forEach((p, i) => {
+      const meta = [`${p.done}/${p.total} agents`, fmtTokens(p.tokens)].filter(Boolean).join(" · ");
+      lines.push(sel(i, `${p.title}  ${dim(meta)}`));
+    });
+  } else if (state.kind === "agents" && state.runId && state.phase) {
+    const agents = model.agents(state.runId, state.phase);
+    state.clamp(agents.length);
+    lines.push(theme.bold(`${model.runName(state.runId)} › ${state.phase}`));
+    agents.forEach((a, i) => {
+      const icon = STATUS_ICON[a.status] ?? "?";
+      const mdl = shortModel(a.model);
+      const meta = [mdl, a.tokens ? fmtTokens(a.tokens) : undefined].filter(Boolean).join(" · ");
+      lines.push(sel(i, `${icon} ${a.label}${meta ? dim(`  ${meta}`) : ""}`));
+    });
+  } else if (state.kind === "detail" && state.runId && state.agentId != null) {
+    const a = model.agentDetail(state.runId, state.agentId);
+    lines.push(theme.bold(a ? a.label : "agent"));
+    if (a) {
+      const body: string[] = [];
+      body.push(dim("Status: ") + (a.status ?? ""));
+      if (a.model) body.push(dim("Model: ") + (shortModel(a.model) ?? ""));
+      if (a.error) body.push(dim("Error: ") + a.error);
+      body.push("", dim("Prompt:"));
+      body.push(...wrap(a.prompt ?? "", width));
+      body.push("", dim("Result:"));
+      body.push(...wrap(a.resultPreview ?? "(none)", width));
+      // Scrollable region.
+      const maxScroll = Math.max(0, body.length - 1);
+      state.scroll = Math.min(state.scroll, maxScroll);
+      lines.push(...body.slice(state.scroll));
+    }
+  }
+
+  lines.push("");
+  lines.push(footerHint(state, theme));
+
+  // Frame the navigator in a background-filled box so it stays legible over a
+  // terminal wallpaper. Only when the full Theme (with bg fill) is present — the
+  // PLAIN fallback used in tests has no `bg`, so it returns the raw lines.
+  const full = theme as Partial<Theme>;
+  return typeof full.bg === "function" ? framePanel(lines, full as Theme, { width }) : lines;
+}
+
+function footerHint(state: NavigatorState, theme: ThemeLike): string {
+  const parts =
+    state.kind === "detail"
+      ? ["j/k scroll", "esc back"]
+      : ["↑/↓ select", "enter open", "esc back", "p pause", "x stop", "r restart", "s save", "q quit"];
+  return theme.fg("dim", parts.join(" · "));
+}
+
+function wrap(text: string, width: number): string[] {
+  const w = Math.max(20, width - 2);
+  const out: string[] = [];
+  for (const para of String(text).split("\n")) {
+    if (para.length <= w) {
+      out.push(para);
+      continue;
+    }
+    let rest = para;
+    while (rest.length > w) {
+      out.push(rest.slice(0, w));
+      rest = rest.slice(w);
+    }
+    if (rest) out.push(rest);
+  }
+  return out;
+}
+
+/** What a key press should do. Pure mapping from a parsed key id to an action. */
+export type NavAction =
+  | { type: "move"; delta: number }
+  | { type: "drill" }
+  | { type: "back" }
+  | { type: "close" }
+  | { type: "pause" }
+  | { type: "stop" }
+  | { type: "restart" }
+  | { type: "save" }
+  | { type: "none" };
+
+export function keyToAction(keyId: string | undefined, kind: ViewKind): NavAction {
+  switch (keyId) {
+    case "up":
+      return { type: "move", delta: -1 };
+    case "down":
+      return { type: "move", delta: 1 };
+    case "k":
+      return { type: "move", delta: -1 };
+    case "j":
+      return { type: "move", delta: 1 };
+    case "enter":
+    case "return":
+    case "right":
+      return kind === "detail" ? { type: "none" } : { type: "drill" };
+    case "escape":
+    case "esc":
+    case "left":
+      return { type: "back" };
+    case "q":
+      return { type: "close" };
+    case "p":
+      return { type: "pause" };
+    case "x":
+      return { type: "stop" };
+    case "r":
+      return { type: "restart" };
+    case "s":
+      return { type: "save" };
+    default:
+      return { type: "none" };
+  }
+}
+
+function currentCount(state: NavigatorState, model: NavigatorModel): number {
+  if (state.kind === "runs") return model.runs().length;
+  if (state.kind === "phases" && state.runId) return model.phases(state.runId).length;
+  if (state.kind === "agents" && state.runId && state.phase) return model.agents(state.runId, state.phase).length;
+  return 0;
+}
+
+export interface NavigatorOptions {
+  storage?: WorkflowStorage;
+  cwd?: string;
+}
+
+/**
+ * Open the interactive `/workflows` navigator as a focused overlay. Resolves when
+ * the user closes it (esc at the top level, or `q`).
+ */
+export function openWorkflowNavigator(
+  pi: ExtensionAPI,
+  manager: WorkflowManager,
+  ui: ExtensionUIContext,
+  opts: NavigatorOptions = {},
+): Promise<void> {
+  const model = new NavigatorModel(manager);
+  const state = new NavigatorState();
+
+  return ui.custom<void>(
+    (tui: TUI, theme: Theme, _keybindings, done: (r: void) => void) => {
+      const rerender = () => tui.requestRender();
+      const events = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
+      const onEvent = () => rerender();
+      for (const ev of events) manager.on(ev, onEvent);
+      const cleanup = () => {
+        for (const ev of events) manager.off(ev, onEvent);
+      };
+
+      const act = (data: string) => {
+        const action = keyToAction(parseKey(data), state.kind);
+        switch (action.type) {
+          case "move":
+            state.move(action.delta, currentCount(state, model));
+            break;
+          case "drill":
+            state.drill(model);
+            break;
+          case "back":
+            if (!state.back()) {
+              cleanup();
+              done();
+            }
+            break;
+          case "close":
+            cleanup();
+            done();
+            return;
+          case "pause": {
+            const id = state.activeRunId(model);
+            if (id) ui.notify(manager.pause(id) ? `Paused ${id}` : `Cannot pause ${id}`, "info");
+            break;
+          }
+          case "stop": {
+            const id = state.activeRunId(model);
+            if (id) ui.notify(manager.stop(id) ? `Stopped ${id}` : `Cannot stop ${id}`, "info");
+            break;
+          }
+          case "restart": {
+            // Restart re-runs the whole workflow from scratch as a fresh
+            // background run (per-agent restart isn't meaningful — agents are
+            // driven by the script). The new run auto-delivers when it finishes.
+            const id = state.activeRunId(model);
+            const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
+            if (!run?.script) {
+              ui.notify(id ? `Cannot restart ${id} (no script saved)` : "No run selected to restart", "warning");
+              break;
+            }
+            const { runId: newId } = manager.startInBackground(run.script, run.args);
+            ui.notify(`Restarted ${run.workflowName || "workflow"} as ${newId}`, "info");
+            break;
+          }
+          case "save": {
+            const id = state.activeRunId(model);
+            const run = id ? manager.listRuns().find((r) => r.runId === id) : undefined;
+            if (!run?.script) {
+              ui.notify("No saved run script to save", "warning");
+            } else if (!opts.storage) {
+              ui.notify("Saving is not available (no storage)", "error");
+            } else {
+              const name = run.workflowName || "workflow";
+              // storage.save -> assertSafeName throws for names with spaces/special
+              // chars (a workflow's meta.name only has to be non-empty to validate).
+              // act() is the synchronous input handler, so an escaping throw would
+              // crash the navigator — catch it and notify instead.
+              try {
+                const saved = opts.storage.save({
+                  name,
+                  description: run.workflowName,
+                  script: run.script,
+                  location: "project",
+                });
+                registerSavedWorkflow(pi, opts.cwd ?? process.cwd(), saved);
+                ui.notify(`Saved /${name}`, "info");
+              } catch (error) {
+                ui.notify(`Cannot save workflow: ${error instanceof Error ? error.message : error}`, "error");
+              }
+            }
+            break;
+          }
+          default:
+            return;
+        }
+        rerender();
+      };
+
+      const component: Component & { dispose?(): void } = {
+        render: (width: number) => profile("render:navigator", () => renderNavigator(state, model, width, theme)),
+        handleInput: (data: string) => act(data),
+        invalidate: () => {},
+        dispose: () => cleanup(),
+      };
+      return component;
+    },
+    { overlay: true },
+  );
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-ui.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-ui.ts
@@ -521,7 +521,18 @@ export function openWorkflowNavigator(
       };
 
       const component: Component & { dispose?(): void } = {
-        render: (width: number) => profile("render:navigator", () => renderNavigator(state, model, width, theme)),
+        // Guard the render: it runs in the TUI render timer, where an uncaught
+        // throw (e.g. theme.fg on an unregistered role, or a model read) crashes
+        // Pi. renderNavigator stays pure; the catch lives at the call site and
+        // falls back to a plain (un-themed) line so the overlay can't take Pi down.
+        render: (width: number) =>
+          profile("render:navigator", () => {
+            try {
+              return renderNavigator(state, model, width, theme);
+            } catch {
+              return ["(workflow navigator failed to render — press esc/q to close)"];
+            }
+          }),
         handleInput: (data: string) => act(data),
         invalidate: () => {},
         dispose: () => cleanup(),

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow-ui.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow-ui.ts
@@ -22,6 +22,10 @@ import { registerSavedWorkflow } from "./saved-commands.ts";
 import type { WorkflowManager } from "./workflow-manager.ts";
 import type { WorkflowStorage } from "./workflow-saved.ts";
 
+// Max cadence for the navigator's on-disk run-list refresh (listRuns = readdir +
+// readFile-per-run). Bounds disk I/O regardless of manager-event volume.
+const NAV_REFRESH_THROTTLE_MS = 200;
+
 const STATUS_ICON: Record<string, string> = {
   pending: "·",
   queued: "·",
@@ -77,18 +81,34 @@ function shortModel(model: string | undefined): string | undefined {
 
 /** Reads run/phase/agent data from the manager, preferring live snapshots. */
 export class NavigatorModel {
+  // Cached on-disk run list. listRuns() does readdirSync + readFileSync-per-run,
+  // so render must never call it; callers refresh() this on open and on a throttled
+  // cadence. Live per-run contents are still overlaid from getRun() (in-memory) on
+  // every render, so progress stays current between refreshes.
+  private cachedRuns: PersistedRunState[] | null = null;
+
   constructor(private readonly manager: Pick<WorkflowManager, "listRuns" | "getRun">) {}
+
+  /** Re-read the persisted run list from disk. Call on open + throttled, NOT per render. */
+  refresh(): void {
+    this.cachedRuns = this.manager.listRuns();
+  }
+
+  private persistedRuns(): PersistedRunState[] {
+    if (this.cachedRuns === null) this.cachedRuns = this.manager.listRuns();
+    return this.cachedRuns;
+  }
 
   private snapshot(runId: string): { snapshot: WorkflowSnapshot; status: string } | undefined {
     const live = this.manager.getRun(runId);
     if (live) return { snapshot: live.snapshot, status: live.status };
-    const p = this.manager.listRuns().find((r) => r.runId === runId);
+    const p = this.persistedRuns().find((r) => r.runId === runId);
     if (!p) return undefined;
     return { snapshot: persistedToSnapshot(p), status: p.status };
   }
 
   runs(): RunRow[] {
-    return this.manager.listRuns().map((p) => {
+    return this.persistedRuns().map((p) => {
       const live = this.manager.getRun(p.runId);
       const agents = (live?.snapshot.agents ?? p.agents) as WorkflowAgentSnapshot[];
       return {
@@ -437,10 +457,34 @@ export function openWorkflowNavigator(
     (tui: TUI, theme: Theme, _keybindings, done: (r: void) => void) => {
       const rerender = () => tui.requestRender();
       const events = ["agentStart", "agentEnd", "phase", "log", "complete", "error", "stopped", "paused", "resumed"];
-      const onEvent = () => rerender();
+      // Coalesce disk refreshes: events burst (log/agentStart per agent during a
+      // fan-out). Re-read the run list at most once per window — renders in between
+      // use the cache + in-memory getRun overlay. We still rerender() immediately on
+      // each event (cheap, no disk) so live progress shows without waiting.
+      let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+      const scheduleRefresh = () => {
+        if (refreshTimer) return;
+        refreshTimer = setTimeout(() => {
+          refreshTimer = null;
+          model.refresh();
+          rerender();
+        }, NAV_REFRESH_THROTTLE_MS);
+        if (typeof (refreshTimer as { unref?: () => void }).unref === "function") {
+          (refreshTimer as { unref: () => void }).unref();
+        }
+      };
+      model.refresh(); // initial on-open snapshot
+      const onEvent = () => {
+        rerender();
+        scheduleRefresh();
+      };
       for (const ev of events) manager.on(ev, onEvent);
       const cleanup = () => {
         for (const ev of events) manager.off(ev, onEvent);
+        if (refreshTimer) {
+          clearTimeout(refreshTimer);
+          refreshTimer = null;
+        }
       };
 
       const act = (data: string) => {

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
@@ -54,6 +54,10 @@ export interface SharedRuntime {
   spent: number;
   tokenUsage: { input: number; output: number; total: number; cost: number };
   depth: number;
+  /** Real subagent runs started (excludes cached resume replays). */
+  agentsAttempted: number;
+  /** Of those, how many failed and were degraded to a null result. */
+  agentsFailed: number;
 }
 
 export interface WorkflowRunOptions extends WorkflowAgentOptions {
@@ -200,12 +204,15 @@ export async function runWorkflow<T = unknown>(
     Math.min(options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2), MAX_CONCURRENCY),
   );
   // Global caps + budget are shared with any nested workflow() so they hold across nesting.
+  const isOutermost = !options.sharedRuntime;
   const shared: SharedRuntime = options.sharedRuntime ?? {
     limiter: createLimiter(concurrency),
     agentCount: 0,
     spent: 0,
     tokenUsage: { input: 0, output: 0, total: 0, cost: 0 },
     depth: 0,
+    agentsAttempted: 0,
+    agentsFailed: 0,
   };
   const limiter = shared.limiter;
 
@@ -284,6 +291,8 @@ export async function runWorkflow<T = unknown>(
     return limiter(async () => {
       const label = requestedLabel || defaultAgentLabel(assignedPhase, agentNumber);
       const timeout = agentOptions.timeoutMs ?? agentTimeoutMs;
+      // A real subagent run (cached resume replays returned earlier, above).
+      shared.agentsAttempted++;
 
       options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
 
@@ -368,6 +377,7 @@ export async function runWorkflow<T = unknown>(
 
         // Return null for recoverable errors
         if (workflowError.recoverable) {
+          shared.agentsFailed++;
           return null;
         }
         throw workflowError;
@@ -520,6 +530,17 @@ export async function runWorkflow<T = unknown>(
     throw error;
   } finally {
     options.signal?.removeEventListener("abort", onExternalAbort);
+  }
+
+  // Every subagent failed: each agent() degraded to null, so the script likely
+  // "succeeded" with all-null results. Surface that loudly instead of letting an
+  // empty success slip into the conversation. Only the outermost run reports, so
+  // a fully-failed nested workflow isn't double-counted.
+  if (isOutermost && shared.agentsAttempted > 0 && shared.agentsFailed >= shared.agentsAttempted) {
+    log(
+      `⚠️ all ${shared.agentsAttempted} agent run(s) failed — results are empty/null. ` +
+        `Check the run log; the workflow did not produce real output.`,
+    );
   }
 
   // Persist logs

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
@@ -698,9 +698,22 @@ function assertDeterministic(ast: AnyNode): void {
     );
   };
   walkAst(ast, null, null, (n, parent, role) => {
-    // Math.random / Math['random'] (Math itself stays available for Math.floor etc.).
-    if (n.type === "MemberExpression" && n.object?.type === "Identifier" && n.object.name === "Math") {
-      if (memberPropName(n) === "random") reject("Math.random");
+    if (n.type === "MemberExpression") {
+      // Math.random / Math['random'] (Math itself stays available for Math.floor etc.).
+      if (n.object?.type === "Identifier" && n.object.name === "Math" && memberPropName(n) === "random") {
+        reject("Math.random");
+      }
+      // Prototype/constructor reach-arounds. The context is seeded with host-realm
+      // intrinsics, so `Object.constructor` is the host Function constructor and
+      // `Object.constructor("return Date.now()")()` would evaluate arbitrary,
+      // non-deterministic (host) code — bypassing the bare-`Function`/`eval` guard
+      // below. Reject both `x.constructor` and `x['constructor']` (and __proto__/
+      // prototype). Dynamically-built keys (`x["cons"+"tructor"]`) are out of scope
+      // for this static guard — it's a determinism guard, not a hard sandbox.
+      const prop = memberPropName(n);
+      if (prop === "constructor" || prop === "__proto__" || prop === "prototype") {
+        reject(`.${prop} access`);
+      }
     }
     // Any value reference to a forbidden global, however it's reached.
     if (n.type === "Identifier" && FORBIDDEN_GLOBALS.has(n.name) && isValueReference(parent, role)) {

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
@@ -1,0 +1,804 @@
+import { createHash } from "node:crypto";
+import vm from "node:vm";
+// acorn is vendored locally (the extension's only non-peer dependency) as a
+// self-contained ESM bundle; see ../vendor/acorn.mjs and ../vendor/ACORN-LICENSE.
+// @ts-ignore - the vendored .mjs ships no type declarations.
+import { parse } from "../vendor/acorn.mjs";
+// Structural stand-in for acorn's Node type (we only read type/start/end and
+// walk child nodes), since the vendored bundle carries no types.
+type Node = { type: string; start: number; end: number };
+import type { TSchema } from "typebox";
+import type { AgentUsage } from "./agent.ts";
+import { WorkflowAgent, type WorkflowAgentOptions } from "./agent.ts";
+import {
+  DEFAULT_AGENT_TIMEOUT_MS,
+  DEFAULT_TOKEN_BUDGET,
+  MAX_AGENTS_PER_RUN,
+  MAX_CONCURRENCY,
+  WORKFLOW_SYNC_TIMEOUT_MS,
+} from "./config.ts";
+import { WorkflowError, WorkflowErrorCode, wrapError } from "./errors.ts";
+import { createWorkflowLogger } from "./logger.ts";
+import { parseModelRoutingFromMeta, resolveModelForPhase } from "./model-routing.ts";
+import { createWorktree, removeWorktree, type Worktree } from "./worktree.ts";
+
+export interface WorkflowMetaPhase {
+  title: string;
+  detail?: string;
+  model?: string;
+}
+
+export interface WorkflowMeta {
+  name: string;
+  description: string;
+  whenToUse?: string;
+  phases?: WorkflowMetaPhase[];
+}
+
+/** One cached agent() result, keyed by its deterministic call index. */
+export interface JournalEntry {
+  index: number;
+  /** sha256 of the call's identity (prompt + model + phase + agentType + schema). */
+  hash: string;
+  result: unknown;
+}
+
+/**
+ * Global resources shared across a run and any workflow() nested inside it, so
+ * the 6-concurrent / 1000-total caps and the token budget hold across nesting
+ * instead of each level getting its own limiter and counters.
+ */
+export interface SharedRuntime {
+  limiter: <T>(fn: () => Promise<T>) => Promise<T>;
+  agentCount: number;
+  spent: number;
+  tokenUsage: { input: number; output: number; total: number; cost: number };
+  depth: number;
+}
+
+export interface WorkflowRunOptions extends WorkflowAgentOptions {
+  args?: unknown;
+  agent?: Pick<WorkflowAgent, "run">;
+  /** The session's main model (provider/id), shown in /workflows for default agents. */
+  mainModel?: string;
+  concurrency?: number;
+  tokenBudget?: number | null;
+  signal?: AbortSignal;
+  /** Maximum number of agents allowed in this run. Default: 1000 */
+  maxAgents?: number;
+  /** Timeout per agent in milliseconds. Default: 5 minutes */
+  agentTimeoutMs?: number;
+  /** Whether to persist logs to disk. Default: true */
+  persistLogs?: boolean;
+  /** Run ID for persistence. Auto-generated if not provided. */
+  runId?: string;
+  /** Resume: cached agent results keyed by deterministic call index. */
+  resumeJournal?: Map<number, JournalEntry>;
+  /** Resume: the run being resumed (informational; enables resume mode). */
+  resumeFromRunId?: string;
+  /** Called after each live agent completes so the caller can persist the journal. */
+  onAgentJournal?: (entry: JournalEntry) => void;
+  /** Internal: shared runtime inherited by a nested workflow() call. */
+  sharedRuntime?: SharedRuntime;
+  /** Resolve a saved-workflow name to its script, enabling `workflow('name', args)`. */
+  loadSavedWorkflow?: (name: string) => string | undefined;
+  onLog?: (message: string) => void;
+  onPhase?: (title: string) => void;
+  onAgentStart?: (event: { label: string; phase?: string; prompt: string; model?: string }) => void;
+  onAgentEnd?: (event: {
+    label: string;
+    phase?: string;
+    result: unknown;
+    tokens?: number;
+    worktree?: string;
+    model?: string;
+  }) => void;
+  onTokenUsage?: (usage: { input: number; output: number; total: number; cost: number }) => void;
+}
+
+export interface WorkflowRunResult<T = unknown> {
+  meta: WorkflowMeta;
+  result: T;
+  logs: string[];
+  phases: string[];
+  agentCount: number;
+  durationMs: number;
+  runId?: string;
+  tokenUsage?: {
+    input: number;
+    output: number;
+    total: number;
+    cost: number;
+  };
+}
+
+export interface AgentOptions<TSchemaDef extends TSchema | undefined = TSchema | undefined> {
+  label?: string;
+  phase?: string;
+  schema?: TSchemaDef;
+  /**
+   * Run this agent on a specific model (`provider/modelId` or a bare `modelId`).
+   * The workflow author chooses per-agent models per the routing policy in the
+   * tool guidelines (e.g. a lighter model for exploration, the main model for
+   * analysis). When omitted, the session's main model is used.
+   */
+  model?: string;
+  isolation?: "worktree";
+  agentType?: string;
+  /** Override timeout for this specific agent. */
+  timeoutMs?: number;
+}
+
+interface RuntimeState {
+  currentPhase?: string;
+  logs: string[];
+  phases: string[];
+  /** Monotonic, assigned at lexical agent() call time — the stable resume key. */
+  callSeq: number;
+}
+
+type AnyNode = Node & { [key: string]: any; start: number; end: number };
+
+/**
+ * A `Math` without `random`, handed to the workflow vm context. The static
+ * determinism guard (assertDeterministic) already rejects `Math.random` and
+ * references to Date/globalThis/Reflect/Function/eval, but it can't see an alias
+ * like `const M = Math; M.random()`. Removing `random` from the live binding
+ * closes that residual at runtime. Native Math methods don't use `this`, so the
+ * copied references work; the constants (PI, E, …) copy by value.
+ */
+const SAFE_MATH: typeof Math = Object.freeze(
+  Object.fromEntries(
+    Object.getOwnPropertyNames(Math)
+      .filter((key) => key !== "random")
+      .map((key) => [key, (Math as unknown as Record<string, unknown>)[key]]),
+  ),
+) as unknown as typeof Math;
+
+export async function runWorkflow<T = unknown>(
+  script: string,
+  options: WorkflowRunOptions = {},
+): Promise<WorkflowRunResult<T>> {
+  const started = Date.now();
+  const { meta, body } = parseWorkflowScript(script);
+  // Per-phase model routing from meta.phases[].model (empty when none declared).
+  const routingConfig = parseModelRoutingFromMeta(meta.phases);
+  const maxAgents = options.maxAgents ?? MAX_AGENTS_PER_RUN;
+  const agentTimeoutMs = options.agentTimeoutMs ?? DEFAULT_AGENT_TIMEOUT_MS;
+  const runId = options.runId ?? `run-${started.toString(36)}`;
+  const baseCwd = options.cwd ?? process.cwd();
+
+  // Internal abort, linked to (but distinct from) the external/user signal. We
+  // abort it ourselves when a non-recoverable error (agent-cap / token-budget)
+  // bubbles out of parallel()/pipeline(), so in-flight sibling subagents stop
+  // instead of running on detached. Kept separate from options.signal so the
+  // manager still distinguishes a real failure (this) from a user abort.
+  const runAbort = new AbortController();
+  const onExternalAbort = () => runAbort.abort();
+  if (options.signal) {
+    if (options.signal.aborted) runAbort.abort();
+    else options.signal.addEventListener("abort", onExternalAbort, { once: true });
+  }
+
+  // Initialize logger
+  const logger = createWorkflowLogger({
+    runId,
+    cwd: options.cwd ?? process.cwd(),
+    persist: options.persistLogs ?? true,
+    onLog: options.onLog,
+  });
+
+  const state: RuntimeState = {
+    logs: [],
+    phases: [],
+    callSeq: 0,
+  };
+
+  const agentRunner = options.agent ?? new WorkflowAgent(options);
+  const concurrency = Math.max(
+    1,
+    Math.min(options.concurrency ?? Math.max(1, (globalThis.navigator?.hardwareConcurrency ?? 8) - 2), MAX_CONCURRENCY),
+  );
+  // Global caps + budget are shared with any nested workflow() so they hold across nesting.
+  const shared: SharedRuntime = options.sharedRuntime ?? {
+    limiter: createLimiter(concurrency),
+    agentCount: 0,
+    spent: 0,
+    tokenUsage: { input: 0, output: 0, total: 0, cost: 0 },
+    depth: 0,
+  };
+  const limiter = shared.limiter;
+
+  const log = (message: string) => {
+    const text = String(message);
+    state.logs.push(text);
+    logger.log(text);
+  };
+
+  const phase = (title: string) => {
+    state.currentPhase = title;
+    if (!state.phases.includes(title)) state.phases.push(title);
+    options.onPhase?.(title);
+  };
+
+  const tokenBudget = options.tokenBudget ?? DEFAULT_TOKEN_BUDGET;
+  const budget = Object.freeze({
+    total: tokenBudget,
+    spent: () => shared.spent,
+    remaining: () => (tokenBudget == null ? Infinity : Math.max(0, tokenBudget - shared.spent)),
+  });
+
+  const throwIfAborted = () => {
+    if (runAbort.signal.aborted) {
+      throw new WorkflowError("workflow aborted", WorkflowErrorCode.WORKFLOW_ABORTED, { recoverable: true });
+    }
+  };
+
+  const agent = async (prompt: string, agentOptions: AgentOptions = {}) => {
+    throwIfAborted();
+
+    // Check agent limit
+    if (shared.agentCount >= maxAgents) {
+      throw new WorkflowError(
+        `Agent limit exceeded (${maxAgents}). Use maxAgents option to increase the limit.`,
+        WorkflowErrorCode.AGENT_LIMIT_EXCEEDED,
+        { recoverable: false },
+      );
+    }
+
+    if (budget.total !== null && budget.remaining() <= 0) {
+      throw new WorkflowError("workflow token budget exhausted", WorkflowErrorCode.TOKEN_BUDGET_EXHAUSTED, {
+        recoverable: false,
+      });
+    }
+
+    // Reserve the slot synchronously, before the limiter, so a wide
+    // parallel()/pipeline() fan-out can't enqueue more than maxAgents before any
+    // of them start (the cap is a per-run lifetime cap, not a concurrency cap).
+    const agentNumber = ++shared.agentCount;
+
+    const assignedPhase = agentOptions.phase ?? state.currentPhase;
+    const requestedLabel = agentOptions.label?.trim();
+    // Precedence: explicit agentOptions.model > phase model (meta.phases[].model).
+    const modelSpec = agentOptions.model ?? resolveModelForPhase(assignedPhase, routingConfig);
+    // For display in /workflows: the model this agent runs on — its explicit/phase
+    // spec, else the session's main model. The real resolved id overrides this via
+    // onModelResolved once the subagent session is created.
+    let displayModel = modelSpec ?? options.mainModel;
+
+    // Deterministic resume key: assigned at lexical call time, before the limiter,
+    // so parallel()/pipeline() fan-out is reproducible for a fixed script.
+    const callIndex = state.callSeq++;
+    const callHash = hashAgentCall(prompt, modelSpec, assignedPhase, agentOptions);
+
+    // Resume: replay a cached result for an unchanged call (matching hash), without
+    // consuming a concurrency slot, tokens, or a real subagent run.
+    const cached = options.resumeJournal?.get(callIndex);
+    if (cached && cached.hash === callHash) {
+      const label = requestedLabel || defaultAgentLabel(assignedPhase, agentNumber);
+      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
+      options.onAgentEnd?.({ label, phase: assignedPhase, result: cached.result, tokens: 0, model: displayModel });
+      return cached.result;
+    }
+
+    return limiter(async () => {
+      const label = requestedLabel || defaultAgentLabel(assignedPhase, agentNumber);
+      const timeout = agentOptions.timeoutMs ?? agentTimeoutMs;
+
+      options.onAgentStart?.({ label, phase: assignedPhase, prompt, model: displayModel });
+
+      // Optional per-agent worktree isolation (deterministic name -> stable resume keys).
+      let worktree: Worktree | undefined;
+      if (agentOptions.isolation === "worktree") {
+        worktree = await createWorktree(baseCwd, `${runId}-${callIndex}-${label}`);
+        if (!worktree.isolated) log(`isolation ignored for "${label}" (${worktree.reason})`);
+      }
+      const runCwd = worktree?.isolated ? worktree.cwd : undefined;
+
+      // Captured from the subagent's real session usage; falls back to an
+      // estimate when the provider reports no usage (total === 0).
+      let usage: AgentUsage | undefined;
+      const recordTokens = (result: unknown): number => {
+        const tokens = usage && usage.total > 0 ? usage.total : estimateTokens(result) + estimateTokens(prompt);
+        if (usage) {
+          shared.tokenUsage.input += usage.input;
+          shared.tokenUsage.output += usage.output;
+          shared.tokenUsage.cost += usage.cost;
+        }
+        shared.tokenUsage.total += tokens;
+        shared.spent += tokens;
+        return tokens;
+      };
+
+      // Per-agent timeout that actually aborts the subagent: a controller linked
+      // to the workflow signal, aborted on timeout. agent.ts wires the signal to
+      // session.abort(), so the subagent stops instead of being orphaned by a
+      // bare Promise.race — and because we await the real run promise (it settles
+      // after the abort), the worktree teardown below runs only once it's gone.
+      const agentController = new AbortController();
+      let timedOut = false;
+      const onParentAbort = () => agentController.abort();
+      // Link to the run's internal signal so BOTH a user abort and an internal
+      // non-recoverable-error abort stop this subagent.
+      if (runAbort.signal.aborted) agentController.abort();
+      else runAbort.signal.addEventListener("abort", onParentAbort, { once: true });
+      const timeoutTimer = setTimeout(() => {
+        timedOut = true;
+        agentController.abort();
+      }, timeout);
+      const timeoutError = () =>
+        new WorkflowError(`Agent "${label}" timed out after ${timeout}ms`, WorkflowErrorCode.AGENT_TIMEOUT, {
+          recoverable: true,
+        });
+
+      try {
+        throwIfAborted();
+
+        const result = await agentRunner.run(prompt, {
+          label,
+          schema: agentOptions.schema,
+          signal: agentController.signal,
+          instructions: buildAgentInstructions(assignedPhase, agentOptions),
+          model: modelSpec,
+          cwd: runCwd,
+          onModelResolved: (id: string) => {
+            displayModel = id;
+          },
+          onUsage: (u: AgentUsage) => {
+            usage = u;
+          },
+        } as any);
+
+        if (timedOut) throw timeoutError();
+        throwIfAborted();
+
+        const tokens = recordTokens(result);
+        options.onAgentJournal?.({ index: callIndex, hash: callHash, result });
+        options.onAgentEnd?.({ label, phase: assignedPhase, result, tokens, worktree: runCwd, model: displayModel });
+        return result;
+      } catch (error) {
+        // A timeout aborts agentController, so the run rejects with an abort
+        // error; classify that as a (recoverable) timeout rather than an abort.
+        const workflowError = timedOut ? timeoutError() : wrapError(error, { agentLabel: label });
+        if (!timedOut && options.signal?.aborted) throw error;
+
+        logger.error(`agent ${label} failed: ${workflowError.message}`);
+        const tokens = recordTokens(null);
+        options.onAgentEnd?.({ label, phase: assignedPhase, result: null, tokens, worktree: runCwd });
+
+        // Return null for recoverable errors
+        if (workflowError.recoverable) {
+          return null;
+        }
+        throw workflowError;
+      } finally {
+        clearTimeout(timeoutTimer);
+        runAbort.signal.removeEventListener("abort", onParentAbort);
+        // Always tear down the worktree, even on timeout/abort.
+        if (worktree?.isolated) await removeWorktree(worktree);
+      }
+    });
+  };
+
+  const parallel = async (thunks: Array<() => Promise<unknown>>) => {
+    throwIfAborted();
+    if (!Array.isArray(thunks)) throw new TypeError("parallel() expects an array of functions");
+    if (thunks.some((thunk) => typeof thunk !== "function")) {
+      throw new TypeError("parallel() expects an array of functions, not promises. Wrap each call: () => agent(...)");
+    }
+    return Promise.all(
+      thunks.map(async (thunk, index) => {
+        try {
+          return await thunk();
+        } catch (error) {
+          if (options.signal?.aborted) throw error;
+          const workflowError = wrapError(error);
+          // Cap/budget errors are non-recoverable: abort the fan-out (stopping
+          // in-flight siblings) instead of silently degrading them to null.
+          if (!workflowError.recoverable) {
+            runAbort.abort();
+            throw workflowError;
+          }
+          log(`parallel[${index}] failed: ${workflowError.message}`);
+          return null;
+        }
+      }),
+    );
+  };
+
+  const pipeline = async (
+    items: unknown[],
+    ...stages: Array<(prev: unknown, original: unknown, index: number) => unknown>
+  ) => {
+    throwIfAborted();
+    if (!Array.isArray(items)) throw new TypeError("pipeline() expects an array as the first argument");
+    if (stages.some((stage) => typeof stage !== "function")) {
+      throw new TypeError("pipeline() stages must be functions: pipeline(items, item => ..., result => ...)");
+    }
+    return Promise.all(
+      items.map(async (item, index) => {
+        let value: unknown = item;
+        for (const stage of stages) {
+          try {
+            throwIfAborted();
+            value = await stage(value, item, index);
+            throwIfAborted();
+          } catch (error) {
+            if (options.signal?.aborted) throw error;
+            const workflowError = wrapError(error);
+            // Cap/budget errors are non-recoverable: abort the pipeline (stopping
+            // in-flight siblings) instead of silently degrading them to null.
+            if (!workflowError.recoverable) {
+              runAbort.abort();
+              throw workflowError;
+            }
+            log(`pipeline[${index}] failed: ${workflowError.message}`);
+            return null;
+          }
+        }
+        return value;
+      }),
+    );
+  };
+
+  // Nested workflow(): run a saved workflow (or a raw script) inline, sharing this
+  // run's limiter/counters/budget so the global caps hold. One level deep only.
+  const workflowFn = async (nameOrScript: string, childArgs?: unknown) => {
+    throwIfAborted();
+    if (shared.depth >= 1) {
+      throw new WorkflowError("workflow() can nest only one level deep", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+        recoverable: false,
+      });
+    }
+    const resolved = options.loadSavedWorkflow?.(String(nameOrScript));
+    const childScript = resolved ?? String(nameOrScript);
+    shared.depth++;
+    try {
+      const child = await runWorkflow(childScript, {
+        ...options,
+        args: childArgs,
+        sharedRuntime: shared,
+        // A nested run is its own script; never reuse the parent's resume journal.
+        resumeJournal: undefined,
+        resumeFromRunId: undefined,
+        runId: `${runId}-nested${shared.depth}`,
+        persistLogs: false,
+      });
+      return child.result;
+    } finally {
+      shared.depth--;
+    }
+  };
+
+  const context = vm.createContext({
+    agent,
+    parallel,
+    pipeline,
+    workflow: workflowFn,
+    log,
+    phase,
+    args: options.args,
+    cwd: options.cwd ?? process.cwd(),
+    process: Object.freeze({ cwd: () => options.cwd ?? process.cwd() }),
+    budget,
+    console: {
+      log,
+      info: log,
+      warn: (m: unknown) => log(`[warn] ${String(m)}`),
+      error: (m: unknown) => log(`[error] ${String(m)}`),
+    },
+    JSON,
+    // Math without `random` (see SAFE_MATH) — defense-in-depth for aliased forms.
+    Math: SAFE_MATH,
+    Array,
+    Object,
+    String,
+    Number,
+    Boolean,
+    Set,
+    Map,
+    Promise,
+  });
+
+  const wrapped = `(async () => {\n${body}\n})()`;
+  let result: unknown;
+  try {
+    // The `vm` timeout bounds SYNCHRONOUS evaluation — the script's sync prefix
+    // up to its first await — which is exactly the freeze case (a sync infinite
+    // loop before any await blocks the TUI). Async orchestration is unbounded.
+    result = await new vm.Script(wrapped, { filename: `${meta.name || "workflow"}.js` }).runInContext(context, {
+      timeout: WORKFLOW_SYNC_TIMEOUT_MS,
+    });
+  } catch (error) {
+    if (error instanceof Error && /timed out/i.test(error.message)) {
+      throw new WorkflowError(
+        `workflow script exceeded ${WORKFLOW_SYNC_TIMEOUT_MS}ms of synchronous execution (likely an infinite loop before the first await)`,
+        WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+        { recoverable: false },
+      );
+    }
+    throw error;
+  } finally {
+    options.signal?.removeEventListener("abort", onExternalAbort);
+  }
+
+  // Persist logs
+  const logFile = logger.persist();
+  if (logFile) {
+    log(`Logs persisted to ${logFile}`);
+  }
+
+  // Emit final token usage
+  options.onTokenUsage?.(shared.tokenUsage);
+
+  return {
+    meta,
+    result: result as T,
+    logs: state.logs,
+    phases: state.phases,
+    agentCount: shared.agentCount,
+    durationMs: Date.now() - started,
+    runId,
+    tokenUsage: shared.tokenUsage,
+  };
+}
+
+export function parseWorkflowScript(script: string): { meta: WorkflowMeta; body: string } {
+  const ast = parse(script, {
+    ecmaVersion: "latest",
+    sourceType: "module",
+    allowAwaitOutsideFunction: true,
+    allowReturnOutsideFunction: true,
+    ranges: false,
+  }) as AnyNode;
+
+  // Determinism is enforced on the AST (not a raw-source regex), so the tokens
+  // are only rejected as real calls — never inside strings or comments — and
+  // `Date['now']()`-style bypasses are still caught.
+  assertDeterministic(ast);
+
+  const first = ast.body?.[0] as AnyNode | undefined;
+  if (first?.type !== "ExportNamedDeclaration") {
+    throw new WorkflowError(
+      "`export const meta = { name, description, phases }` must be the first statement in the script",
+      WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+      { recoverable: false },
+    );
+  }
+
+  const declaration = first.declaration as AnyNode | null;
+  if (declaration?.type !== "VariableDeclaration" || declaration.kind !== "const") {
+    throw new WorkflowError(
+      "meta export must be `export const meta = ...`",
+      WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+      {
+        recoverable: false,
+      },
+    );
+  }
+  if (declaration.declarations.length !== 1) {
+    throw new WorkflowError("meta export must declare only `meta`", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+      recoverable: false,
+    });
+  }
+
+  const declarator = declaration.declarations[0] as AnyNode;
+  if (declarator.id?.type !== "Identifier" || declarator.id.name !== "meta") {
+    throw new WorkflowError("meta export must declare `meta`", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+      recoverable: false,
+    });
+  }
+  if (!declarator.init)
+    throw new WorkflowError("meta must have a literal value", WorkflowErrorCode.SCRIPT_VALIDATION_ERROR, {
+      recoverable: false,
+    });
+
+  const meta = evaluateLiteral(declarator.init, "meta");
+  validateMeta(meta);
+
+  return {
+    meta,
+    body: script.slice(0, first.start) + script.slice(first.end),
+  };
+}
+
+/**
+ * Depth-first walk over an acorn AST, visiting every child node with its parent
+ * and the parent key (role) under which it sits — so a visitor can tell, e.g., a
+ * value reference to `Date` from the `.Date` of a member access or a `{Date:…}` key.
+ */
+function walkAst(
+  node: AnyNode | null | undefined,
+  parent: AnyNode | null,
+  role: string | null,
+  visit: (n: AnyNode, parent: AnyNode | null, role: string | null) => void,
+): void {
+  if (!node || typeof node !== "object" || typeof node.type !== "string") return;
+  visit(node, parent, role);
+  for (const key of Object.keys(node)) {
+    const value = (node as Record<string, unknown>)[key];
+    if (Array.isArray(value)) {
+      for (const child of value) walkAst(child as AnyNode, node, key, visit);
+    } else if (value && typeof value === "object") {
+      walkAst(value as AnyNode, node, key, visit);
+    }
+  }
+}
+
+/** Static property name of a MemberExpression — `obj.prop` or `obj['prop']`, else undefined. */
+function memberPropName(node: AnyNode): string | undefined {
+  const prop = node.property as AnyNode;
+  if (!node.computed && prop?.type === "Identifier") return prop.name;
+  if (node.computed && prop?.type === "Literal" && typeof prop.value === "string") return prop.value;
+  return undefined;
+}
+
+/**
+ * True when an Identifier node is a *value reference* (a read of the binding),
+ * not a property name (`x.Date`), an object-literal key (`{Date:…}`), or a
+ * binding site (`const Date = …`, a function parameter/name). Used to flag uses
+ * of forbidden globals while ignoring harmless same-named properties/keys.
+ */
+function isValueReference(parent: AnyNode | null, role: string | null): boolean {
+  if (!parent) return true;
+  if (parent.type === "MemberExpression" && role === "property" && !parent.computed) return false;
+  if (parent.type === "Property" && role === "key" && !parent.computed) return false;
+  if (parent.type === "VariableDeclarator" && role === "id") return false;
+  if (
+    (parent.type === "FunctionDeclaration" ||
+      parent.type === "FunctionExpression" ||
+      parent.type === "ArrowFunctionExpression") &&
+    (role === "id" || role === "params")
+  ) {
+    return false;
+  }
+  if (parent.type === "CatchClause" && role === "param") return false;
+  return true;
+}
+
+/**
+ * Non-deterministic globals that have no legitimate use in a deterministic
+ * workflow script. Forbidding any *value reference* to them (not just `Date.now`)
+ * also catches member-chained and aliased forms — `globalThis.Date.now()`,
+ * `const D = Date; D.now()`, `Reflect.get(Date,'now')()`, `Function('return Date')()`.
+ * `Math` is intentionally absent: it's needed for `Math.floor` etc.; only
+ * `Math.random` is rejected, by property name below.
+ */
+const FORBIDDEN_GLOBALS = new Set(["Date", "globalThis", "Reflect", "Function", "eval"]);
+
+/** Reject the non-deterministic builtins (Date / Math.random / globalThis / …) via the AST. */
+function assertDeterministic(ast: AnyNode): void {
+  const reject = (what: string): never => {
+    throw new WorkflowError(
+      `Workflow scripts must be deterministic: ${what} is not available ` +
+        "(Date.now()/Math.random()/new Date() — including globalThis/alias forms — are rejected)",
+      WorkflowErrorCode.SCRIPT_VALIDATION_ERROR,
+      { recoverable: false },
+    );
+  };
+  walkAst(ast, null, null, (n, parent, role) => {
+    // Math.random / Math['random'] (Math itself stays available for Math.floor etc.).
+    if (n.type === "MemberExpression" && n.object?.type === "Identifier" && n.object.name === "Math") {
+      if (memberPropName(n) === "random") reject("Math.random");
+    }
+    // Any value reference to a forbidden global, however it's reached.
+    if (n.type === "Identifier" && FORBIDDEN_GLOBALS.has(n.name) && isValueReference(parent, role)) {
+      reject(n.name);
+    }
+  });
+}
+
+function evaluateLiteral(node: AnyNode, path: string): unknown {
+  switch (node.type) {
+    case "ObjectExpression": {
+      const out: Record<string, unknown> = {};
+      for (const prop of node.properties as AnyNode[]) {
+        if (prop.type === "SpreadElement") throw new Error(`spread not allowed in ${path}`);
+        if (prop.type !== "Property") throw new Error(`only plain properties allowed in ${path}`);
+        if (prop.computed) throw new Error(`computed keys not allowed in ${path}`);
+        if (prop.kind !== "init" || prop.method) throw new Error(`methods/accessors not allowed in ${path}`);
+        const key = propertyKey(prop.key as AnyNode, path);
+        if (key === "__proto__" || key === "constructor" || key === "prototype") {
+          throw new Error(`reserved key name not allowed in ${path}: ${key}`);
+        }
+        out[key] = evaluateLiteral(prop.value as AnyNode, `${path}.${key}`);
+      }
+      return out;
+    }
+    case "ArrayExpression":
+      return (node.elements as Array<AnyNode | null>).map((element, index) => {
+        if (!element) throw new Error(`sparse arrays not allowed in ${path}`);
+        if (element.type === "SpreadElement") throw new Error(`spread not allowed in ${path}`);
+        return evaluateLiteral(element, `${path}[${index}]`);
+      });
+    case "Literal":
+      return node.value;
+    case "TemplateLiteral":
+      if (node.expressions.length > 0) throw new Error(`template interpolation not allowed in ${path}`);
+      return node.quasis.map((quasi: AnyNode) => quasi.value.cooked ?? quasi.value.raw).join("");
+    case "UnaryExpression":
+      if (node.operator === "-" && node.argument?.type === "Literal" && typeof node.argument.value === "number") {
+        return -node.argument.value;
+      }
+      throw new Error(`only negative-number unary allowed in ${path}`);
+    default:
+      throw new Error(`non-literal node type in ${path}: ${node.type}`);
+  }
+}
+
+function propertyKey(node: AnyNode, path: string): string {
+  if (node.type === "Identifier") return node.name;
+  if (node.type === "Literal" && (typeof node.value === "string" || typeof node.value === "number"))
+    return String(node.value);
+  throw new Error(`unsupported key type in ${path}: ${node.type}`);
+}
+
+function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
+  if (!meta || typeof meta !== "object") throw new Error("meta must be an object");
+  const value = meta as WorkflowMeta;
+  if (typeof value.name !== "string" || !value.name.trim()) throw new Error("meta.name must be a non-empty string");
+  if (typeof value.description !== "string" || !value.description.trim())
+    throw new Error("meta.description must be a non-empty string");
+  if (value.whenToUse !== undefined && typeof value.whenToUse !== "string")
+    throw new Error("meta.whenToUse must be a string");
+  if (value.phases !== undefined) {
+    if (!Array.isArray(value.phases)) throw new Error("meta.phases must be an array");
+    for (const phase of value.phases) {
+      if (!phase || typeof phase !== "object" || typeof (phase as WorkflowMetaPhase).title !== "string") {
+        throw new Error("each meta phase must have a title string");
+      }
+    }
+  }
+}
+
+function createLimiter(limit: number) {
+  let active = 0;
+  const queue: Array<() => void> = [];
+  const next = () => {
+    active--;
+    queue.shift()?.();
+  };
+  return async <T>(fn: () => Promise<T>): Promise<T> => {
+    if (active >= limit) await new Promise<void>((resolve) => queue.push(resolve));
+    active++;
+    try {
+      return await fn();
+    } finally {
+      next();
+    }
+  };
+}
+
+function defaultAgentLabel(phase: string | undefined, index: number): string {
+  return phase ? `${phase} agent ${index}` : `agent ${index}`;
+}
+
+/** Stable identity hash for an agent() call — a cache miss on resume when anything changes. */
+function hashAgentCall(
+  prompt: string,
+  model: string | undefined,
+  phase: string | undefined,
+  options: AgentOptions,
+): string {
+  const identity = JSON.stringify({
+    prompt,
+    model: model ?? null,
+    phase: phase ?? null,
+    agentType: options.agentType ?? null,
+    schema: options.schema ?? null,
+  });
+  return createHash("sha256").update(identity).digest("hex");
+}
+
+function buildAgentInstructions(phase: string | undefined, options: AgentOptions): string | undefined {
+  const lines = [];
+  if (phase) lines.push(`Workflow phase: ${phase}`);
+  if (options.agentType) lines.push(`Act as workflow subagent type: ${options.agentType}`);
+  if (options.isolation) lines.push(`Requested isolation: ${options.isolation}`);
+  // Note: options.model is applied for real via the session, not injected as prose.
+  return lines.length ? lines.join("\n") : undefined;
+}
+
+function estimateTokens(value: unknown): number {
+  return Math.ceil(JSON.stringify(value ?? "").length / 4);
+}

--- a/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/workflow.ts
@@ -788,17 +788,24 @@ function validateMeta(meta: unknown): asserts meta is WorkflowMeta {
 function createLimiter(limit: number) {
   let active = 0;
   const queue: Array<() => void> = [];
-  const next = () => {
-    active--;
-    queue.shift()?.();
+  // On completion, hand the slot DIRECTLY to the next waiter instead of
+  // release-then-reacquire. A release-then-reacquire leaves a microtask gap in
+  // which a fresh limiter() call can also pass the `active >= limit` check and
+  // take the just-freed slot, so it and the resumed waiter both run — exceeding
+  // `limit`. Here a resumed waiter inherits the completing task's slot (active is
+  // left unchanged); only a caller that never waited increments active.
+  const release = () => {
+    const wake = queue.shift();
+    if (wake) wake();
+    else active--;
   };
   return async <T>(fn: () => Promise<T>): Promise<T> => {
     if (active >= limit) await new Promise<void>((resolve) => queue.push(resolve));
-    active++;
+    else active++;
     try {
       return await fn();
     } finally {
-      next();
+      release();
     }
   };
 }

--- a/users/profiles/pi/extensions/dynamic-workflows/src/worktree.ts
+++ b/users/profiles/pi/extensions/dynamic-workflows/src/worktree.ts
@@ -1,0 +1,88 @@
+/**
+ * Per-agent JJ workspace isolation. When an agent requests `isolation: "worktree"`,
+ * it runs in a throwaway `jj workspace` on its own working-copy commit so parallel
+ * agents can edit the same files without conflict. Results are NOT auto-merged — the
+ * path is surfaced for the caller to inspect. Falls back to a logged no-op when
+ * isolation isn't possible.
+ *
+ * JJ-only by design: this machine uses Jujutsu everywhere, so isolation is built on
+ * `jj workspace` rather than `git worktree`. JJ workspaces share the underlying repo
+ * (`.jj/repo`) but keep independent working copies, and they live under the project
+ * dir (`<repoRoot>/.pi/worktrees/`), so isolation also works inside the jailed-pi
+ * sandbox (which only exposes the project cwd read-write).
+ */
+
+import { execFile } from "node:child_process";
+import { join } from "node:path";
+import { promisify } from "node:util";
+
+const exec = promisify(execFile);
+
+// `--ignore-working-copy` keeps these commands from snapshotting (and thereby
+// mutating) the user's current `@` while a workflow fans out in the background.
+const JJ_GLOBAL = ["--ignore-working-copy"];
+
+export interface Worktree {
+  /** True when a real workspace was created; false means "ran in the shared tree". */
+  isolated: boolean;
+  /** cwd the agent should run in (workspace path when isolated, else the base cwd). */
+  cwd: string;
+  /** JJ workspace name (kept on `branch` for caller/interface compatibility). */
+  branch?: string;
+  /** Repo root the workspace was added to (for teardown). */
+  repoRoot?: string;
+  /** Why isolation was skipped, when isolated === false. */
+  reason?: string;
+}
+
+function slug(name: string): string {
+  return (
+    name
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, "-")
+      .replace(/^-+|-+$/g, "")
+      .slice(0, 32) || "agent"
+  );
+}
+
+/**
+ * Create an isolated JJ workspace under `<repoRoot>/.pi/worktrees/<name>` named
+ * `pi-wf-<name>`. The `name` must be deterministic (derived from runId + call index,
+ * never wall-clock) so resume keys stay stable. Returns a no-op Worktree on any failure.
+ */
+export async function createWorktree(baseCwd: string, name: string): Promise<Worktree> {
+  const id = slug(name);
+  let repoRoot: string;
+  try {
+    const { stdout } = await exec("jj", [...JJ_GLOBAL, "root"], { cwd: baseCwd });
+    repoRoot = stdout.trim();
+  } catch {
+    return { isolated: false, cwd: baseCwd, reason: "not a jj repository" };
+  }
+
+  const path = join(repoRoot, ".pi", "worktrees", id);
+  const workspace = `pi-wf-${id}`;
+  try {
+    await exec("jj", [...JJ_GLOBAL, "workspace", "add", "--name", workspace, path], { cwd: repoRoot });
+    return { isolated: true, cwd: path, branch: workspace, repoRoot };
+  } catch (error) {
+    return { isolated: false, cwd: baseCwd, reason: error instanceof Error ? error.message : String(error) };
+  }
+}
+
+/** Forget a workspace and remove its directory. Best-effort; safe on a no-op Worktree. */
+export async function removeWorktree(wt: Worktree): Promise<void> {
+  if (!wt.isolated || !wt.repoRoot) return;
+  if (wt.branch) {
+    try {
+      await exec("jj", [...JJ_GLOBAL, "workspace", "forget", wt.branch], { cwd: wt.repoRoot });
+    } catch {
+      // already forgotten / locked — fall through
+    }
+  }
+  try {
+    await exec("rm", ["-rf", "--", wt.cwd]);
+  } catch {
+    // directory already gone — best-effort cleanup
+  }
+}

--- a/users/profiles/pi/extensions/footer/index.ts
+++ b/users/profiles/pi/extensions/footer/index.ts
@@ -8,7 +8,8 @@
  * Supports jj (Jujutsu) and git VCS backends (auto-detected).
  */
 
-import { spawnSync } from "node:child_process";
+import { execFile } from "node:child_process";
+import { promisify } from "node:util";
 import type { AgentMessage } from "@earendil-works/pi-agent-core";
 import type {
   ExtensionAPI,
@@ -36,6 +37,8 @@ const JJ_TIMEOUT_MS = 1_500;
 const GIT_TIMEOUT_MS = 2_000;
 const VCS_CACHE_TTL_MS = 2_000;
 
+const execFileAsync = promisify(execFile);
+
 // ── Types ───────────────────────────────────────────────────
 
 interface UsageTotals {
@@ -48,6 +51,7 @@ interface UsageTotals {
 
 let cachedVcsInfo: VcsInfo | null = null;
 let lastVcsRefresh = 0;
+let vcsRefreshInFlight = false;
 
 // ── Usage collection ────────────────────────────────────────
 
@@ -92,46 +96,42 @@ function parseDiffStat(raw: string): DiffStat {
   return { files, insertions, deletions };
 }
 
-/** Detect whether cwd is inside a jj repository. */
-function isJjRepo(cwd: string): boolean {
+/** Run a VCS command asynchronously; returns stdout (empty string on any failure). */
+async function runVcs(cmd: string, args: string[], cwd: string, timeout: number): Promise<string> {
   try {
-    const result = spawnSync("jj", ["root"], {
+    const { stdout } = await execFileAsync(cmd, args, {
       cwd,
-      timeout: JJ_TIMEOUT_MS,
-      stdio: ["ignore", "pipe", "ignore"],
+      timeout,
+      windowsHide: true,
+      maxBuffer: 1024 * 1024,
     });
-    return result.status === 0 && (result.stdout?.toString() ?? "").trim().length > 0;
+    return stdout ?? "";
   } catch {
-    return false;
+    return "";
   }
 }
 
-/** Read jj VCS info synchronously. Returns null when not in a jj repo. */
-function readJjInfoSync(cwd: string): VcsInfo | null {
-  if (!isJjRepo(cwd)) return null;
+/** Detect whether cwd is inside a jj repository. */
+async function isJjRepo(cwd: string): Promise<boolean> {
+  return (await runVcs("jj", ["--ignore-working-copy", "root"], cwd, JJ_TIMEOUT_MS)).trim().length > 0;
+}
 
-  const runJj = (args: string[]): string => {
-    try {
-      const result = spawnSync("jj", args, {
-        cwd,
-        timeout: JJ_TIMEOUT_MS,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      return result.status === 0 ? (result.stdout?.toString() ?? "") : "";
-    } catch {
-      return "";
-    }
-  };
+/** Read jj VCS info. Returns null when not in a jj repo. */
+async function readJjInfo(cwd: string): Promise<VcsInfo | null> {
+  if (!(await isJjRepo(cwd))) return null;
+  // `--ignore-working-copy` keeps these read-only renders from snapshotting the
+  // working copy (which would create operation-log noise on every refresh).
+  const runJj = (args: string[]) => runVcs("jj", ["--ignore-working-copy", ...args], cwd, JJ_TIMEOUT_MS);
 
   // Check if current commit is empty
-  const emptyText = runJj([
+  const emptyText = await runJj([
     "log", "-r", "@", "--no-graph", "-T", 'if(empty, "empty", "nonempty")',
   ]);
   const currentIsEmpty = emptyText.trim() === "empty";
   const revset: "@" | "@-" = currentIsEmpty ? "@-" : "@";
 
   // Get revision info
-  const logOutput = runJj([
+  const logOutput = await runJj([
     "log", "-r", revset, "--no-graph", "-T",
     'change_id.short() ++ "\\n" ++ commit_id.short() ++ "\\n" ++ description.first_line() ++ "\\n" ++ bookmarks.join(" ") ++ "\\n"',
   ]);
@@ -140,14 +140,13 @@ function readJjInfoSync(cwd: string): VcsInfo | null {
   const [changeId = "?", _commitId = "?", _description = "", bookmarkLine = ""] = logOutput.split("\n");
 
   // Check for conflicts
-  const conflictText = runJj([
+  const conflictText = await runJj([
     "log", "-r", `conflicts() & ${revset}`, "--no-graph", "-T", "change_id.short()",
   ]);
   const hasConflict = conflictText.trim().length > 0;
 
   // Get diff stat
-  const diffOutput = runJj(["diff", "--stat"]);
-  const diff = parseDiffStat(diffOutput);
+  const diff = parseDiffStat(await runJj(["diff", "--stat"]));
 
   const bookmarks = bookmarkLine.trim().split(/\s+/).filter(Boolean);
   const branch = bookmarks.length > 0 ? bookmarks[0] : changeId.slice(0, 8);
@@ -163,78 +162,57 @@ function readJjInfoSync(cwd: string): VcsInfo | null {
   };
 }
 
-/** Read git VCS info synchronously via git branch + diff. */
-function readGitInfoSync(cwd: string, footerData: ReadonlyFooterDataProvider): VcsInfo | null {
-  const branch = footerData.getGitBranch();
-  if (!branch) return null;
-
-  const runGit = (args: string[]): string => {
-    try {
-      const result = spawnSync("git", args, {
-        cwd,
-        timeout: GIT_TIMEOUT_MS,
-        stdio: ["ignore", "pipe", "ignore"],
-      });
-      return result.status === 0 ? (result.stdout?.toString() ?? "") : "";
-    } catch {
-      return "";
-    }
-  };
-
-  // Parse diff --numstat for added/deleted
-  const numstat = runGit(["diff", "--numstat", "--no-renames", "HEAD", "--"]);
-  if (!numstat.trim()) {
-    // Try staged + unstaged separately
-    const staged = runGit(["diff", "--cached", "--numstat", "--no-renames", "--"]);
-    const unstaged = runGit(["diff", "--numstat", "--no-renames", "--"]);
-    const parseNumstat = (output: string): { added: number; deleted: number } => {
-      let added = 0;
-      let deleted = 0;
-      for (const line of output.split("\n")) {
-        const trimmed = line.trim();
-        if (!trimmed) continue;
-        const [a, d] = trimmed.split(/\s+/, 3);
-        added += Number.parseInt(a ?? "0", 10) || 0;
-        deleted += Number.parseInt(d ?? "0", 10) || 0;
-      }
-      return { added, deleted };
-    };
-    const s = parseNumstat(staged);
-    const u = parseNumstat(unstaged);
-    return {
-      type: "git",
-      branch,
-      added: s.added + u.added,
-      deleted: s.deleted + u.deleted,
-    };
-  }
-
+function parseNumstat(output: string): { added: number; deleted: number } {
   let added = 0;
   let deleted = 0;
-  for (const line of numstat.split("\n")) {
+  for (const line of output.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     const [a, d] = trimmed.split(/\s+/, 3);
     added += Number.parseInt(a ?? "0", 10) || 0;
     deleted += Number.parseInt(d ?? "0", 10) || 0;
   }
-
-  return {
-    type: "git",
-    branch,
-    added,
-    deleted,
-  };
+  return { added, deleted };
 }
 
-/** Refresh cached VCS info. */
-function refreshVcs(cwd: string, footerData: ReadonlyFooterDataProvider): void {
-  const now = Date.now();
-  if (now - lastVcsRefresh < VCS_CACHE_TTL_MS && cachedVcsInfo !== undefined) return;
+/** Read git VCS info via git branch + diff. */
+async function readGitInfo(cwd: string, footerData: ReadonlyFooterDataProvider): Promise<VcsInfo | null> {
+  const branch = footerData.getGitBranch();
+  if (!branch) return null;
+  const runGit = (args: string[]) => runVcs("git", args, cwd, GIT_TIMEOUT_MS);
 
-  // Try jj first, fall back to git
-  cachedVcsInfo = readJjInfoSync(cwd) ?? readGitInfoSync(cwd, footerData);
-  lastVcsRefresh = now;
+  const numstat = await runGit(["diff", "--numstat", "--no-renames", "HEAD", "--"]);
+  if (!numstat.trim()) {
+    // Try staged + unstaged separately
+    const s = parseNumstat(await runGit(["diff", "--cached", "--numstat", "--no-renames", "--"]));
+    const u = parseNumstat(await runGit(["diff", "--numstat", "--no-renames", "--"]));
+    return { type: "git", branch, added: s.added + u.added, deleted: s.deleted + u.deleted };
+  }
+
+  const { added, deleted } = parseNumstat(numstat);
+  return { type: "git", branch, added, deleted };
+}
+
+/**
+ * Non-blocking VCS refresh. render() always reads the cached value synchronously;
+ * when the cache is stale we kick off ONE background refresh (async child
+ * processes — never spawnSync, which froze the TUI event loop ~65ms every
+ * VCS_CACHE_TTL_MS) and requestRender() once the fresh value lands.
+ */
+function refreshVcs(cwd: string, footerData: ReadonlyFooterDataProvider, requestRender: () => void): void {
+  if (Date.now() - lastVcsRefresh < VCS_CACHE_TTL_MS) return;
+  if (vcsRefreshInFlight) return;
+  vcsRefreshInFlight = true;
+  void (async () => {
+    try {
+      // Try jj first, fall back to git.
+      cachedVcsInfo = (await readJjInfo(cwd)) ?? (await readGitInfo(cwd, footerData));
+    } finally {
+      lastVcsRefresh = Date.now();
+      vcsRefreshInFlight = false;
+      requestRender();
+    }
+  })();
 }
 
 // ── Provider-label helper ───────────────────────────────────
@@ -286,11 +264,12 @@ function buildLine(
   codexQuotaTracker: QuotaTracker,
   openCodeGoQuotaTracker: QuotaTracker,
   width: number,
+  requestRender: () => void,
 ): string {
   if (width <= 0) return "";
 
-  // Ensure VCS info is fresh (bounded by TTL)
-  refreshVcs(ctx.cwd, footerData);
+  // Kick a background VCS refresh if stale (non-blocking; render uses the cache).
+  refreshVcs(ctx.cwd, footerData, requestRender);
 
   // Collect usage data
   const usage = collectUsage(ctx);
@@ -418,6 +397,7 @@ export default function footerExtension(pi: ExtensionAPI): void {
               codexQuotaTracker,
               openCodeGoQuotaTracker,
               width,
+              () => tui.requestRender(),
             ),
           ];
         },

--- a/users/profiles/pi/extensions/plan-mode/index.ts
+++ b/users/profiles/pi/extensions/plan-mode/index.ts
@@ -3,6 +3,7 @@ import type { ExtensionAPI, ExtensionCommandContext, ExtensionContext } from "@e
 import { isToolCallEventType } from "@earendil-works/pi-coding-agent";
 import { Key } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
+import { showPlanReview } from "./plan-review.ts";
 import {
   buildPlanFileSummary,
   createInitialState,
@@ -278,13 +279,12 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     if (!ctx.hasUI) return "ExitPlanMode requires an interactive/RPC UI approval flow; no approval was granted.";
 
     const title = extractPlanTitle(plan);
-    const choice = await ctx.ui.select(`${buildPlanReview(plan, planPath)}\n\nChoose approval action for: ${title}`, [
-      APPROVE_HERE,
-      APPROVE_FRESH,
-      EDIT_PLAN,
-      REJECT_REVISE,
-      CANCEL_APPROVAL,
-    ]);
+    const choice = await showPlanReview(ctx.ui, {
+      plan,
+      title,
+      summary: buildPlanFileSummary(plan, planPath),
+      actions: [APPROVE_HERE, APPROVE_FRESH, EDIT_PLAN, REJECT_REVISE, CANCEL_APPROVAL],
+    });
 
     if (choice === APPROVE_HERE) {
       state.lastApprovedPlanFilePath = planPath;
@@ -319,6 +319,21 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
     }
 
     return "Plan approval cancelled. Stay in plan mode and call ExitPlanMode when the plan is ready.";
+  }
+
+  async function showReadOnlyReview(ctx: ExtensionContext, planPath: string): Promise<void> {
+    const plan = readPlan(planPath) ?? "";
+    // The custom overlay needs an interactive UI; fall back to a (clipped) toast otherwise.
+    if (!ctx.hasUI) {
+      ctx.ui.notify(buildPlanReview(plan, planPath), "info");
+      return;
+    }
+    await showPlanReview(ctx.ui, {
+      plan,
+      title: extractPlanTitle(plan),
+      summary: buildPlanFileSummary(plan, planPath),
+      actions: ["Close"],
+    });
   }
 
   pi.registerFlag("plan", {
@@ -359,7 +374,7 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
 
       if (trimmed === "review") {
         const planPath = ensurePlan(ctx);
-        ctx.ui.notify(buildPlanReview(readPlan(planPath) ?? "", planPath), "info");
+        await showReadOnlyReview(ctx, planPath);
         return;
       }
 
@@ -398,7 +413,7 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
       if (!trimmed) {
         if (state.active) {
           const planPath = ensurePlan(ctx);
-          ctx.ui.notify(buildPlanReview(readPlan(planPath) ?? "", planPath), "info");
+          await showReadOnlyReview(ctx, planPath);
         } else {
           const planPath = enterPlanMode(ctx);
           ctx.ui.notify(`Plan mode enabled. Plan file: ${planPath}`, "info");
@@ -511,23 +526,32 @@ export default function blazedPlanMode(pi: ExtensionAPI): void {
   });
 
   pi.on("context", async (event) => {
-    if (state.active) return;
-    return {
-      messages: event.messages.filter(
-        (message) => !isCustomContextMessage(message, PLAN_CONTEXT_TYPE) && !isCustomContextMessage(message, LEGACY_APPROVED_CONTEXT_TYPE),
-      ),
-    };
+    // Strip any prior plan-context snapshots (older sessions persisted one per
+    // turn), and — while active — inject exactly one fresh, EPHEMERAL copy of the
+    // current plan. The context result applies only to this LLM call, so nothing
+    // accumulates in the stored conversation.
+    const messages = event.messages.filter(
+      (message) => !isCustomContextMessage(message, PLAN_CONTEXT_TYPE) && !isCustomContextMessage(message, LEGACY_APPROVED_CONTEXT_TYPE),
+    );
+    if (state.active && state.planFilePath) {
+      messages.push({
+        role: "custom",
+        customType: PLAN_CONTEXT_TYPE,
+        content: buildPlanModeInstructions(state.planFilePath, readPlan(state.planFilePath)),
+        display: false,
+        timestamp: Date.now(),
+      });
+    }
+    return { messages };
   });
 
   pi.on("before_agent_start", async (event, ctx) => {
     if (!state.active) return;
-    const planPath = ensurePlan(ctx);
+    // Ensure a plan file exists; the plan CONTENT is injected ephemerally by the
+    // `context` hook (above), not as a persisted message here — otherwise a fresh
+    // snapshot would be appended to the conversation every turn and pile up.
+    ensurePlan(ctx);
     return {
-      message: {
-        customType: PLAN_CONTEXT_TYPE,
-        content: buildPlanModeInstructions(planPath, readPlan(planPath)),
-        display: false,
-      },
       systemPrompt: `${event.systemPrompt}\n\n[PLAN MODE] Planning is active. Do not implement. Bash is disabled. Write only the plan file and call ExitPlanMode for approval.`,
     };
   });

--- a/users/profiles/pi/extensions/plan-mode/plan-review.ts
+++ b/users/profiles/pi/extensions/plan-mode/plan-review.ts
@@ -1,0 +1,324 @@
+/**
+ * Scrollable plan-review overlay.
+ *
+ * Pi renders a `ui.select` title (and `ui.notify` body) as a static, clipped
+ * block — a plan taller than the terminal can't be scrolled and pushes the
+ * options off-screen. This presents the plan in a focused `ui.custom` overlay
+ * that scrolls the plan body while keeping the action list pinned and visible.
+ *
+ * Keys: ↑/↓ or j/k scroll · PageUp/PageDown (Ctrl-U/Ctrl-D, space) page ·
+ *       g/Home top · G/End bottom · Tab/←→ (or 1–9) move action ·
+ *       Enter confirm · Esc/q cancel.
+ *
+ * The state, line rendering, and key mapping are pure (no pi-tui imports) so
+ * they stay testable; `showPlanReview` is the thin Component shell that wires
+ * them to the overlay. Modeled on dynamic-workflows' openWorkflowNavigator.
+ */
+
+import type { ExtensionUIContext } from "@earendil-works/pi-coding-agent";
+import type { Component, TUI } from "@earendil-works/pi-tui";
+import { parseKey, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+
+/**
+ * Minimal theme surface (matches what plan-mode/index.ts already relies on).
+ * `bg` is optional: the real Theme provides it, the PLAIN test stand-in doesn't,
+ * so the border falls back to an unfilled frame without it.
+ */
+export interface ThemeLike {
+  fg(color: string, text: string): string;
+  bold(text: string): string;
+  bg?(role: string, text: string): string;
+}
+
+const PLAIN: ThemeLike = { fg: (_c, t) => t, bold: (t) => t };
+
+// Horizontal padding between the border and the content.
+const FRAME_PAD = 1;
+// The only background role pi's Theme.bg reliably registers (cardBg/pageBg exist
+// in theme JSON but aren't exposed via Theme.bg). selectedBg is used by pi core,
+// so every theme provides it. See reference_pi_theme_bg_roles.
+const FRAME_BG = "selectedBg";
+
+/** Sentinel line: framePlanPanel renders it as a connecting `├───┤` divider. */
+export const PANEL_DIVIDER = "\x00plan-divider";
+
+/**
+ * Wrap `lines` in a rounded border exactly `width` columns wide, with the title
+ * inline in the top edge. Content rows are right-padded (and bg-filled when the
+ * theme supports it) so the panel stays solid over a terminal wallpaper. A
+ * PANEL_DIVIDER entry becomes a side-connected `├───┤` rule; any entry that
+ * contains newlines is split so it can't escape the frame.
+ * Defensive: any styling failure falls back to the raw lines — this runs in the
+ * TUI render timer, where an uncaught throw crashes pi.
+ */
+export function framePlanPanel(lines: string[], theme: ThemeLike, width: number, title: string): string[] {
+  try {
+    const fill = theme.bg ? (s: string) => theme.bg!(FRAME_BG, s) : (s: string) => s;
+    const edge = (s: string) => fill(theme.fg("border", s));
+    const inner = Math.max(8, width - 2); // span between the two vertical edges
+    const contentW = inner - FRAME_PAD * 2;
+    const pad = " ".repeat(FRAME_PAD);
+    const row = (body: string) =>
+      edge("│") + fill(pad + truncateToWidth(body, contentW, "…", true) + pad) + edge("│");
+
+    // Truncate an over-long title so the top edge can't overflow `width`.
+    const t = truncateToWidth(title, Math.max(0, width - 6), "…");
+    const dashes = Math.max(1, width - 5 - visibleWidth(t)); // ╭(1)─( )(2) t ( )(1) ╮(1)
+    const top = edge("╭─ ") + fill(theme.bold(theme.fg("accent", t))) + edge(` ${"─".repeat(dashes)}╮`);
+    const bottom = edge(`╰${"─".repeat(inner)}╯`);
+    const divider = edge(`├${"─".repeat(inner)}┤`);
+
+    const body = lines.flatMap((line) =>
+      line === PANEL_DIVIDER ? [divider] : line.split("\n").map(row),
+    );
+    return [top, ...body, bottom];
+  } catch {
+    return lines;
+  }
+}
+
+export interface PlanReviewState {
+  scroll: number;
+  actionCursor: number;
+  /** Captured each render cycle via OverlayOptions.visible (render() gets width only). */
+  termHeight: number;
+  /** Plan-body rows shown by the last render — the page-scroll step. */
+  lastViewport: number;
+}
+
+export function createPlanReviewState(): PlanReviewState {
+  return { scroll: 0, actionCursor: 0, termHeight: 24, lastViewport: 0 };
+}
+
+/** Wrap text to the viewport width, preserving blank lines and hard newlines. */
+export function wrapPlan(plan: string, width: number): string[] {
+  const w = Math.max(20, width - 2);
+  const out: string[] = [];
+  for (const para of String(plan).replace(/\t/g, "  ").split("\n")) {
+    if (para.length <= w) {
+      out.push(para);
+      continue;
+    }
+    let rest = para;
+    while (rest.length > w) {
+      out.push(rest.slice(0, w));
+      rest = rest.slice(w);
+    }
+    if (rest) out.push(rest);
+  }
+  return out;
+}
+
+/**
+ * How many plan-body rows fit, given the captured terminal height and the count
+ * of reserved (non-body) rows: borders, summary lines, indicators, divider,
+ * actions, and footer. Computed by the caller so it adapts to a multi-line
+ * summary or a varying number of actions.
+ */
+export function planViewportRows(termHeight: number, reservedRows: number): number {
+  const budget = Math.max(8, Math.floor(termHeight * 0.85));
+  return Math.max(3, budget - reservedRows);
+}
+
+export function maxScrollFor(bodyLen: number, viewportRows: number): number {
+  return Math.max(0, bodyLen - viewportRows);
+}
+
+export interface PlanReviewView {
+  header: string;
+  /** Optional second header line (e.g. plan-file summary). */
+  subheader?: string;
+  actions: string[];
+}
+
+/** Pure: build the overlay's lines for the current scroll/cursor state. */
+export function renderPlanReview(
+  state: PlanReviewState,
+  bodyLines: string[],
+  view: PlanReviewView,
+  width: number,
+  theme: ThemeLike = PLAIN,
+): string[] {
+  const dim = (t: string) => theme.fg("dim", t);
+
+  // Plan-file metadata (a multi-line string) above the plan body.
+  const head: string[] = [];
+  if (view.subheader) for (const line of view.subheader.split("\n")) head.push(dim(line));
+  head.push("");
+
+  // A divider rule separates the plan from the approval actions + footer hint.
+  const tail: string[] = [PANEL_DIVIDER];
+  view.actions.forEach((label, i) => {
+    tail.push(i === state.actionCursor ? theme.fg("accent", theme.bold(`❯ ${label}`)) : `  ${label}`);
+  });
+  tail.push(dim("↑/↓ scroll · PgUp/PgDn page · g/G top/bottom · Tab/1-9 action · enter select · esc cancel"));
+
+  // Reserved = head + the two scroll-indicator rows + tail + the two border rows.
+  const reserved = head.length + 2 + tail.length + 2;
+  const viewport = planViewportRows(state.termHeight, reserved);
+  state.lastViewport = viewport;
+
+  const maxScroll = maxScrollFor(bodyLines.length, viewport);
+  state.scroll = Math.max(0, Math.min(state.scroll, maxScroll));
+  const above = state.scroll;
+  const windowLines = bodyLines.slice(state.scroll, state.scroll + viewport);
+  const below = Math.max(0, bodyLines.length - (state.scroll + viewport));
+
+  const inner = [
+    ...head,
+    above > 0 ? dim(`↑ ${above} more`) : "",
+    ...windowLines,
+    below > 0 ? dim(`↓ ${below} more`) : "",
+    ...tail,
+  ];
+
+  // The title lives in the border's top edge; the frame sizes rows to `width`.
+  return framePlanPanel(inner, theme, width, view.header);
+}
+
+export type PlanReviewAction =
+  | { type: "scroll"; delta: number }
+  | { type: "page"; delta: number }
+  | { type: "top" }
+  | { type: "bottom" }
+  | { type: "moveAction"; delta: number }
+  | { type: "selectAction"; index: number }
+  | { type: "confirm" }
+  | { type: "cancel" }
+  | { type: "none" };
+
+/** Pure: map a parsed key id to a plan-review action. */
+export function keyToPlanAction(keyId: string | undefined): PlanReviewAction {
+  switch (keyId) {
+    case "up":
+    case "k":
+      return { type: "scroll", delta: -1 };
+    case "down":
+    case "j":
+      return { type: "scroll", delta: 1 };
+    case "pageUp":
+    case "ctrl+u":
+      return { type: "page", delta: -1 };
+    case "pageDown":
+    case "ctrl+d":
+    case "space":
+      return { type: "page", delta: 1 };
+    case "g":
+    case "home":
+      return { type: "top" };
+    case "G":
+    case "shift+g":
+    case "end":
+      return { type: "bottom" };
+    case "tab":
+    case "right":
+      return { type: "moveAction", delta: 1 };
+    case "shift+tab":
+    case "left":
+      return { type: "moveAction", delta: -1 };
+    case "enter":
+    case "return":
+      return { type: "confirm" };
+    case "escape":
+    case "esc":
+    case "q":
+      return { type: "cancel" };
+    default:
+      if (keyId && /^[1-9]$/.test(keyId)) return { type: "selectAction", index: Number(keyId) - 1 };
+      return { type: "none" };
+  }
+}
+
+export interface PlanReviewOptions {
+  /** The plan body to display (already read from disk — do no I/O in render). */
+  plan: string;
+  /** Header title (e.g. the plan title). */
+  title: string;
+  /** Optional subheader line (e.g. plan-file summary). */
+  summary?: string;
+  /** Selectable actions; the resolved value is the chosen label, or undefined on cancel. */
+  actions: string[];
+}
+
+/**
+ * Show the scrollable plan-review overlay. Resolves to the chosen action label,
+ * or undefined when cancelled (esc/q). Requires an interactive UI.
+ */
+export function showPlanReview(ui: ExtensionUIContext, opts: PlanReviewOptions): Promise<string | undefined> {
+  const state = createPlanReviewState();
+  const actions = opts.actions.length ? opts.actions : ["Close"];
+  const view: PlanReviewView = { header: `📋 ${opts.title}`, subheader: opts.summary, actions };
+
+  return ui.custom<string | undefined>(
+    (tui: TUI, theme, _keybindings, done) => {
+      let bodyLines: string[] = [];
+      let lastWidth = -1;
+
+      const pageDelta = () => Math.max(1, state.lastViewport - 1);
+
+      const act = (data: string) => {
+        const action = keyToPlanAction(parseKey(data));
+        switch (action.type) {
+          case "scroll":
+            state.scroll += action.delta;
+            break;
+          case "page":
+            state.scroll += action.delta * pageDelta();
+            break;
+          case "top":
+            state.scroll = 0;
+            break;
+          case "bottom":
+            // Clamped against maxScroll in render; a large value pins to bottom.
+            state.scroll = bodyLines.length;
+            break;
+          case "moveAction":
+            state.actionCursor = (state.actionCursor + action.delta + actions.length) % actions.length;
+            break;
+          case "selectAction":
+            if (action.index < actions.length) state.actionCursor = action.index;
+            break;
+          case "confirm":
+            done(actions[state.actionCursor]);
+            return;
+          case "cancel":
+            done(undefined);
+            return;
+          default:
+            return;
+        }
+        if (state.scroll < 0) state.scroll = 0;
+        tui.requestRender();
+      };
+
+      const component: Component = {
+        render: (width: number) => {
+          if (width !== lastWidth) {
+            // Frame eats 2 edge cols + 2 padding cols; wrapPlan keeps its own
+            // gutter, so width-2 yields lines that fit the framed content width.
+            bodyLines = wrapPlan(opts.plan, width - 2);
+            lastWidth = width;
+          }
+          return renderPlanReview(state, bodyLines, view, width, theme);
+        },
+        handleInput: (data: string) => act(data),
+        invalidate: () => {
+          lastWidth = -1;
+        },
+      };
+      return component;
+    },
+    {
+      overlay: true,
+      overlayOptions: {
+        width: "85%",
+        maxHeight: "85%",
+        anchor: "center",
+        visible: (_termWidth: number, termHeight: number) => {
+          state.termHeight = termHeight;
+          return true;
+        },
+      },
+    },
+  );
+}


### PR DESCRIPTION
## Summary

Adds the **dynamic-workflows** pi extension plus two related extension improvements, in three reviewable commits:

1. **feat(pi): add dynamic-workflows extension** — deterministic `agent()`/`parallel()`/`pipeline()` workflow orchestration: background runs, pause/resume, a `/workflows` navigator, saved workflows, and the `/deep-research` + `/adversarial-review` commands. `acorn` is Nix-vendored and co-located in the extension's `vendor/` dir so its relative `../vendor/acorn.mjs` import resolves under the symlinked store. `web_search` uses **Exa** (`api.exa.ai`) when `EXA_API_KEY` / `~/.pi/web-search.json` is configured (else a best-effort Bing scrape), with a breadcrumb at `.pi/workflows/runs/web-search.log` recording which backend ran. Plain `pi` now also picks up the Exa key from the agenix secret (mirroring `jailed-pi`).
2. **feat(pi-plan-mode): scrollable bordered plan review + ephemeral plan context** — the approval flow renders the plan in a scrollable, bordered `ui.custom` overlay (replacing the clipped, non-scrollable select), and injects plan context per-LLM-call so hidden plan snapshots no longer accumulate in the conversation while plan mode is active.
3. **fix(pi-footer): gather VCS info asynchronously, without snapshotting the working copy** — moves jj/git status gathering off the TUI event loop (sync exec → async + background cache refresh) and passes `--ignore-working-copy` so a render never snapshots the working copy or creates operation-log churn.

A static code review of the initial extension code flagged ~12 issues; the fixes are folded into the relevant commits: unhandled background-run rejection, synchronous agent-slot reservation + non-recoverable error propagation in `parallel`/`pipeline`, per-agent timeout that actually aborts the subagent, pause-vs-abort status handling, background exec options + a ≥1-agent check for all modes, path-traversal guards on saved names/run IDs, `.gitignore` for run state, a VM sync-timeout + AST-based determinism guard, and editor restore-on-shutdown.

## Validation

- Touched TypeScript type-checked in isolation (strict `tsc`, `@earendil-works/*` mapped to the pi dist `.d.ts`) and/or transpiled with esbuild; Nix linted with `statix` and key derivations (`pi-extensions`, `pi-with-exa`) built.
- Runtime-tested in isolation: AST determinism guard (rejects `Date.now()`/`Math.random()`/`new Date()`/`Date['now']()`, allows them in strings/comments), plan-review panel geometry, Exa request/parse/fallback, and the breadcrumb writer.

## Test plan

- `nix flake check --impure` (or build the relevant host config).
- After a home-manager switch:
  - `/plan <task>` → `ExitPlanMode`: scroll a long plan with ↑/↓/PgUp/PgDn, confirm the action row stays visible and selectable.
  - `/deep-research <question>`: `tail -f .pi/workflows/runs/web-search.log` and confirm `web_search[exa] …` lines (vs `[bing]` fallback).
  - Confirm the footer renders without adding `jj op log` entries.