### PR TITLE
ci: cache codex and enable lighter host builds

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -92,7 +92,7 @@ jobs:
     - env:
         PKG: ${{ matrix.pkg }}
       run: |
-        nix build .#packages.x86_64-linux.$PKG -L
+        nix build ".#packages.x86_64-linux.$PKG" -L
 
   router_test:
     runs-on: ubuntu-latest
@@ -115,33 +115,31 @@ jobs:
         # against the seeded output, instead of just trusting the cache.
         nix build .#checks.x86_64-linux.router -L --rebuild
 
-  # Disable until own runners
-  # host_x86_64_linux:
-  #   needs: hosts_x86_64_linux
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix: ${{ fromJson(needs.hosts_x86_64_linux.outputs.matrix) }}
-  #   steps:
-  #   - uses: actions/checkout@v6
-  #   - uses: DeterminateSystems/nix-installer-action@v22
-  #     with:
-  #       extra-conf: |
-  #         accept-flake-config = true
-  #   - uses: cachix/cachix-action@v17
-  #     with:
-  #       name: blazed
-  #   - name: Run the Magic Nix Cache
-  #     uses: DeterminateSystems/magic-nix-cache-action@v13
-  #   - env:
-  #       HOST: ${{ matrix.host }}
-  #     run: |
-  #       nix build .#nixosConfigurations.$HOST.config.system.build.toplevel
+  host_x86_64_linux:
+    needs: hosts_x86_64_linux
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix: ${{ fromJson(needs.hosts_x86_64_linux.outputs.matrix) }}
+    steps:
+    - uses: actions/checkout@v6
+    - uses: DeterminateSystems/nix-installer-action@v22
+      with:
+        extra-conf: |
+          accept-flake-config = true
+    - uses: cachix/cachix-action@v17
+      with:
+        name: blazed
+        authToken: '${{ secrets.CACHIX_AUTH_TOKEN }}'
+    - env:
+        HOST: ${{ matrix.host }}
+      run: |
+        nix build ".#nixosConfigurations.$HOST.config.system.build.toplevel"
 
   summarize:
     if: ${{ always() }}
     runs-on: ubuntu-latest
     name: Build (matrix)
-    needs: [pkg_x86_64_linux, nix_lint, nix_check, router_test]
+    needs: [pkg_x86_64_linux, host_x86_64_linux, nix_lint, nix_check, router_test]
     steps:
       - name: Check linting status
         if: ${{ needs.nix_lint.result != 'success' }}
@@ -152,9 +150,9 @@ jobs:
       - name: Check router test status
         if: ${{ needs.router_test.result != 'success' }}
         run: exit 1
-      # - name: Check x86_64-linux host build matrix status
-      #   if: ${{ needs.host_x86_64_linux.result != 'success' }}
-      #   run: exit 1
+      - name: Check x86_64-linux host build matrix status
+        if: ${{ needs.host_x86_64_linux.result != 'success' }}
+        run: exit 1
       - name: Check x86_64-linux package build matrix status
         if: ${{ needs.pkg_x86_64_linux.result != 'success' }}
         run: exit 1

--- a/flake.nix
+++ b/flake.nix
@@ -8,12 +8,14 @@
       "https://blazed.cachix.org"
       "https://cachix.cachix.org"
       "https://hyprland.cachix.org"
+      "https://cache.numtide.com"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
       "blazed.cachix.org-1:e9Rx3vtlQSp3nckCdGYpSFJbOb/hi1KuTyvWTBkiwAI="
       "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
       "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
+      "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
     ];
   };
 

--- a/flake/github-actions.nix
+++ b/flake/github-actions.nix
@@ -19,6 +19,14 @@ let
     "devenv-up"
     "candle" # Disabled until I can figure out why it fails
   ];
+  # These workstation hosts currently exceed GitHub-hosted runner limits when
+  # building from a cold cache. Keep lighter host builds enabled, and cache the
+  # agent packages through the package matrix instead.
+  hostSkip = [
+    "amelia"
+    "diana"
+    "nicolina"
+  ];
 in
 {
   flake = {
@@ -54,7 +62,9 @@ in
     github-actions-host-matrix-x86-64-linux = {
       os = [ "ubuntu-latest" ];
       host = mapAttrsToList (name: _: name) (
-        filterAttrs (_: config: config.pkgs.system == "x86_64-linux") self.nixosConfigurations
+        filterAttrs (
+          name: config: config.pkgs.system == "x86_64-linux" && !(elem name hostSkip)
+        ) self.nixosConfigurations
       );
     };
 

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -48,6 +48,7 @@
           };
           persway = inputs.persway.packages.${system}.default;
           candle = inputs.candle.packages.${system}.default;
+          codex = inputs.llm-agents.packages.${system}.codex;
 
           inherit (inputs.hyprland.packages.${system})
             hyprland


### PR DESCRIPTION
## Summary
- enable the x86_64 host build matrix for hosts that fit on GitHub-hosted runners
- skip workstation hosts (`amelia`, `diana`, `nicolina`) because they timed out from a cold cache in CI
- expose Codex as a package output so the package matrix pushes it to blazed.cachix.org
- add Numtide's binary cache for llm-agents.nix substitutions
- quote nix build flake refs to satisfy actionlint/shellcheck

## Validation
- nix eval .#github-actions-host-matrix-x86-64-linux --json
- nix eval .#github-actions-package-matrix-x86-64-linux --json
- nix eval .#packages.x86_64-linux.codex.drvPath --raw
- nix shell nixpkgs#actionlint --command actionlint .github/workflows/ci.yaml
- statix check .