### PR TITLE
feat(flatpak): manage workstation apps declaratively

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -1264,6 +1264,22 @@
         "type": "github"
       }
     },
+    "nix-flatpak": {
+      "locked": {
+        "lastModified": 1767983141,
+        "narHash": "sha256-7ZCulYUD9RmJIDULTRkGLSW1faMpDlPKcbWJLYHoXcs=",
+        "owner": "gmodena",
+        "repo": "nix-flatpak",
+        "rev": "440818969ac2cbd77bfe025e884d0aa528991374",
+        "type": "github"
+      },
+      "original": {
+        "owner": "gmodena",
+        "ref": "v0.7.0",
+        "repo": "nix-flatpak",
+        "type": "github"
+      }
+    },
     "nix2container": {
       "inputs": {
         "nixpkgs": [
@@ -1754,6 +1770,7 @@
         "mk-shell-bin": "mk-shell-bin",
         "niri": "niri",
         "nix-amd-ai": "nix-amd-ai",
+        "nix-flatpak": "nix-flatpak",
         "nix2container": "nix2container_2",
         "nixos-generators": "nixos-generators",
         "nixos-hardware": "nixos-hardware",

--- a/flake.nix
+++ b/flake.nix
@@ -73,6 +73,7 @@
     # pinned nixpkgs so its Cachix (nix-amd-ai.cachix.org) substitutes; following
     # our nixpkgs would re-hash every backend and force a from-source rebuild.
     nix-amd-ai.url = "github:noamsto/nix-amd-ai";
+    nix-flatpak.url = "github:gmodena/nix-flatpak/?ref=v0.7.0";
     nixos-generators.inputs.nixpkgs.follows = "nixpkgs";
     nixos-generators.url = "github:nix-community/nixos-generators";
     nixos-hardware.url = "github:nixos/nixos-hardware";

--- a/hosts/x86_64-linux/nicolina.nix
+++ b/hosts/x86_64-linux/nicolina.nix
@@ -71,7 +71,6 @@
   };
 
   programs.steam.enable = true;
-  services.flatpak.enable = true;
 
   services.input-remapper.enable = true;
 

--- a/profiles/home-manager.nix
+++ b/profiles/home-manager.nix
@@ -10,6 +10,7 @@
     ../users/modules/theme.nix
     ../users/modules/userinfo.nix
     inputs.dms.homeModules.dank-material-shell
+    inputs.nix-flatpak.homeManagerModules.nix-flatpak
     inputs.niri.homeModules.niri
   ];
 }

--- a/profiles/workstation.nix
+++ b/profiles/workstation.nix
@@ -65,6 +65,7 @@
   services.gnome.gcr-ssh-agent.enable = false;
 
   services.pcscd.enable = true;
+  services.flatpak.enable = true;
 
   programs.dconf.enable = true;
 

--- a/users/profiles/flatpak.nix
+++ b/users/profiles/flatpak.nix
@@ -1,0 +1,15 @@
+{
+  services.flatpak = {
+    enable = true;
+    packages = [
+      "com.discordapp.Discord"
+      "com.github.tchx84.Flatseal"
+      "com.usebottles.bottles"
+    ];
+    uninstallUnmanaged = true;
+    update.auto = {
+      enable = true;
+      onCalendar = "weekly";
+    };
+  };
+}

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -14,6 +14,7 @@ in
     ./chromium.nix
     ./dank-material-shell.nix
     ./faugus.nix
+    ./flatpak.nix
     ./lutris.nix
     ./niri.nix
     ./obs.nix


### PR DESCRIPTION
## Summary

- add and pin nix-flatpak v0.7.0
- manage Discord, Flatseal, and Bottles from a shared Home Manager workstation profile
- enable Flatpak on workstation systems, prune unmanaged user apps/remotes, and schedule weekly updates

## Testing

- `statix check .`
- `nixfmt --check` on changed Nix files
- `deadnix -f` on changed Nix files
- evaluated Flatpak packages and policies for amelia, diana, and nicolina
- `nix build --no-link path:.#nixosConfigurations.nicolina.config.system.build.toplevel`