### PR TITLE
feat(noctalia): add noctalia shell

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1908,6 +1908,26 @@
         "type": "github"
       }
     },
+    "noctalia": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1782752009,
+        "narHash": "sha256-+H6nBHPo67v1Y8C7mD/m3eOlYOiBaIETqTN+ZSxiMgg=",
+        "owner": "noctalia-dev",
+        "repo": "noctalia-shell",
+        "rev": "47382149c5d681a0ec28b7ae23ded4aff5cd8f99",
+        "type": "github"
+      },
+      "original": {
+        "owner": "noctalia-dev",
+        "repo": "noctalia-shell",
+        "type": "github"
+      }
+    },
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_10",
@@ -2042,6 +2062,7 @@
         "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
         "nixpkgs": "nixpkgs_5",
+        "noctalia": "noctalia",
         "nur": "nur",
         "persway": "persway",
         "pre-commit-hooks": "pre-commit-hooks_2",

--- a/flake.nix
+++ b/flake.nix
@@ -72,6 +72,8 @@
     nixos-generators.url = "github:nix-community/nixos-generators";
     nixos-hardware.url = "github:nixos/nixos-hardware";
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    noctalia.url = "github:noctalia-dev/noctalia-shell";
+    noctalia.inputs.nixpkgs.follows = "nixpkgs";
     nur.url = "github:nix-community/NUR";
     persway.inputs.crane.follows = "crane";
     persway.inputs.devenv.follows = "devenv";

--- a/flake/packages.nix
+++ b/flake/packages.nix
@@ -49,6 +49,7 @@
           persway = inputs.persway.packages.${system}.default;
           candle = inputs.candle.packages.${system}.default;
           codex = inputs.llm-agents.packages.${system}.codex;
+          noctalia = inputs.noctalia.packages.${system}.default;
 
           inherit (inputs.hyprland.packages.${system})
             hyprland

--- a/profiles/home-manager.nix
+++ b/profiles/home-manager.nix
@@ -8,5 +8,6 @@
   home-manager.sharedModules = [
     ../users/modules/theme.nix
     ../users/modules/userinfo.nix
+    inputs.noctalia.homeModules.default
   ];
 }

--- a/profiles/k3s.nix
+++ b/profiles/k3s.nix
@@ -1,5 +1,7 @@
 {
+  config,
   hostName,
+  lib,
   pkgs,
   ...
 }:
@@ -19,6 +21,11 @@
       "wlan+"
     ];
   };
+
+  networking.networkmanager.unmanaged = lib.mkIf config.networking.networkmanager.enable [
+    "interface-name:cilium_*"
+    "interface-name:lxc*"
+  ];
 
   systemd.services.metadata =
     let

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -39,6 +39,8 @@
   security.rtkit.enable = true;
   hardware.bluetooth.enable = true;
   networking.wireless.iwd.enable = true;
+  networking.networkmanager.enable = true;
+  networking.networkmanager.wifi.backend = "iwd";
 
   environment.pathsToLink = [ "/etc/gconf" ];
 

--- a/users/profiles/noctalia.nix
+++ b/users/profiles/noctalia.nix
@@ -1,0 +1,106 @@
+{
+  pkgs,
+  inputs,
+  ...
+}:
+{
+  home.packages = [ pkgs.gpu-screen-recorder ];
+
+  programs.noctalia = {
+    enable = true;
+    package = inputs.noctalia.packages.${pkgs.stdenv.hostPlatform.system}.default;
+    systemd.enable = true;
+    settings = {
+      bar.default = {
+        background_opacity = 0.65;
+        font_weight = 400;
+        margin_edge = 0;
+        margin_ends = 0;
+        radius = 0;
+        thickness = 28;
+        start = [
+          "launcher"
+          "wallpaper"
+          "workspaces"
+          "spacer_2"
+          "network_rx"
+          "network_tx"
+          "spacer_3"
+          "sysmon"
+        ];
+        end = [
+          "caffeine"
+          "media"
+          "tray"
+          "notifications"
+          "clipboard"
+          "network"
+          "bluetooth"
+          "volume"
+          "brightness"
+          "battery"
+          "control-center"
+          "session"
+        ];
+      };
+      location.auto_locate = true;
+      lockscreen_widgets = {
+        enabled = false;
+        schema_version = 2;
+        widget_order = [
+          "lockscreen-login-box@eDP-1"
+          "lockscreen-login-box@DP-1"
+        ];
+        grid = {
+          cell_size = 16;
+          major_interval = 4;
+          visible = true;
+        };
+        widget."lockscreen-login-box@DP-1" = {
+          box_height = 0.0;
+          box_width = 0.0;
+          cx = 1536.0;
+          cy = 1605.0;
+          output = "DP-1";
+          rotation = 0.0;
+          type = "login_box";
+        };
+        widget."lockscreen-login-box@eDP-1" = {
+          box_height = 0.0;
+          box_width = 0.0;
+          cx = 1440.0;
+          cy = 1797.0;
+          output = "eDP-1";
+          rotation = 0.0;
+          type = "login_box";
+        };
+      };
+      nightlight.enabled = true;
+      shell = {
+        niri_overview_type_to_launch_enabled = true;
+        panel.transparency_mode = "glass";
+        screen_corners = {
+          enabled = true;
+          size = 16;
+        };
+        shadow.direction = "down_right";
+      };
+      theme = {
+        builtin = "Nord";
+        community_palette = "Miasma";
+        templates = {
+          enable_builtin_templates = false;
+          enable_community_templates = false;
+        };
+      };
+      widget = {
+        bongocat = {
+          script = "scripts/bongocat.lua";
+          type = "scripted";
+        };
+        spacer_2.type = "spacer";
+        spacer_3.type = "spacer";
+      };
+    };
+  };
+}

--- a/users/profiles/waybar.nix
+++ b/users/profiles/waybar.nix
@@ -1,6 +1,6 @@
 { lib, ... }:
 {
-  programs.waybar.enable = true;
+  programs.waybar.enable = false;
   programs.waybar.settings.topBar = {
     bar_id = "top";
     ipc = true;

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -13,6 +13,7 @@ in
   ++ [
     ./chromium.nix
     ./lutris.nix
+    ./noctalia.nix
     ./obs.nix
     ./pueue.nix
     ./rofi.nix


### PR DESCRIPTION
Adds the [noctalia-shell](https://github.com/noctalia-dev/noctalia-shell) desktop shell.

## Changes
- Add `noctalia` flake input (follows `nixpkgs`) and expose its package.
- Add the noctalia home-manager module and `users/profiles/noctalia.nix` (bar/widgets config).
- Wire `./noctalia.nix` into the workstation user profile and disable `waybar` in favor of noctalia.
- Enable NetworkManager (iwd backend) to back noctalia's network widgets, and mark cilium/lxc interfaces unmanaged so k3s networking is untouched.

## Notes
- First of a two-commit split; the niri compositor config will follow as a stacked PR on top of this.
- Rebased on latest `main`; `flake.lock` includes only the `noctalia` node (it follows `nixpkgs`, so no other entries change).