### PR TITLE
Stop enabling Podman on server profile

### DIFF
--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -16,9 +16,6 @@ in
   networking.usePredictableInterfaceNames = false;
   networking.useDHCP = true;
 
-  virtualisation.podman.enable = true;
-  virtualisation.podman.dockerCompat = true;
-
   environment.systemPackages = [
     pkgs.wget
     pkgs.vim

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -56,8 +56,11 @@
   environment.persistence."/keep".directories = [ "/var/cache/powertop" ];
 
   virtualisation.docker.enable = false;
-  virtualisation.podman.enable = true;
-  virtualisation.podman.dockerCompat = true;
+  virtualisation.podman = {
+    enable = true;
+    dockerCompat = true;
+    extraPackages = [ pkgs.podman-compose ];
+  };
 
   programs.ssh.startAgent = true;
   services.gnome.gcr-ssh-agent.enable = false;

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -32,7 +32,7 @@ let
   thirdPartyPackages = [
     "npm:@juicesharp/rpiv-ask-user-question@1.18.2"
     "npm:@juicesharp/rpiv-todo@1.18.2"
-    "npm:@plannotator/pi-extension@0.20.2"
+    "npm:@blazed/plannotator-pi-extension@0.20.2-blazed.0"
     "npm:pi-hashline-readmap@0.9.1"
     "npm:pi-web-access@0.10.7"
   ];


### PR DESCRIPTION
## Summary
- stop enabling Podman in the generic server profile
- keep Podman and podman-compose support on workstations, including nicolina
- switch Pi to the blazed plannotator extension fork

## Validation
- statix check .
- nix eval nicolina virtualisation settings: Podman enabled with podman-compose
- nix eval sophia virtualisation settings: Docker/Podman disabled
