### PR TITLE
chore(pi): update tooling and jj-core docs for jj 0.42

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -361,11 +361,11 @@
         "rust-overlay": "rust-overlay"
       },
       "locked": {
-        "lastModified": 1782153911,
-        "narHash": "sha256-Z7BG4cSJX1ybJeZztEMV8WlE6GrXJsSd34x9eHvpzU8=",
+        "lastModified": 1782231411,
+        "narHash": "sha256-W/Yhek5L3nc0gaGgMHPrzO6DbLGq7Yb9DKw/kvLwij0=",
         "owner": "cachix",
         "repo": "devenv",
-        "rev": "d894e487bb23ed87e0555d2158710844bde65322",
+        "rev": "a4fd3348220d96f7602385adff0ace482e720586",
         "type": "github"
       },
       "original": {
@@ -402,11 +402,11 @@
         "rust-analyzer-src": "rust-analyzer-src"
       },
       "locked": {
-        "lastModified": 1782131086,
-        "narHash": "sha256-M73jIp606F878X6bq/dQ11IRmAwd+/ssdK+7qvr50vo=",
+        "lastModified": 1782208688,
+        "narHash": "sha256-oEax2Unvaq0wD8tZs+Kk3zzeUduOegVYW8R9nM5S3Os=",
         "owner": "nix-community",
         "repo": "fenix",
-        "rev": "309fb007facc8caa25c99413502b38fddb3ffdc2",
+        "rev": "5d0542f6ba83f9366095b0e9966b0377c4c1cb31",
         "type": "github"
       },
       "original": {
@@ -965,11 +965,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782166451,
-        "narHash": "sha256-SA7LyrayyZBvtzZnesnSLV7haciFuVLeZaX2hd5v4j4=",
+        "lastModified": 1782233665,
+        "narHash": "sha256-h/xOtrByoA/Ak1lWHn0O1lVZz4qWYbwOSLQ8YSwQO0I=",
         "owner": "nix-community",
         "repo": "home-manager",
-        "rev": "471a1d2f840eb7fcbdfd541d99c13a64096f46db",
+        "rev": "062581938b4a378a82dfbb294b494808157153a1",
         "type": "github"
       },
       "original": {
@@ -1074,11 +1074,11 @@
         "xdph": "xdph"
       },
       "locked": {
-        "lastModified": 1782070887,
-        "narHash": "sha256-rwKRD8h3bxVebEDNyoaPh+q0dqdqvrAE8+1T4Jo3xxs=",
+        "lastModified": 1782226626,
+        "narHash": "sha256-aFkQmqXUPXzV117P853JKe6s/pzohzxZSjzCs9Pw9fc=",
         "owner": "hyprwm",
         "repo": "Hyprland",
-        "rev": "5a7078d20a14bb199ef9bb81faa4faeaf5e92117",
+        "rev": "049595e196db4a4ab162ce58aadd016e929327c8",
         "type": "github"
       },
       "original": {
@@ -1380,11 +1380,11 @@
         "treefmt-nix": "treefmt-nix_3"
       },
       "locked": {
-        "lastModified": 1782166408,
-        "narHash": "sha256-bAgLlHVh6HEhEKKvmtc7kGAu5d6JGecr0jVdDJdYkCM=",
+        "lastModified": 1782242201,
+        "narHash": "sha256-zmzZD0IPkvCdSxHjyYkXf5jtec0uHlxywdCWOZoLyPU=",
         "owner": "numtide",
         "repo": "llm-agents.nix",
-        "rev": "8383ddd91648932b480499f886c3c4b288c7d5ad",
+        "rev": "c7b5635bb1720f34047f192d4ac13a20ae6b661a",
         "type": "github"
       },
       "original": {
@@ -1824,11 +1824,11 @@
         "nixpkgs": "nixpkgs_5"
       },
       "locked": {
-        "lastModified": 1782168698,
-        "narHash": "sha256-a8Q3QKjUM9Vnl3UDRGsFPqiiTphwpZNDIQ6t0m59vIk=",
+        "lastModified": 1782242685,
+        "narHash": "sha256-OoL5ETkya/eVdRyNWYj0GMVX0dFqer/Xmjp+yy7xJzQ=",
         "owner": "nix-community",
         "repo": "NUR",
-        "rev": "37af6266c24b505174f60833915b8f4a5758e5d6",
+        "rev": "18827751f4d833028823ef39aac452b740d3fde2",
         "type": "github"
       },
       "original": {
@@ -1961,11 +1961,11 @@
     "rust-analyzer-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1782030001,
-        "narHash": "sha256-1JBvwtGyIsEBIemJBi6syH7iQ+pct7i+HNa1WSZfozs=",
+        "lastModified": 1782126558,
+        "narHash": "sha256-HLXplzCGoc5mBVXdJriEsfX0gLDNXZ+O5urcdTmLP+E=",
         "owner": "rust-lang",
         "repo": "rust-analyzer",
-        "rev": "69ccffdb5b3570c6c14c5780bf2e8836f2209d90",
+        "rev": "ff5fcc70d9bcdc54db365114e2f7b1c18056ed4f",
         "type": "github"
       },
       "original": {
@@ -2003,11 +2003,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1782098508,
-        "narHash": "sha256-YeBVH+avasLg/ZTOyshNI4qfU8p5RbMs9O8944A1QDg=",
+        "lastModified": 1782184651,
+        "narHash": "sha256-4XHdXp3MRa++XiGkltJChCtdbCmSlNTwQRfWQOhqbRw=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "67eed429b53d462923d9be580cfc9ed372f7564f",
+        "rev": "f59bc28dd0b89e9c0240d1b80195559fc79c2471",
         "type": "github"
       },
       "original": {

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -30,7 +30,7 @@ let
   # ---- Declarative extensibility knobs --------------------------------------
   # THIRD-PARTY extensions Pi auto-installs (settings.packages):
   thirdPartyPackages = [
-    "npm:@blazed/plannotator-pi-extension@0.20.2-blazed.1"
+    "npm:@blazed/plannotator-pi-extension@0.20.3-blazed.3"
     "npm:@juicesharp/rpiv-ask-user-question@1.20.0"
     "npm:@juicesharp/rpiv-todo@1.20.0"
     "npm:pi-hashline-readmap@0.10.0"

--- a/users/profiles/pi/skills/jj-core/SKILL.md
+++ b/users/profiles/pi/skills/jj-core/SKILL.md
@@ -1,10 +1,10 @@
 ---
 name: jj-core
-description: Expert guidance for using JJ (Jujutsu) version control system. MUST be used before any `jj` or `git` command or version-control operation in JJ-backed repositories, including status/log/diff/fetch/push/bookmark/branch/history inspection. Covers JJ operations, revsets, templates, evolog, recovery, and Git interop boundaries.
+description: Expert guidance for using JJ (Jujutsu) version control system. MUST be used before any `jj` or `git` command or version-control operation in JJ-backed repositories, including status/log/diff/fetch/push/bookmark/branch/history inspection. Covers JJ operations, revsets, templates, evolog, recovery, `jj fix`, and Git interop boundaries.
 metadata:
-  keywords: ["jj", "jujutsu", "git", "revsets", "bookmarks", "history"]
+  keywords: ["jj", "jujutsu", "git", "revsets", "bookmarks", "history", "fix", "formatting"]
   related: [jj-todo, conventional-commits]
-  version_target: "0.41.x"
+  version_target: "0.42.x"
 ---
 
 # JJ (Jujutsu) Version Control Helper
@@ -13,7 +13,7 @@ Git-compatible VCS with a different data model: no staging area; the working cop
 
 > ⚠️ **Avoid `git` mutations in a JJ repo** — they bypass JJ's operation log and can confuse colocated state. Prefer `jj` for mutating operations. Read-only Git commands like `git log`, `git diff`, `git show`, `git blame`, and `git grep` are fine.
 
-Tested against `jj 0.41.0`. Prefer current canonical command names in examples;
+Tested against `jj 0.42.0`. Prefer current canonical command names in examples;
 short aliases are often configured by default but can be disabled or confusing in
 `jj help` output.
 
@@ -56,6 +56,8 @@ jj restore --from <rev> <fileset>     # Restore files from another revision
 
 jj split -r <rev> <paths> -m "text"   # Split selected paths into another revision
 jj absorb                             # Auto-squash changes into ancestor commits
+jj fix [filesets]                    # Run configured fix tools (default source: revsets.fix or reachable(@, mutable()))
+jj fix -s <revset> [filesets]        # Limit source revisions and paths/filesets to fix
 jj rebase -s <src> -o <dest>          # Rebase source and descendants onto dest
 jj rebase -r <rev> -o <dest>          # Rebase only selected revision(s)
 
@@ -82,6 +84,30 @@ jj tag delete <name>                  # Delete local tag
 jj git colocation enable              # Convert to colocated repo
 jj git colocation disable             # Convert to non-colocated
 ```
+
+## Formatting/Fixing with `jj fix`
+
+Use `jj fix` when configured formatters or content transformers should be applied
+through JJ history rather than directly editing the working tree.
+
+```bash
+jj fix                         # Fix changed files in revsets.fix, else reachable(@, mutable())
+jj fix -s @                    # Fix @ and its descendants
+jj fix 'glob:**/*.nix'         # Limit to matching paths/filesets
+jj fix --include-unchanged-files <fileset>  # Also process unchanged matching files
+jj fix --all-lines             # Ignore line-range config and format whole modified files
+```
+
+By default, `jj fix` rewrites files changed in the source revisions and updates
+descendants for the same paths so fixes are not lost. Path arguments are JJ
+filesets. Review the operation with `jj op show -p`; recover with `jj undo` (or
+`jj op restore <op>` from `jj op log`).
+
+Configure tools in JJ config under `fix.tools.<name>` with a `command` array and
+`patterns` filesets. Optional keys include `enabled`, `line-range-arg`, and
+`run-tool-if-zero-line-ranges`. Tool commands read stdin and write fixed content
+to stdout; use `$path` for the repo-relative file path and `$root` for the
+workspace root. See [command syntax](references/command-syntax.md#jj-fix-config-patterns) for expanded examples.
 
 ## Quick Revset Reference
 

--- a/users/profiles/pi/skills/jj-core/references/batch-operations.md
+++ b/users/profiles/pi/skills/jj-core/references/batch-operations.md
@@ -1,6 +1,6 @@
 # Batch Operations on Multiple Revisions
 
-Target: `jj 0.41.x`.
+Target: `jj 0.42.x`.
 
 ## Problem
 

--- a/users/profiles/pi/skills/jj-core/references/command-syntax.md
+++ b/users/profiles/pi/skills/jj-core/references/command-syntax.md
@@ -1,6 +1,6 @@
 # JJ Command Syntax Reference
 
-Target: `jj 0.41.x`.
+Target: `jj 0.42.x`.
 
 ## The `-r` Flag
 
@@ -16,9 +16,9 @@ jj rebase -r <revset> -o main
 jj edit <revset>
 ```
 
-In 0.41, some help prose mentions `--revisions/-r` while the option table says
-`--revision`. Avoid the mismatch by using `-r` unless the long form is important
-for readability.
+As of 0.42, help prose and option tables can still use different long-form
+names for some revision arguments. Avoid the mismatch by using `-r` unless the
+long form is important for readability.
 
 ## Canonical Command Names
 
@@ -50,7 +50,7 @@ jj revert -d main           → jj revert -o main
 jj describe --edit          → jj describe --editor
 ```
 
-By 0.41, `-d` is still accepted as an alias for `-o` on rebase/split/revert.
+By 0.42, `-d` is still accepted as an alias for `-o` on rebase/split/revert.
 Prefer `-o`/`--onto` in new scripts and docs.
 
 ## Command Patterns
@@ -128,6 +128,33 @@ jj op restore <op-id>
 
 `--no-integrate-operation` is useful for local JJ graph mutations, but it does
 not prevent side effects outside the repo (for example, a Git push still pushes).
+
+### `jj fix` Config Patterns
+
+`jj fix` tools are subprocess filters: JJ sends file content on stdin and uses
+stdout as the fixed file content when the command exits successfully.
+
+```toml
+[fix.tools.clang-format]
+command = ["clang-format", "--assume-filename=$path"]
+patterns = ["glob:**/*.cc", "glob:**/*.h"]
+line-range-arg = "--lines=$first:$last"
+
+[fix.tools.black]
+command = ["black", "-", "--stdin-filename=$path"]
+patterns = ["glob:**/*.py"]
+
+[fix.tools.biome]
+command = ["$root/node_modules/@biomejs/biome/bin/biome", "format", "--stdin-file-path=$path"]
+patterns = ["glob:**/*.ts", "glob:**/*.tsx"]
+```
+
+Useful optional keys:
+
+- `enabled = false`: define a global tool but enable it per repo.
+- `line-range-arg`: pass modified-line ranges to tools that support them.
+- `run-tool-if-zero-line-ranges = true`: run even when there are no modified
+  line ranges, useful for import sorting or `--include-unchanged-files`.
 
 ## Revset Syntax
 


### PR DESCRIPTION
## Summary
- update pinned Pi tooling in the Nix flake lock/profile
- refresh jj-core skill docs and references for JJ 0.42

## Testing
- not run (PR opened from already-pushed bookmark)