### PR TITLE
feat(agents): improve local tooling and Pi runtime

### DIFF
--- a/users/profiles/backlog-md.nix
+++ b/users/profiles/backlog-md.nix
@@ -1,0 +1,14 @@
+{
+  pkgs,
+  inputs,
+  ...
+}:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  llm = inputs.llm-agents.packages.${system};
+in
+{
+  home.packages = [
+    llm.backlog-md
+  ];
+}

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -11,6 +11,7 @@ in
     # keep-sorted start
     ./aider.nix
     ./alacritty.nix
+    ./backlog-md.nix
     ./bat.nix
     ./chromium.nix
     ./claude.nix

--- a/users/profiles/git.nix
+++ b/users/profiles/git.nix
@@ -45,6 +45,7 @@ in
     ignores = [
       ".aider*"
       ".nvimlog" # TODO(blazed): find out why this is needed?
+      ".pi/remote-pi/"
       ".pi/workflows/"
       "pi-session*.html" # agent-browser session dumps (see users/profiles/pi)
     ];

--- a/users/profiles/jailed-agents-builders.nix
+++ b/users/profiles/jailed-agents-builders.nix
@@ -12,6 +12,7 @@ let
   inherit (pkgs.stdenv.hostPlatform) system;
   jail = inputs.jail-nix.lib.init pkgs;
   llm = inputs.llm-agents.packages.${system};
+  piNode = import ./pi/node-package.nix { inherit pkgs inputs; };
 
   # Tools on PATH inside every jail. Deliberately excludes gcloud/kubectl/aws/ssh
   # so a runaway agent can't reach cloud or remote credentials.
@@ -177,7 +178,7 @@ let
       extra = c: [ (c.try-fwd-env "OPENAI_API_KEY") ];
     };
     pi = {
-      pkg = llm.pi; # github:numtide/llm-agents.nix
+      pkg = piNode;
       paths = [
         "~/.agents"
         "~/.pi"
@@ -191,6 +192,13 @@ let
       # Chromium is invoked by absolute path (wrapper env) via the ro /nix/store
       # mount — though launching it under bubblewrap may need extra sandbox perms.
       extra = c: [
+        # Node's os.tmpdir() respects TMPDIR. Pi keeps truncated command output
+        # there for later inspection, so use the disk-backed ~/.pi mount instead
+        # of the host's small tmpfs root. The Pi profile ages these files out.
+        (c.add-runtime ''
+          ${cu}/install -d -m 0700 "$HOME/.pi/tmp"
+          RUNTIME_ARGS+=(--setenv TMPDIR "$HOME/.pi/tmp")
+        '')
         (c.add-runtime ''RUNTIME_ARGS+=(--setenv PATH "${llm.agent-browser}/bin:${devToolsPath}:$PATH")'')
         # pi-web-access's web_search uses Exa. The jail can't read /run/agenix, but
         # this wrapper runs on the HOST before bwrap — so read the exa-api-key

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -12,6 +12,8 @@
 #                   dirs stay writable and coexist with third-party auto-installs.
 #   auth.json     - UNMANAGED: written 0600 by `pi /login`, persisted via
 #                   impermanence (profiles/state.nix). Never touched here.
+#   tmp/          - Pi/Node temporary files, kept off the tmpfs root and cleaned
+#                   after seven days by the user tmpfiles timer.
 {
   pkgs,
   inputs,
@@ -22,22 +24,37 @@
 let
   system = pkgs.stdenv.hostPlatform.system;
   llm = inputs.llm-agents.packages.${system};
-  inherit (llm) pi;
+  piNode = import ./node-package.nix { inherit pkgs inputs; };
+
   # Browser-automation CLI for agents (Vercel Labs). The llm-agents build bundles
   # a Nix Chromium, so it works on NixOS with no Chrome download / nix-ld.
   inherit (llm) agent-browser;
 
   # ---- Declarative extensibility knobs --------------------------------------
-  # THIRD-PARTY extensions Pi auto-installs (settings.packages):
-  thirdPartyPackages = [
-    "git:github.com/blazed/pi-openai-compaction@b087ebf12329a4da7bdd9376d3f7b28603cae2c1"
-    "npm:@blazed/plannotator-pi-extension@0.20.3-blazed.3"
-    "npm:@juicesharp/rpiv-ask-user-question@1.20.0"
-    "npm:@juicesharp/rpiv-todo@1.20.0"
-    "npm:pi-hashline-readmap@0.11.1"
-    "npm:pi-web-access@0.13.0"
-    "npm:remote-pi@0.5.4"
-  ];
+  # THIRD-PARTY packages Pi auto-installs (settings.packages):
+  thirdPartyPackages =
+    # remote-pi imports @napi-rs/keyring during extension loading. Install its
+    # platform binding directly so npm's optional-dependency bug cannot omit it
+    # during an incremental remote-pi update. Keep this version aligned with
+    # the @napi-rs/keyring version required by remote-pi.
+    lib.optionals (system == "x86_64-linux") [
+      {
+        source = "npm:@napi-rs/keyring-linux-x64-gnu@1.3.0";
+        extensions = [ ];
+        skills = [ ];
+        prompts = [ ];
+        themes = [ ];
+      }
+    ]
+    ++ [
+      "git:github.com/blazed/pi-openai-compaction@b087ebf12329a4da7bdd9376d3f7b28603cae2c1"
+      "npm:@juicesharp/rpiv-ask-user-question@1.20.0"
+      "npm:@juicesharp/rpiv-todo@1.20.0"
+      "npm:@plannotator/pi-extension@0.23.1"
+      "npm:pi-hashline-readmap@0.11.1"
+      "npm:pi-web-access@0.13.0"
+      "npm:remote-pi@0.5.4"
+    ];
 
   # Extra SKILL dirs beyond the auto-discovered ~/.pi/agent/skills + ~/.agents/skills:
   extraSkillDirs = [
@@ -168,10 +185,11 @@ let
 
   piWithExa = pkgs.symlinkJoin {
     name = "pi-with-exa";
-    paths = [ pi ];
+    paths = [ piNode ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
       wrapProgram $out/bin/pi \
+        --run 'export TMPDIR="$HOME/.pi/tmp"; ${pkgs.coreutils}/bin/install -d -m 0700 "$TMPDIR"' \
         --run 'if [ -z "''${EXA_API_KEY:-}" ] && [ -r /run/agenix/exa-api-key ]; then export EXA_API_KEY="$(< /run/agenix/exa-api-key)"; fi'
     '';
   };
@@ -180,6 +198,13 @@ in
   home.packages = [
     piWithExa
     agent-browser
+  ];
+
+  # Pi preserves truncated command output in TMPDIR so it can show the full-output
+  # path in the transcript. Keep it on the persistent disk rather than the 16 GiB
+  # tmpfs root, then age it out automatically.
+  systemd.user.tmpfiles.rules = [
+    "d %h/.pi/tmp 0700 - - 7d"
   ];
 
   # Self-authored skills & extensions (per-file symlinks; parent dirs writable).

--- a/users/profiles/pi/node-package.nix
+++ b/users/profiles/pi/node-package.nix
@@ -1,0 +1,29 @@
+{
+  pkgs,
+  inputs,
+}:
+let
+  system = pkgs.stdenv.hostPlatform.system;
+  pi = inputs.llm-agents.packages.${system}.pi;
+in
+# llm-agents compiles Pi into a standalone Bun binary. Bun binaries cannot
+# resolve external native add-ons loaded by extensions (remote-pi's
+# @napi-rs/keyring in particular), even when the .node package is installed.
+# Reuse the same fetched npm source/dependency closure but retain Pi's normal
+# Node entry point instead of compiling and deleting it.
+pi.overrideAttrs {
+  postUnpack = "";
+  preInstall = "";
+  postInstall = ''
+    wrapProgram $out/bin/pi \
+      --prefix PATH : ${
+        pkgs.lib.makeBinPath [
+          pkgs.fd
+          pkgs.ripgrep
+        ]
+      } \
+      --set PI_PACKAGE_DIR "$out/lib/node_modules/@earendil-works/pi-coding-agent" \
+      --set PI_SKIP_VERSION_CHECK 1 \
+      --set PI_TELEMETRY 0
+  '';
+}


### PR DESCRIPTION
## Summary

- add `backlog-md` to the shared user profile and refresh Pi-managed packages
- keep Pi temporary output on persistent storage with automatic cleanup
- run Pi 0.80.7 through its Node entry point so native extensions such as `remote-pi` load in direct and jailed sessions
- update flake inputs

## Validation

- `statix check .`
- `deadnix -f` on changed Nix files
- `nixfmt --check` on changed Nix files
- direct and jailed Pi RPC startup smoke tests
- `nix flake check --impure path:.`