### PR TITLE
feat(ai): add nix-amd-ai lemonade profile; switch margot from llama-swap

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -485,6 +485,27 @@
         "type": "github"
       }
     },
+    "flake-parts_10": {
+      "inputs": {
+        "nixpkgs-lib": [
+          "nur",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1733312601,
+        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "type": "github"
+      },
+      "original": {
+        "owner": "hercules-ci",
+        "repo": "flake-parts",
+        "type": "github"
+      }
+    },
     "flake-parts_2": {
       "inputs": {
         "nixpkgs-lib": "nixpkgs-lib"
@@ -629,17 +650,14 @@
     },
     "flake-parts_9": {
       "inputs": {
-        "nixpkgs-lib": [
-          "nur",
-          "nixpkgs"
-        ]
+        "nixpkgs-lib": "nixpkgs-lib_3"
       },
       "locked": {
-        "lastModified": 1733312601,
-        "narHash": "sha256-4pDvzqnegAfRkPwO3wmwBhVi/Sye1mzps0zHWYnP88c=",
+        "lastModified": 1775087534,
+        "narHash": "sha256-91qqW8lhL7TLwgQWijoGBbiD4t7/q75KTi8NxjVmSmA=",
         "owner": "hercules-ci",
         "repo": "flake-parts",
-        "rev": "205b12d8b7cd4802fbcb8e8ef6a0f1408781a4f9",
+        "rev": "3107b77cd68437b9a76194f0f7f9c55f2329ca5b",
         "type": "github"
       },
       "original": {
@@ -1498,6 +1516,47 @@
         "type": "github"
       }
     },
+    "nix-amd-ai": {
+      "inputs": {
+        "flake-parts": "flake-parts_9",
+        "nix-darwin": "nix-darwin",
+        "nixpkgs": "nixpkgs_3"
+      },
+      "locked": {
+        "lastModified": 1782131589,
+        "narHash": "sha256-ipToNNGW5HJlnLrZUAtydnXmht6PX4/piL9UTPXxzOg=",
+        "owner": "noamsto",
+        "repo": "nix-amd-ai",
+        "rev": "b304a0136f959204d9d32d1783387c47267a3a43",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noamsto",
+        "repo": "nix-amd-ai",
+        "type": "github"
+      }
+    },
+    "nix-darwin": {
+      "inputs": {
+        "nixpkgs": [
+          "nix-amd-ai",
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1781242433,
+        "narHash": "sha256-bchLZZ3sRn740zyvD2icZSnNoTaanN0nw7l6fjVXO+E=",
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "rev": "aabb2037edfc0f210723b72cd5f528aab5dd3f0b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-darwin",
+        "repo": "nix-darwin",
+        "type": "github"
+      }
+    },
     "nix2container": {
       "inputs": {
         "nixpkgs": [
@@ -1672,7 +1731,7 @@
     },
     "nixos-hardware": {
       "inputs": {
-        "nixpkgs": "nixpkgs_3"
+        "nixpkgs": "nixpkgs_4"
       },
       "locked": {
         "lastModified": 1782166108,
@@ -1734,6 +1793,21 @@
         "type": "github"
       }
     },
+    "nixpkgs-lib_3": {
+      "locked": {
+        "lastModified": 1774748309,
+        "narHash": "sha256-+U7gF3qxzwD5TZuANzZPeJTZRHS29OFQgkQ2kiTJBIQ=",
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "rev": "333c4e0545a6da976206c74db8773a1645b5870a",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-community",
+        "repo": "nixpkgs.lib",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1768564909,
@@ -1752,6 +1826,22 @@
     },
     "nixpkgs_3": {
       "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_4": {
+      "locked": {
         "lastModified": 1767892417,
         "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
         "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
@@ -1763,7 +1853,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_4": {
+    "nixpkgs_5": {
       "locked": {
         "lastModified": 1781577229,
         "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
@@ -1779,7 +1869,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_5": {
+    "nixpkgs_6": {
       "locked": {
         "lastModified": 1781577229,
         "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
@@ -1820,8 +1910,8 @@
     },
     "nur": {
       "inputs": {
-        "flake-parts": "flake-parts_9",
-        "nixpkgs": "nixpkgs_5"
+        "flake-parts": "flake-parts_10",
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1782242685,
@@ -1947,10 +2037,11 @@
         "kured": "kured",
         "llm-agents": "llm-agents",
         "mk-shell-bin": "mk-shell-bin",
+        "nix-amd-ai": "nix-amd-ai",
         "nix2container": "nix2container_2",
         "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_4",
+        "nixpkgs": "nixpkgs_5",
         "nur": "nur",
         "persway": "persway",
         "pre-commit-hooks": "pre-commit-hooks_2",

--- a/flake.nix
+++ b/flake.nix
@@ -9,6 +9,7 @@
       "https://cachix.cachix.org"
       "https://hyprland.cachix.org"
       "https://cache.numtide.com"
+      "https://nix-amd-ai.cachix.org"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
@@ -16,6 +17,7 @@
       "cachix.cachix.org-1:eWNHQldwUO7G2VkjpnjDbWwy4KQ/HNxht7H4SSoMckM="
       "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
       "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
+      "nix-amd-ai.cachix.org-1:F4OU4vw/lV2oiG6SBHZ+nqjl4EFJuqI4X9A7pvaBmhQ="
     ];
   };
 
@@ -61,6 +63,11 @@
     mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
     nix2container.url = "github:nlewo/nix2container";
+    # AMD AI stack (Lemonade server, XRT/NPU, ROCm/Vulkan backends). Deliberately
+    # NOT `.follows`-ing nixpkgs: the overlay is built against this flake's own
+    # pinned nixpkgs so its Cachix (nix-amd-ai.cachix.org) substitutes; following
+    # our nixpkgs would re-hash every backend and force a from-source rebuild.
+    nix-amd-ai.url = "github:noamsto/nix-amd-ai";
     nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
     nixos-generators.url = "github:nix-community/nixos-generators";
     nixos-hardware.url = "github:nixos/nixos-hardware";

--- a/hosts/x86_64-linux/margot.nix
+++ b/hosts/x86_64-linux/margot.nix
@@ -11,7 +11,7 @@
     ../../profiles/admin-user/user.nix
     ../../profiles/hardware/framework-desktop.nix
     ../../profiles/disk/btrfs-on-luks.nix
-    ../../profiles/ai.nix
+    ../../profiles/ai-lemonade.nix
     ../../profiles/k3s-agent.nix
     ../../profiles/server.nix
     ../../profiles/state.nix

--- a/profiles/ai-lemonade.nix
+++ b/profiles/ai-lemonade.nix
@@ -1,0 +1,99 @@
+{
+  config,
+  lib,
+  inputs,
+  adminUser,
+  ...
+}:
+let
+  cfg = config.hardware.amd-npu;
+in
+{
+  # Lemonade AI server (noamsto/nix-amd-ai) as an alternative to profiles/ai.nix
+  # (llama-swap). Swap which one margot imports to switch between them.
+  #
+  # nixosModules.default sets `nixpkgs.overlays`; cake injects a prebuilt pkgs via
+  # `nixpkgs.pkgs`, and NixOS appends overlays to it (misc/nixpkgs.nix: appendOverlays),
+  # so the AMD packages land on margot's package set without a setup.nix change.
+  imports = [ inputs.nix-amd-ai.nixosModules.default ];
+
+  hardware.amd-npu = {
+    enable = true;
+
+    # NPU (XDNA2 / amdxdna) stays OFF on purpose. profiles/hardware/framework-desktop.nix
+    # sets amd_iommu=off (≈6% memory-bandwidth win, avoids the >64 GB loader hang) and
+    # blacklists amdxdna. The NPU needs IOMMU on for SVA, so enabling it would undo that
+    # tune and turn the ai.nix <-> ai-lemonade.nix swap into a kernel-param change + reboot.
+    # To try FastFlowLM on the NPU later: drop amd_iommu=off and the amdxdna blacklist in
+    # framework-desktop.nix, then set enableNPU = enableFastFlowLM = true here.
+    enableNPU = false;
+    enableFastFlowLM = false;
+
+    enableLemonade = true;
+    enableVulkan = true; # RADV STRIX_HALO — the working in-lemonade GPU backend (full 115 GB).
+    # ROCm stays OFF: lemonade 10.8.0 implements its ROCm backend by downloading AMD's own
+    # "TheRock" gfx1151 ROCm runtime at load time and ignores a system llama-cpp-rocm binary,
+    # so wiring enableROCm here just adds a redundant ~1.5 GB closure lemonade never uses.
+    # ROCm-in-lemonade is instead a runtime opt-in (`lemonade backends install llamacpp:rocm`),
+    # which works now that .cache/lemonade is persisted (TheRock extracts to /keep, not the
+    # 8 GB tmpfs that made it fail). For maximally-tuned gfx1151 ROCm, use profiles/ai.nix.
+    enableROCm = false;
+    enableImageGen = false; # LLM-only; flip on for stable-diffusion.cpp.
+
+    lemonade = {
+      user = adminUser.name;
+      host = "0.0.0.0"; # mirror ai.nix's LAN exposure; reachable for the tailscale serve below.
+      desktopApp.enable = false; # headless server — skip the Tauri/Rust/npm build path.
+    };
+
+    # GTT pool is already sized to 112 GiB via ttm.pages_limit in
+    # profiles/hardware/framework-desktop.nix, so gpuMemory.* is left at its default
+    # (null) to avoid a second, conflicting modprobe setting.
+  };
+
+  # lemond runs as the admin user; it needs the iGPU render node for the Vulkan backend.
+  users.users.${adminUser.name}.extraGroups = [
+    "video"
+    "render"
+  ];
+
+  networking.firewall.allowedTCPPorts = [ cfg.lemonade.port ];
+
+  # HuggingFace model cache. margot's / is an 8 GB tmpfs and impermanence wipes
+  # anything not under /keep, so lemonade's default ~/.cache/huggingface runs out of
+  # space (the "Insufficient disk space" download error) and would be lost on reboot.
+  # Persist it onto the btrfs /keep pool (hundreds of GB free) so multi-GB GGUFs land
+  # there and survive reboots. (The old profiles/ai.nix achieved the same for
+  # llama-swap via XDG_CACHE_HOME=/var/cache + a systemd CacheDirectory.)
+  environment.persistence."/keep" = lib.mkIf config.ephemeralRoot {
+    users.${adminUser.name}.directories = [
+      ".cache/huggingface" # multi-GB GGUF blobs
+      # lemonade state: config.json (regenerates from the nix seed, but persisting it
+      # is harmless since the module uses stable /etc/lemonade/backends/* paths) and
+      # user_models.json (the imported custom models — NOT reproducible from the seed,
+      # so this is what actually needs persisting across the nightly autoUpgrade reboot).
+      ".cache/lemonade"
+    ];
+  };
+
+  # Mirror profiles/ai.nix: expose the server over Tailscale HTTPS.
+  systemd.services.tailscale-serve-lemonade = {
+    description = "Expose lemonade over Tailscale HTTPS";
+    after = [
+      "tailscaled.service"
+      "tailscale-auth.service"
+      "lemond.service"
+    ];
+    wants = [
+      "tailscaled.service"
+      "lemond.service"
+    ];
+    wantedBy = [ "multi-user.target" ];
+    serviceConfig = {
+      Type = "oneshot";
+      RemainAfterExit = true;
+      ExecStart = "${lib.getExe config.services.tailscale.package} serve --bg --https=443 http://127.0.0.1:${toString cfg.lemonade.port}";
+      ExecStop = "${lib.getExe config.services.tailscale.package} serve --https=443 off";
+    };
+  };
+}


### PR DESCRIPTION
## What

Adds [`noamsto/nix-amd-ai`](https://github.com/noamsto/nix-amd-ai) as a flake input and a new `profiles/ai-lemonade.nix` that runs the **Lemonade** AI server on `margot`, as an alternative to the existing llama-swap setup in `profiles/ai.nix`. `margot` now imports the new profile; `ai.nix` is left in place so switching back is a one-line import change.

## Why these toggles

- **NPU / FastFlowLM: off.** The XDNA2 NPU needs the IOMMU on for SVA, but `profiles/hardware/framework-desktop.nix` sets `amd_iommu=off` (memory-bandwidth tune) and blacklists `amdxdna`. Enabling the NPU would undo that and break the clean profile swap.
- **ROCm: off.** lemonade 10.8.0 implements its ROCm backend by downloading AMD's "TheRock" runtime at load time and ignores a system `llama-cpp-rocm`, so wiring `enableROCm` only adds an unused ~1.5 GB closure. **Vulkan (RADV) is the working in-lemonade GPU backend** and benchmarked *faster* than TheRock ROCm on this box (79 vs 54 tok/s prefill on Qwen3.6-27B-Q4). `profiles/ai.nix` remains the tuned-gfx1151-ROCm path.
- **`nix-amd-ai` nixpkgs is deliberately not `follows`-ed** — its overlay is built against its own pinned nixpkgs so its Cachix substitutes; following ours would force a from-source rebuild. (Both happen to pin the same nixpkgs rev, so no closure bloat.) Added its Cachix substituter + key.

## Persistence

`margot`'s `/` is an 8 GB tmpfs, so this persists `~/.cache/huggingface` and `~/.cache/lemonade` onto the `/keep` btrfs pool — otherwise lemonade runs out of space pulling multi-GB GGUFs and loses its model registry on the nightly autoUpgrade reboot.

## Tested

- `statix` + `deadnix` clean; `nix eval` of `nixosConfigurations.margot.config.system.build.toplevel` instantiates.
- Deployed to `margot`: lemond serves over Tailscale, models load and run on the Vulkan backend.

## Notes

- Only `margot` is affected; `profiles/ai.nix` is unchanged and just no longer imported.
