### PR TITLE
feat(niri): add niri compositor configuration

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1413,6 +1413,62 @@
         "type": "github"
       }
     },
+    "niri": {
+      "inputs": {
+        "niri-stable": "niri-stable",
+        "niri-unstable": "niri-unstable",
+        "nixpkgs": "nixpkgs_4",
+        "nixpkgs-stable": "nixpkgs-stable",
+        "xwayland-satellite-stable": "xwayland-satellite-stable",
+        "xwayland-satellite-unstable": "xwayland-satellite-unstable"
+      },
+      "locked": {
+        "lastModified": 1784686714,
+        "narHash": "sha256-6HCWRBQq/U2NPY2msnnysnWczZYzEzhS1UZURmrr2f0=",
+        "owner": "sodiboo",
+        "repo": "niri-flake",
+        "rev": "4dfd38bad6150c07be6cc3fd7682787765092eea",
+        "type": "github"
+      },
+      "original": {
+        "owner": "sodiboo",
+        "repo": "niri-flake",
+        "type": "github"
+      }
+    },
+    "niri-stable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1756556321,
+        "narHash": "sha256-RLD89dfjN0RVO86C/Mot0T7aduCygPGaYbog566F0Qo=",
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "rev": "01be0e65f4eb91a9cd624ac0b76aaeab765c7294",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YaLTeR",
+        "ref": "v25.08",
+        "repo": "niri",
+        "type": "github"
+      }
+    },
+    "niri-unstable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784570726,
+        "narHash": "sha256-9EMn69JBcFWFgUM7f0VBAX+jBby5b9H3M59U75+5yI4=",
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "rev": "7f26c3ee804fb6ed458ef7fb0e3c794f14e0b3bc",
+        "type": "github"
+      },
+      "original": {
+        "owner": "YaLTeR",
+        "repo": "niri",
+        "type": "github"
+      }
+    },
     "nix": {
       "inputs": {
         "flake-compat": [
@@ -1464,7 +1520,7 @@
         "flake-compat": "flake-compat_4",
         "flake-parts": "flake-parts_9",
         "nix-darwin": "nix-darwin",
-        "nixpkgs": "nixpkgs_4"
+        "nixpkgs": "nixpkgs_5"
       },
       "locked": {
         "lastModified": 1784641307,
@@ -1674,7 +1730,7 @@
     },
     "nixos-hardware": {
       "inputs": {
-        "nixpkgs": "nixpkgs_5"
+        "nixpkgs": "nixpkgs_6"
       },
       "locked": {
         "lastModified": 1784310968,
@@ -1751,6 +1807,22 @@
         "type": "github"
       }
     },
+    "nixpkgs-stable": {
+      "locked": {
+        "lastModified": 1782847189,
+        "narHash": "sha256-twXPFqFsrrY5r28Zh7Homgcp2gUMBgQ6WDS98Q/3xFI=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b6018f87da91d19d0ab4cf979885689b469cdd41",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-25.11",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
         "lastModified": 1768564909,
@@ -1801,6 +1873,22 @@
     },
     "nixpkgs_5": {
       "locked": {
+        "lastModified": 1784497964,
+        "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "241313f4e8e508cb9b13278c2b0fa25b9ca27163",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "nixpkgs_6": {
+      "locked": {
         "lastModified": 1767892417,
         "narHash": "sha256-8bW3q88CEg2u4hSP66Vf4lpbLonHz7hqDNBMcCY7E9U=",
         "rev": "3497aa5c9457a9d88d71fa93a4a8368816fbeeba",
@@ -1812,7 +1900,7 @@
         "url": "https://channels.nixos.org/nixos-unstable/nixexprs.tar.xz"
       }
     },
-    "nixpkgs_6": {
+    "nixpkgs_7": {
       "locked": {
         "lastModified": 1783224372,
         "narHash": "sha256-8i/87eeoqiGE4yOTjwSA3Eh/ziJRQEmd/unYU+K27sk=",
@@ -1828,7 +1916,7 @@
         "type": "github"
       }
     },
-    "nixpkgs_7": {
+    "nixpkgs_8": {
       "locked": {
         "lastModified": 1784497964,
         "narHash": "sha256-vlHUuqAcbcH2RKmHbPiuQzbv1pnzzavXnI62RD0bqCU=",
@@ -1890,7 +1978,7 @@
     "nur": {
       "inputs": {
         "flake-parts": "flake-parts_10",
-        "nixpkgs": "nixpkgs_7"
+        "nixpkgs": "nixpkgs_8"
       },
       "locked": {
         "lastModified": 1784672315,
@@ -2014,11 +2102,12 @@
         "kured": "kured",
         "llm-agents": "llm-agents",
         "mk-shell-bin": "mk-shell-bin",
+        "niri": "niri",
         "nix-amd-ai": "nix-amd-ai",
         "nix2container": "nix2container_2",
         "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",
-        "nixpkgs": "nixpkgs_6",
+        "nixpkgs": "nixpkgs_7",
         "noctalia": "noctalia",
         "nur": "nur",
         "persway": "persway",
@@ -2287,6 +2376,39 @@
       "original": {
         "owner": "hyprwm",
         "repo": "xdg-desktop-portal-hyprland",
+        "type": "github"
+      }
+    },
+    "xwayland-satellite-stable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755491097,
+        "narHash": "sha256-m+9tUfsmBeF2Gn4HWa6vSITZ4Gz1eA1F5Kh62B0N4oE=",
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
+        "rev": "388d291e82ffbc73be18169d39470f340707edaa",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Supreeeme",
+        "ref": "v0.7",
+        "repo": "xwayland-satellite",
+        "type": "github"
+      }
+    },
+    "xwayland-satellite-unstable": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1784679892,
+        "narHash": "sha256-Mb7jpqnrcYCfNSItIkkHpuR3YxWFxPuIBfcwNKlRBkk=",
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
+        "rev": "8d135d3b2854b30fd01ea6cd6c27e523dd50a839",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Supreeeme",
+        "repo": "xwayland-satellite",
         "type": "github"
       }
     }

--- a/flake.nix
+++ b/flake.nix
@@ -10,6 +10,7 @@
       "https://hyprland.cachix.org"
       "https://cache.numtide.com"
       "https://nix-amd-ai.cachix.org"
+      "https://niri.cachix.org"
     ];
     extra-trusted-public-keys = [
       "nix-community.cachix.org-1:mB9FSh9qf2dCimDSUo8Zy7bkq5CX+/rkCWyvRCYg3Fs="
@@ -18,6 +19,7 @@
       "hyprland.cachix.org-1:a7pgxzMz7+chwVL3/pzj6jIBMioiJM7ypFP8PwtkuGc="
       "niks3.numtide.com-1:DTx8wZduET09hRmMtKdQDxNNthLQETkc/yaX7M4qK0g="
       "nix-amd-ai.cachix.org-1:F4OU4vw/lV2oiG6SBHZ+nqjl4EFJuqI4X9A7pvaBmhQ="
+      "niri.cachix.org-1:Wv0OmO7PsuocRKzfDoJ3mulSl7Z6oezYhGhR+3W2964="
     ];
   };
 
@@ -62,6 +64,7 @@
     # uses pnpm 11 with a fetcher version incompatible with our newer nixpkgs.
     llm-agents.url = "github:numtide/llm-agents.nix";
     mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
+    niri.url = "github:sodiboo/niri-flake";
     nix2container.inputs.nixpkgs.follows = "nixpkgs";
     nix2container.url = "github:nlewo/nix2container";
     # AMD AI stack (Lemonade server, XRT/NPU, ROCm/Vulkan backends). Deliberately

--- a/flake/setup.nix
+++ b/flake/setup.nix
@@ -22,6 +22,7 @@
         ];
         overlays = [
           inputs.agenix.overlays.default
+          inputs.niri.overlays.niri
           inputs.nur.overlays.default
           (
             _final: _prev:

--- a/hosts/x86_64-linux/amelia.nix
+++ b/hosts/x86_64-linux/amelia.nix
@@ -1,6 +1,7 @@
 {
   adminUser,
   config,
+  inputs,
   ...
 }:
 {
@@ -20,6 +21,8 @@
     ../../profiles/tailscale.nix
     ../../profiles/zram.nix
   ];
+
+  greeter.defaultSession = "niri";
 
   boot.loader.systemd-boot.memtest86.enable = true;
 
@@ -57,7 +60,9 @@
 
   home-manager = {
     users.${adminUser.name} = {
-      imports = [ ../../users/profiles/workstation.nix ];
+      imports = [
+        ../../users/profiles/workstation.nix
+      ];
       programs.git.settings.user.signingKey = config.age.secrets.id_ed25519.path;
       programs.jujutsu.settings.signing = {
         behavior = "own";

--- a/profiles/greetd.nix
+++ b/profiles/greetd.nix
@@ -1,4 +1,5 @@
 {
+  config,
   pkgs,
   lib,
   ...
@@ -81,6 +82,24 @@ let
     cmd = "${pkgs.hyprland}/bin/Hyprland";
   };
 
+  runNiri = runViaShell {
+    env = {
+      XDG_SESSION_TYPE = "wayland";
+      XDG_CURRENT_DESKTOP = "niri";
+      XDG_SESSION_DESKTOP = "niri";
+    };
+    name = "niri";
+    cmd = "${config.programs.niri.package}/bin/niri-session";
+  };
+
+  defaultSessionCommand =
+    {
+      sway = "${runSway}/bin/sway";
+      Hyprland = "${runHyprland}/bin/Hyprland";
+      niri = "${runNiri}/bin/niri";
+    }
+    .${config.greeter.defaultSession};
+
   desktopSession =
     name: command:
     pkgs.writeText "${name}.desktop" ''
@@ -107,6 +126,10 @@ let
       name = "bash.desktop";
       path = desktopSession "bash" "${pkgs.bashInteractive}/bin/bash";
     }
+    {
+      name = "niri.desktop";
+      path = desktopSession "niri" "${runNiri}/bin/niri";
+    }
   ];
 
   createGreeter =
@@ -132,46 +155,60 @@ let
     };
 in
 {
-  programs.regreet.enable = true;
-
-  environment.systemPackages = [
-    pkgs.nordic
-    pkgs.nordzy-cursor-theme
-    pkgs.arc-icon-theme
-  ];
-
-  programs.regreet.settings = {
-    commands = {
-      reboot = [
-        "systemctl"
-        "reboot"
+  options.greeter = {
+    defaultSession = lib.mkOption {
+      type = lib.types.enum [
+        "sway"
+        "Hyprland"
+        "niri"
       ];
-      poweroff = [
-        "systemctl"
-        "poweroff"
-      ];
-    };
-    appearance = {
-      greeting_msg = "Welcome back!";
-    };
-    GTK = {
-      cursor_theme_name = lib.mkForce "Nordzy-cursors";
-      font_name = lib.mkForce "Roboto Medium 14";
-      icon_theme_name = lib.mkForce "Nordzy-dark";
-      theme_name = lib.mkForce "Nordic-darker";
-      application_prefer_dark_theme = lib.mkForce true;
+      default = "sway";
+      description = "Session greetd launches by default and tuigreet preselects.";
     };
   };
 
-  services.greetd = {
-    enable = true;
-    restart = true;
-    settings = {
-      default_session.command = "${createGreeter "${runSway}/bin/sway" sessions}/bin/greeter";
+  config = {
+    programs.regreet.enable = true;
+
+    environment.systemPackages = [
+      pkgs.nordic
+      pkgs.nordzy-cursor-theme
+      pkgs.arc-icon-theme
+    ];
+
+    programs.regreet.settings = {
+      commands = {
+        reboot = [
+          "systemctl"
+          "reboot"
+        ];
+        poweroff = [
+          "systemctl"
+          "poweroff"
+        ];
+      };
+      appearance = {
+        greeting_msg = "Welcome back!";
+      };
+      GTK = {
+        cursor_theme_name = lib.mkForce "Nordzy-cursors";
+        font_name = lib.mkForce "Roboto Medium 14";
+        icon_theme_name = lib.mkForce "Nordzy-dark";
+        theme_name = lib.mkForce "Nordic-darker";
+        application_prefer_dark_theme = lib.mkForce true;
+      };
     };
-  };
-  systemd.services.greetd.serviceConfig = {
-    ExecStartPre = "${pkgs.util-linux}/bin/kill -SIGRTMIN+21 1";
-    ExecStopPost = "${pkgs.util-linux}/bin/kill -SIGRTMIN+20 1";
+
+    services.greetd = {
+      enable = true;
+      restart = true;
+      settings = {
+        default_session.command = "${createGreeter defaultSessionCommand sessions}/bin/greeter";
+      };
+    };
+    systemd.services.greetd.serviceConfig = {
+      ExecStartPre = "${pkgs.util-linux}/bin/kill -SIGRTMIN+21 1";
+      ExecStopPost = "${pkgs.util-linux}/bin/kill -SIGRTMIN+20 1";
+    };
   };
 }

--- a/profiles/home-manager.nix
+++ b/profiles/home-manager.nix
@@ -1,13 +1,15 @@
 {
+  adminUser,
   hostName,
   inputs,
   ...
 }:
 {
-  home-manager.extraSpecialArgs = { inherit hostName inputs; };
+  home-manager.extraSpecialArgs = { inherit hostName inputs adminUser; };
   home-manager.sharedModules = [
     ../users/modules/theme.nix
     ../users/modules/userinfo.nix
+    inputs.niri.homeModules.niri
     inputs.noctalia.homeModules.default
   ];
 }

--- a/users/profiles/niri.nix
+++ b/users/profiles/niri.nix
@@ -1,0 +1,368 @@
+{
+  config,
+  inputs,
+  lib,
+  pkgs,
+  ...
+}:
+let
+  call = pkgs.lib.flip import {
+    inherit
+      inputs
+      kdl
+      docs
+      binds
+      settings
+      ;
+    inherit (pkgs) lib;
+  };
+  kdl = call "${inputs.niri}/kdl.nix";
+  binds = call "${inputs.niri}/binds.nix";
+  docs = call "${inputs.niri}/docs.nix";
+  settings = call "${inputs.niri}/settings.nix";
+
+  xcursor_theme = config.gtk.cursorTheme.name;
+  noctalia = inputs.noctalia.packages.${pkgs.stdenv.hostPlatform.system}.default;
+  noctaliaIPC = "${noctalia}/bin/noctalia msg";
+
+  noctaliaInit = pkgs.writeShellApplication {
+    name = "noctalia-init";
+    text = ''
+      while ! [ -S "''${XDG_RUNTIME_DIR}/noctalia-''${WAYLAND_DISPLAY:-wayland-0}.sock" ]; do
+        sleep 0.1
+      done
+      ${noctaliaIPC} wallpaper-random
+      sleep 0.1
+      ${noctaliaIPC} session lock
+    '';
+  };
+
+  screenshot = pkgs.writeShellApplication {
+    name = "screenshot";
+    runtimeInputs = [
+      pkgs.slurp
+      pkgs.grim
+    ];
+    text = ''
+      mkdir -p ~/Pictures/screenshots
+      slurp | grim -g - ~/Pictures/screenshots/"$(date +'%Y-%m-%dT%H%M%S.png')"
+    '';
+  };
+
+  extraConfig = pkgs.writeText "extra-niri-config" ''
+    blur {
+      passes 2
+      offset 4
+      noise 0.0015
+      saturation 1.1
+    }
+
+    window-rule {
+      background-effect {
+          blur true
+          xray true
+      }
+      popups {
+          background-effect {
+              blur true
+              xray true
+          }
+      }
+    }
+
+    window-rule {
+      match is-active=false
+      opacity 0.89
+    }
+  '';
+in
+{
+  home.packages = with pkgs; [
+    brightnessctl
+    pamixer
+    scripts
+  ];
+
+  programs.niri = {
+    package = pkgs.niri-unstable;
+    enable = true;
+
+    config = kdl.serialize.nodes (settings.render config.programs.niri.settings) + ''
+
+
+      include "${extraConfig}"
+    '';
+
+    settings = {
+      input = {
+        keyboard = {
+          xkb = {
+            layout = "us";
+            variant = "dvp";
+            options = "compose:ralt,caps:escape";
+          };
+          repeat-delay = 300;
+          repeat-rate = 20;
+        };
+        touchpad = {
+          tap = true;
+          natural-scroll = true;
+          dwt = true;
+        };
+        focus-follows-mouse.enable = true;
+        warp-mouse-to-focus.enable = true;
+        workspace-auto-back-and-forth = true;
+      };
+
+      outputs = {
+        "eDP-1" = {
+          scale = 1.5;
+        };
+      };
+
+      spawn-at-startup = [
+        { sh = "${noctaliaInit}/bin/noctalia-init"; }
+      ];
+
+      hotkey-overlay.skip-at-startup = true;
+
+      cursor = {
+        theme = xcursor_theme;
+      };
+
+      layout = {
+        gaps = 8;
+        center-focused-column = "never";
+        preset-column-widths = [
+          { proportion = 1.0 / 3.0; }
+          { proportion = 1.0 / 2.0; }
+          { proportion = 2.0 / 3.0; }
+        ];
+        default-column-width = {
+          proportion = 0.5;
+        };
+
+        tab-indicator = {
+          gap = 8;
+          gaps-between-tabs = 4;
+          corner-radius = 8;
+          width = 10;
+          position = "top";
+        };
+
+        focus-ring = {
+          width = 2;
+          active = {
+            color = "#7fc8ff";
+          };
+          inactive = {
+            color = "#505050";
+          };
+        };
+
+        border = {
+          enable = false;
+        };
+        shadow = {
+          enable = true;
+          softness = 30;
+          spread = 5;
+          offset = {
+            x = 0;
+            y = 5;
+          };
+          color = "#0007";
+        };
+
+        struts = {
+          left = 8;
+          right = 8;
+          top = 8;
+          bottom = 8;
+        };
+      };
+
+      prefer-no-csd = true;
+      screenshot-path = "~/Pictures/screenshots/%Y-%m-%dT%H-%M-%S.png";
+
+      window-rules = [
+        {
+          geometry-corner-radius = {
+            top-left = 6.0;
+            top-right = 6.0;
+            bottom-left = 6.0;
+            bottom-right = 6.0;
+          };
+          clip-to-geometry = true;
+        }
+
+        {
+          matches = [
+            {
+              app-id = "^firefox$";
+              title = "^Picture-in-Picture$";
+            }
+          ];
+          open-floating = true;
+        }
+      ];
+
+      binds = {
+        "Mod+Shift+Slash".action.show-hotkey-overlay = [ ];
+        "Mod+Return".action.spawn = [
+          "wezterm"
+          "start"
+          "--always-new-process"
+        ];
+        "Mod+D".action.spawn-sh = "${noctaliaIPC} panel-toggle launcher";
+        "Mod+Shift+X".action.spawn-sh = "${noctaliaIPC} session lock";
+
+        "XF86AudioRaiseVolume" = {
+          allow-when-locked = true;
+          action.spawn = [
+            "wpctl"
+            "set-volume"
+            "@DEFAULT_AUDIO_SINK@"
+            "0.1+"
+          ];
+        };
+        "XF86AudioLowerVolume" = {
+          allow-when-locked = true;
+          action.spawn = [
+            "wpctl"
+            "set-volume"
+            "@DEFAULT_AUDIO_SINK@"
+            "0.1-"
+          ];
+        };
+        "XF86AudioMute" = {
+          allow-when-locked = true;
+          action.spawn = [
+            "wpctl"
+            "set-mute"
+            "@DEFAULT_AUDIO_SINK@"
+            "toggle"
+          ];
+        };
+        "XF86MonBrightnessUp" = {
+          allow-when-locked = true;
+          action.spawn = [
+            "light"
+            "-A"
+            "5"
+          ];
+        };
+        "XF86MonBrightnessDown" = {
+          allow-when-locked = true;
+          action.spawn = [
+            "light"
+            "-U"
+            "5"
+          ];
+        };
+
+        "Mod+Tab".action.toggle-overview = [ ];
+
+        "Mod+Shift+Q".action.close-window = [ ];
+
+        "Mod+Left".action.focus-column-left = [ ];
+        "Mod+Down".action.focus-window-or-workspace-down = [ ];
+        "Mod+Up".action.focus-window-or-workspace-up = [ ];
+        "Mod+Right".action.focus-column-right = [ ];
+        "Mod+H".action.focus-column-left = [ ];
+        "Mod+J".action.focus-window-down = [ ];
+        "Mod+K".action.focus-window-up = [ ];
+        "Mod+L".action.focus-column-right = [ ];
+
+        "Mod+Ctrl+Left".action.move-column-left = [ ];
+        "Mod+Ctrl+Down".action.move-window-down = [ ];
+        "Mod+Ctrl+Up".action.move-window-up = [ ];
+        "Mod+Ctrl+Right".action.move-column-right = [ ];
+        "Mod+Ctrl+H".action.move-column-left = [ ];
+        "Mod+Ctrl+J".action.move-window-down = [ ];
+        "Mod+Ctrl+K".action.move-window-up = [ ];
+        "Mod+Ctrl+L".action.move-column-right = [ ];
+
+        "Mod+Page_Down".action.focus-workspace-down = [ ];
+        "Mod+Page_Up".action.focus-workspace-up = [ ];
+        "Mod+U".action.focus-workspace-down = [ ];
+        "Mod+I".action.focus-workspace-up = [ ];
+        "Mod+Ctrl+Page_Down".action.move-column-to-workspace-down = [ ];
+        "Mod+Ctrl+Page_Up".action.move-column-to-workspace-up = [ ];
+        "Mod+Ctrl+U".action.move-column-to-workspace-down = [ ];
+        "Mod+Ctrl+I".action.move-column-to-workspace-up = [ ];
+
+        "Mod+Shift+Page_Down".action.move-workspace-down = [ ];
+        "Mod+Shift+Page_Up".action.move-workspace-up = [ ];
+        "Mod+Shift+U".action.move-workspace-down = [ ];
+        "Mod+Shift+I".action.move-workspace-up = [ ];
+        "Mod+Space".action.swap-window-left = [ ];
+        "Mod+Shift+Space".action.swap-window-right = [ ];
+
+        "Mod+WheelScrollDown" = {
+          action.focus-workspace-down = [ ];
+          cooldown-ms = 150;
+        };
+        "Mod+WheelScrollUp" = {
+          action.focus-workspace-up = [ ];
+          cooldown-ms = 150;
+        };
+        "Mod+Ctrl+WheelScrollDown" = {
+          action.move-column-to-workspace-down = [ ];
+          cooldown-ms = 150;
+        };
+
+        "Mod+Ctrl+WheelScrollUp" = {
+          action.move-column-to-workspace-up = [ ];
+          cooldown-ms = 150;
+        };
+
+        MouseForward.action.toggle-overview = [ ];
+
+        "Mod+1".action.focus-workspace = 1;
+        "Mod+2".action.focus-workspace = 2;
+        "Mod+3".action.focus-workspace = 3;
+        "Mod+4".action.focus-workspace = 4;
+        "Mod+5".action.focus-workspace = 5;
+        "Mod+6".action.focus-workspace = 6;
+        "Mod+7".action.focus-workspace = 7;
+        "Mod+8".action.focus-workspace = 8;
+        "Mod+9".action.focus-workspace = 9;
+
+        "Mod+Ctrl+1".action.move-column-to-workspace = 1;
+        "Mod+Ctrl+2".action.move-column-to-workspace = 2;
+        "Mod+Ctrl+3".action.move-column-to-workspace = 3;
+        "Mod+Ctrl+4".action.move-column-to-workspace = 4;
+        "Mod+Ctrl+5".action.move-column-to-workspace = 5;
+        "Mod+Ctrl+6".action.move-column-to-workspace = 6;
+        "Mod+Ctrl+7".action.move-column-to-workspace = 7;
+        "Mod+Ctrl+8".action.move-column-to-workspace = 8;
+        "Mod+Ctrl+9".action.move-column-to-workspace = 9;
+
+        "Mod+BracketLeft".action.consume-or-expel-window-left = [ ];
+        "Mod+BracketRight".action.consume-or-expel-window-right = [ ];
+
+        "Mod+Comma".action.consume-window-into-column = [ ];
+        "Mod+Period".action.expel-window-from-column = [ ];
+
+        "Mod+R".action.switch-preset-column-width = [ ];
+        "Mod+Shift+R".action.switch-preset-window-height = [ ];
+        "Mod+Ctrl+R".action.reset-window-height = [ ];
+        "Mod+F".action.maximize-column = [ ];
+        "Mod+Shift+F".action.fullscreen-window = [ ];
+
+        "Mod+Ctrl+F".action.expand-column-to-available-width = [ ];
+
+        "Mod+C".action.center-column = [ ];
+
+        "Mod+W".action.toggle-column-tabbed-display = [ ];
+
+        "Mod+Escape" = {
+          allow-inhibiting = false;
+          action.toggle-keyboard-shortcuts-inhibit = [ ];
+        };
+      };
+
+    };
+  };
+}

--- a/users/profiles/waybar.nix
+++ b/users/profiles/waybar.nix
@@ -8,6 +8,7 @@
     modules-left = [
       "hyprland/workspaces"
       "sway/workspaces"
+      "niri/workspaces"
       "sway/mode"
       "hyprland/submap"
     ];
@@ -32,6 +33,10 @@
       format = "{id}";
       on-scroll-up = "hyprctl dispatch workspace e-1";
       on-scroll-down = "hyprctl dispatch workspace e+1";
+      all-outputs = false;
+    };
+    "niri/workspaces" = {
+      format = "{index}";
       all-outputs = false;
     };
     "hyprland/submap" = {

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -14,6 +14,7 @@ in
     ./chromium.nix
     ./faugus.nix
     ./lutris.nix
+    ./niri.nix
     ./noctalia.nix
     ./obs.nix
     ./pueue.nix


### PR DESCRIPTION
Adds the [niri](https://github.com/YaLTeR/niri) scrollable-tiling Wayland compositor, building on the noctalia shell from #1116.

## Changes
- Add the `niri` flake input, overlay, and cachix substituter.
- Add `users/profiles/niri.nix`: compositor config, keybinds, and noctalia integration (spawns noctalia, panel/launcher via `noctalia msg`).
- Wire `./niri.nix` into the workstation user profile and add the niri home-manager module.
- greetd: add a niri session + a `greeter.defaultSession` option; set amelia's default session to niri.
- waybar: add a `niri/workspaces` module.

## Notes
- Follow-up to #1116 (noctalia); the two are coupled — niri's config drives noctalia as its shell.
- `flake.lock` adds the `niri` nodes (niri pulls its own nixpkgs, hence the node renumbering).