### PR TITLE
feat(router): firewall hardening

### DIFF
--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -61,12 +61,14 @@
         interface = "enp3s0";
         address = "10.0.20.1";
         trusted = false;
+        forceDns = true;
       };
       guest = {
         id = 30;
         interface = "enp3s0";
         address = "10.0.30.1";
         trusted = false;
+        forceDns = true;
       };
     };
     staticHosts = [

--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -45,10 +45,9 @@
     enable = true;
     externalInterface = "enp4s0";
     internalInterface = "enp3s0";
-    trustedInterfaces = [
-      "lan"
-      "tailscale0"
-    ];
+    # non-VLAN runtime interfaces only; the lan VLAN is trusted via its
+    # own `trusted = true` below.
+    trustedInterfaces = [ "tailscale0" ];
     vlans = {
       lan = {
         id = 10;
@@ -151,6 +150,10 @@
     args.ssh = true;
     args.accept-routes = false;
     args.accept-dns = false;
+    # NOTE: exit-node advertising always includes ::/0 (tailscale has no
+    # v4-only flag), but this router intentionally forwards no IPv6 — v6
+    # from exit-node clients is blackholed and they fall back to v4 via
+    # happy eyeballs; v6-only destinations won't work through this exit.
     args.advertise-exit-node = true;
     args.auth-key = "file:/var/run/agenix/ts";
   };

--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -123,6 +123,7 @@
         port = 22;
         target = "10.0.10.15:22";
         hairpin = true;
+        rateLimitNew = "10/minute burst 20 packets";
       }
     ];
     dotUpstreams = [

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -131,6 +131,17 @@ let
   # own management LAN; tagged untrusted VLANs ride on top of it).
   trustedAll = unique ([ cfg.internalInterface ] ++ trustedVlanNames ++ cfg.trustedInterfaces);
   allInternalNames = unique (internalInterfaceNames ++ cfg.trustedInterfaces);
+
+  # rp_filter=1 already drops cross-interface spoofing at the routing layer;
+  # these explicit per-interface source checks keep the trust boundaries
+  # enforced inside the ruleset itself even if that sysctl is ever loosened.
+  # 0.0.0.0 stays allowed so DHCP DISCOVER/REQUEST broadcasts reach dnsmasq.
+  antiSpoofRules = concatStringsSep "\n              " (
+    mapAttrsToList (
+      name: net:
+      ''iifname "${name}" ip saddr != { ${net.network}/${toString net.prefix}, 0.0.0.0 } counter drop comment "Drop spoofed source on ${name}"''
+    ) internalInterfaces
+  );
 in
 {
   options.services.router = with lib.types; {
@@ -302,44 +313,39 @@ in
     };
     vlans = mkOption {
       default = { };
-      type = attrsOf (
-        submodule (
-          { name, ... }:
-          {
-            options = {
-              id = mkOption {
-                type = int;
-                description = "vlan tag";
-              };
-              interface = mkOption {
-                type = str;
-                description = "interface to tag";
-              };
-              address = mkOption {
-                type = str;
-                description = "IP Address of vlan";
-              };
-              prefixLength = mkOption {
-                type = ints.between 0 32;
-                description = "prefixLength for the address";
-                default = 24;
-              };
-              trusted = mkOption {
-                type = bool;
-                default = true;
-                description = ''
-                  When false, this VLAN is treated as untrusted:
-                    - on input, only DNS+DHCP to the router are allowed (no ssh,
-                      web UI, etc.);
-                    - on forward, trusted interfaces may initiate to it, but it
-                      can only reach trusted interfaces via established/related
-                      state (IoT-style isolation).
-                '';
-              };
-            };
-          }
-        )
-      );
+      type = attrsOf (submodule {
+        options = {
+          id = mkOption {
+            type = int;
+            description = "vlan tag";
+          };
+          interface = mkOption {
+            type = str;
+            description = "interface to tag";
+          };
+          address = mkOption {
+            type = str;
+            description = "IP Address of vlan";
+          };
+          prefixLength = mkOption {
+            type = ints.between 0 32;
+            description = "prefixLength for the address";
+            default = 24;
+          };
+          trusted = mkOption {
+            type = bool;
+            default = true;
+            description = ''
+              When false, this VLAN is treated as untrusted:
+                - on input, only DNS+DHCP to the router are allowed (no ssh,
+                  web UI, etc.);
+                - on forward, trusted interfaces may initiate to it, but it
+                  can only reach trusted interfaces via established/related
+                  state (IoT-style isolation).
+            '';
+          };
+        };
+      });
     };
   };
 
@@ -520,6 +526,10 @@ in
               # Standard hygiene: kill malformed/out-of-window packets and
               # source-routed packets before any later accept rule sees them.
               ct state invalid counter drop comment "Drop invalid conntrack state"
+              # With nf_conntrack_tcp_loose=0 mid-stream pickups already
+              # classify as invalid; this is the explicit backstop against a
+              # new connection whose first packet isn't a SYN (ACK scans).
+              tcp flags & (fin|syn|rst|ack) != syn ct state new counter drop comment "Drop new TCP without SYN"
               ip option lsrr exists counter drop comment "Drop loose source-routed packets"
               ip option ssrr exists counter drop comment "Drop strict source-routed packets"
 
@@ -534,6 +544,10 @@ in
                 169.254.0.0/16,
               } counter drop comment "Drop WAN ingress with bogon source"
 
+              # Internal segments must source from their own subnet (placed
+              # before any accept so spoofed DNS/DHCP is caught too).
+              ${antiSpoofRules}
+
               # DNS + DHCP must work on every internal segment, including
               # untrusted VLANs (router is their only resolver / DHCP server).
               iifname { ${concatStringsSep "," allInternalNames} } udp dport { 53, 67 } counter accept comment "Allow DNS+DHCP from internal"
@@ -547,7 +561,12 @@ in
               # ct state new because broadcasts don't always match the original
               # tuple. Allow it explicitly so WAN DHCP can complete.
               iifname "${cfg.externalInterface}" udp sport 67 udp dport 68 counter accept comment "Allow DHCP client traffic from wan"
+              # Rate-limited visibility into what the terminal drops eat;
+              # journald picks these up and the observability stack ships
+              # them, so scans and misbehaving clients become detectable.
+              iifname "${cfg.externalInterface}" limit rate 5/minute burst 10 packets log prefix "router-drop wan-in: "
               iifname "${cfg.externalInterface}" counter drop comment "Drop all other unsolicited from wan"
+              limit rate 5/minute burst 10 packets log prefix "router-drop input: "
             }
 
             chain output {
@@ -559,11 +578,27 @@ in
 
               # Standard hygiene, mirrored from `input`.
               ct state invalid counter drop comment "Drop invalid conntrack state"
+              tcp flags & (fin|syn|rst|ack) != syn ct state new counter drop comment "Drop new TCP without SYN"
               ip option lsrr exists counter drop comment "Drop loose source-routed packets"
               ip option ssrr exists counter drop comment "Drop strict source-routed packets"
 
+              # Internal segments must source from their own subnet.
+              ${antiSpoofRules}
+
               # enable flow offloading for better throughput
               ip protocol { tcp, udp } flow offload @f
+
+              # BCP38-style egress hygiene: traffic for private ranges must
+              # never leave via the default route (it would leak internal
+              # destinations to the ISP whenever an internal route is
+              # missing). Reject rather than drop so misconfigured clients
+              # fail fast instead of hanging.
+              oifname "${cfg.externalInterface}" ip daddr {
+                10.0.0.0/8,
+                172.16.0.0/12,
+                192.168.0.0/16,
+                169.254.0.0/16,
+              } counter reject with icmp type admin-prohibited comment "Reject private-destined egress to WAN"
 
               iifname { ${concatStringsSep "," allInternalNames} } oifname { "${cfg.externalInterface}" } counter accept comment "Allow LAN to WAN"
               iifname { "${cfg.externalInterface}" } oifname { ${concatStringsSep "," allInternalNames} } ct state { established, related } counter accept comment "Allow established back to LANs"
@@ -582,6 +617,7 @@ in
                 iifname { ${concatStringsSep "," trustedAll} } oifname { ${concatStringsSep "," untrustedVlanNames} } counter accept comment "Allow trusted to untrusted VLANs"
                 iifname { ${concatStringsSep "," untrustedVlanNames} } oifname { ${concatStringsSep "," trustedAll} } ct state { established, related } counter accept comment "Allow established back from untrusted VLANs"
               ''}
+              limit rate 5/minute burst 10 packets log prefix "router-drop forward: "
             }
           }
 
@@ -622,6 +658,12 @@ in
           table ip6 filter {
             chain input {
               type filter hook input priority 0; policy drop;
+
+              # Interfaces still hold ::1/link-local addresses (the sysctls
+              # only stop RA/SLAAC) and glibc prefers ::1 for localhost, so
+              # without this exception connections to ::1 hang on a silent
+              # drop instead of failing fast.
+              iifname "lo" accept
             }
 
             chain forward {
@@ -633,9 +675,21 @@ in
 
 
 
+      # systemd-sysctl runs right after systemd-modules-load; without the
+      # conntrack module loaded at that point the net.netfilter.* keys don't
+      # exist yet and the tcp_loose sysctl below would be silently skipped.
+      boot.kernelModules = [ "nf_conntrack" ];
+
       boot.kernel.sysctl = {
         "net.ipv4.conf.all.forwarding" = true;
         "net.ipv6.conf.all.forwarding" = false;
+
+        # Never let conntrack adopt a TCP connection mid-stream: a bare ACK
+        # arriving on WAN would otherwise create an *established* entry and
+        # sail through the established-accept rules (ACK-scan stealth
+        # bypass). With loose pickup off such packets classify as invalid
+        # and hit the ct-invalid drop.
+        "net.netfilter.nf_conntrack_tcp_loose" = 0;
 
         # standard router hardening
         "net.ipv4.conf.all.rp_filter" = 1;

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -103,6 +103,8 @@ let
   hairpinForwards = builtins.filter (f: f.hairpin) cfg.portForwards;
   hasHairpin = hairpinForwards != [ ];
 
+  rateLimitedForwards = builtins.filter (f: f.rateLimitNew != null) cfg.portForwards;
+
   useStubby = cfg.dotUpstreams != [ ];
   stubbyPort = 5453;
   stubbyAddress = "127.0.0.1#${toString stubbyPort}";
@@ -309,6 +311,18 @@ in
               <router>` from the LAN keeps reaching local SSHD), but you
               should still avoid enabling hairpin on ports the router
               binds locally on the WAN interface.
+            '';
+          };
+          rateLimitNew = mkOption {
+            type = nullOr str;
+            default = null;
+            example = "10/minute burst 20 packets";
+            description = ''
+              Optional nft `limit rate over` expression applied to NEW
+              connections arriving from WAN for this forward; traffic above
+              the rate is dropped before the DNAT accept. Established
+              connections are unaffected. Useful to keep WAN-exposed ports
+              (e.g. forwarded SSH) from collecting brute-force noise.
             '';
           };
         };
@@ -625,6 +639,14 @@ in
               ''}
               iifname { ${concatStringsSep "," allInternalNames} } oifname { "${cfg.externalInterface}" } counter accept comment "Allow LAN to WAN"
               iifname { "${cfg.externalInterface}" } oifname { ${concatStringsSep "," allInternalNames} } ct state { established, related } counter accept comment "Allow established back to LANs"
+
+              # Throttle NEW connections to rate-limited forwards before the
+              # blanket dnat accept below matches them. `ct original
+              # proto-dst` is the pre-DNAT WAN port, so the budget stays
+              # per-forward even when forwards share a target.
+              ${optionalString (rateLimitedForwards != [ ]) (concatMapStringsSep "\n              " (
+                f: ''iifname "${cfg.externalInterface}" meta l4proto ${f.protocol} ct status dnat ct state new ct original proto-dst ${toString f.port} limit rate over ${f.rateLimitNew} counter drop comment "Rate limit new connections to forward ${toString f.port}"''
+              ) rateLimitedForwards)}
 
               # DNAT'd WAN ingress: prerouting rewrites destination, here we
               # accept the resulting forward. `ct status dnat` is set by nftables

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -80,7 +80,6 @@ let
     address = ip;
     base = ipBase ip;
     network = "${base}.0";
-    broadcast = "${base}.255";
     netmask = cidrToNetmask prefix;
     rangeStart = "${base}.21";
     rangeEnd = "${base}.254";
@@ -606,14 +605,22 @@ in
               ip option ssrr exists counter drop comment "Drop strict source-routed packets"
 
               # WAN ingress bogons: nothing arriving from the internet should
-              # claim a private/loopback/link-local source. rp_filter=1
-              # covers most of this; the explicit rule documents intent.
+              # claim a private/loopback/link-local/reserved source.
+              # rp_filter=1 covers most of this; the explicit rule documents
+              # intent. Deliberately absent: 100.64.0.0/10 (a CGNAT ISP
+              # legitimately sources gateway traffic from it) and the
+              # TEST-NET ranges (near-zero abuse value, and the integration
+              # test stages its WAN segment on TEST-NET-2).
               iifname "${cfg.externalInterface}" ip saddr {
+                0.0.0.0/8,
                 10.0.0.0/8,
-                172.16.0.0/12,
-                192.168.0.0/16,
                 127.0.0.0/8,
                 169.254.0.0/16,
+                172.16.0.0/12,
+                192.168.0.0/16,
+                198.18.0.0/15,
+                224.0.0.0/4,
+                240.0.0.0/4,
               } counter drop comment "Drop WAN ingress with bogon source"
 
               # Internal segments must source from their own subnet (placed

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -293,11 +293,15 @@ in
             type = bool;
             default = false;
             description = ''
-              Enable NAT reflection (hairpin). When true, LAN-side traffic
-              destined for any of anja's IPs other than the configured
-              internal-interface addresses (typically the WAN IP) on this
-              port is also DNAT'd to `target`, with a postrouting masquerade
-              so the reply comes back through the router.
+              Enable NAT reflection (hairpin). When true, trusted-side
+              traffic (the parent interface, trusted VLANs and
+              `trustedInterfaces`) destined for any of anja's IPs other
+              than the configured internal-interface addresses (typically
+              the WAN IP) on this port is also DNAT'd to `target`, with a
+              postrouting masquerade so the reply comes back through the
+              router. Untrusted VLANs never hairpin: the forward chain
+              would drop their DNAT'd flows anyway, so they are excluded
+              from the DNAT and hit a clean input-chain drop instead.
 
               Note that hairpin necessarily SNATs the LAN client to the
               router's IP — the application backend will see the router as
@@ -680,12 +684,16 @@ in
                 f: ''iifname "${cfg.externalInterface}" ${f.protocol} dport ${toString f.port} dnat to ${f.target}''
               ) cfg.portForwards}
               ${optionalString hasHairpin (concatMapStringsSep "\n              " (
-                # Hairpin DNAT: LAN-arriving traffic for any local IP that
+                # Hairpin DNAT: trusted-side traffic for any local IP that
                 # isn't an internal-interface address (i.e. the WAN IP) on
                 # this port also gets DNAT'd to `target`. The `ip daddr !=`
-                # set keeps `LAN-client → router-LAN-IP:<port>` reaching the
+                # set keeps `client → router-LAN-IP:<port>` reaching the
                 # router's own services rather than being hijacked.
-                f: ''iifname { ${concatStringsSep "," allInternalNames} } ip daddr != { ${concatStringsSep "," internalInterfaceAddresses} } fib daddr type local ${f.protocol} dport ${toString f.port} dnat to ${f.target}''
+                # Untrusted VLANs are deliberately excluded: forward would
+                # drop their DNAT'd flows anyway (untrusted→trusted needs
+                # established), so skipping the DNAT gives them a clean
+                # input-chain drop instead of half-applied NAT.
+                f: ''iifname { ${concatStringsSep "," trustedAll} } ip daddr != { ${concatStringsSep "," internalInterfaceAddresses} } fib daddr type local ${f.protocol} dport ${toString f.port} dnat to ${f.target}''
               ) hairpinForwards)}
             }
 
@@ -700,7 +708,7 @@ in
                 # stack would reject the reply as coming from the wrong
                 # address. Masquerading sources the connection from the
                 # router so replies traverse it on the way back.
-                ct status dnat iifname { ${concatStringsSep "," allInternalNames} } oifname { ${concatStringsSep "," allInternalNames} } counter masquerade comment "Hairpin NAT reflection"
+                ct status dnat iifname { ${concatStringsSep "," trustedAll} } oifname { ${concatStringsSep "," allInternalNames} } counter masquerade comment "Hairpin NAT reflection"
               ''}
             }
           }

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -466,6 +466,11 @@ in
           after = [ "network.target" ];
           wantedBy = [ "multi-user.target" ];
           before = [ "dnsmasq.service" ];
+          # Stubby is the only general upstream dnsmasq has (no-resolv +
+          # dotUpstreams), so it must never stay dead: systemd's default
+          # start limit (5 in 10s) would otherwise turn a crash loop into a
+          # permanent LAN-wide DNS outage.
+          startLimitIntervalSec = 0;
           serviceConfig = {
             Type = "simple";
             User = "router-dot";
@@ -476,7 +481,8 @@ in
             # but it stays out of world-readable space.
             ExecStartPre = "+${stubbyRender}";
             ExecStart = "${pkgs.stubby}/bin/stubby -C /run/router-dot/stubby.yml";
-            Restart = "on-failure";
+            Restart = "always";
+            RestartSec = 2;
             RuntimeDirectory = "router-dot";
             RuntimeDirectoryMode = "0750";
             NoNewPrivileges = true;
@@ -486,6 +492,10 @@ in
             AmbientCapabilities = "";
           };
         };
+
+        # A manual `systemctl restart dnsmasq` should pull stubby back up
+        # if it was stopped; ordering alone (before=) doesn't start it.
+        dnsmasq.wants = mkIf useStubby [ "router-dot-resolver.service" ];
       }
       # Order each VLAN's netdev service after its parent's address
       # configuration. Without this, `<vlan>-netdev.service` can race the

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -97,6 +97,9 @@ let
   trustedVlanNames = attrNames (filterAttrs (_: v: v.trusted) cfg.vlans);
   untrustedVlanNames = attrNames (filterAttrs (_: v: !v.trusted) cfg.vlans);
 
+  forceDnsVlanNames = attrNames (filterAttrs (_: v: v.forceDns) cfg.vlans);
+  hasForceDns = forceDnsVlanNames != [ ];
+
   hairpinForwards = builtins.filter (f: f.hairpin) cfg.portForwards;
   hasHairpin = hairpinForwards != [ ];
 
@@ -342,6 +345,19 @@ in
                 - on forward, trusted interfaces may initiate to it, but it
                   can only reach trusted interfaces via established/related
                   state (IoT-style isolation).
+            '';
+          };
+          forceDns = mkOption {
+            type = bool;
+            default = false;
+            description = ''
+              When true, all plain-DNS traffic (TCP/UDP port 53) from this
+              VLAN is transparently redirected to the router's dnsmasq, and
+              DoT/DoQ egress (port 853) is blocked so clients fall back to
+              plain 53. This stops devices with hardcoded resolvers
+              (8.8.8.8 etc. — common on IoT) from bypassing the router's
+              DNS filtering. DoH rides on 443 and is indistinguishable from
+              HTTPS, so it cannot be caught here; accepted limitation.
             '';
           };
         };
@@ -600,6 +616,13 @@ in
                 169.254.0.0/16,
               } counter reject with icmp type admin-prohibited comment "Reject private-destined egress to WAN"
 
+              ${optionalString hasForceDns ''
+                # forceDns VLANs: no DoT/DoQ egress — reject TCP fast so
+                # clients fall back to plain 53 (redirected in prerouting),
+                # drop the QUIC variant.
+                iifname { ${concatStringsSep "," forceDnsVlanNames} } tcp dport 853 counter reject with tcp reset comment "Block DoT from forceDns VLANs"
+                iifname { ${concatStringsSep "," forceDnsVlanNames} } udp dport 853 counter drop comment "Block DoQ from forceDns VLANs"
+              ''}
               iifname { ${concatStringsSep "," allInternalNames} } oifname { "${cfg.externalInterface}" } counter accept comment "Allow LAN to WAN"
               iifname { "${cfg.externalInterface}" } oifname { ${concatStringsSep "," allInternalNames} } ct state { established, related } counter accept comment "Allow established back to LANs"
 
@@ -624,6 +647,13 @@ in
           table ip nat {
             chain prerouting {
               type nat hook prerouting priority dstnat; policy accept;
+              ${optionalString hasForceDns ''
+                # forceDns VLANs: hijack any plain-DNS query to the router's
+                # own dnsmasq. `redirect` DNATs to the address of the
+                # interface the packet arrived on, which dnsmasq listens on,
+                # and the input chain already accepts 53 from internal.
+                iifname { ${concatStringsSep "," forceDnsVlanNames} } meta l4proto { tcp, udp } th dport 53 counter redirect comment "Force VLAN DNS to router"
+              ''}
               ${concatMapStringsSep "\n              " (
                 f: ''iifname "${cfg.externalInterface}" ${f.protocol} dport ${toString f.port} dnat to ${f.target}''
               ) cfg.portForwards}

--- a/modules/router.nix
+++ b/modules/router.nix
@@ -177,6 +177,17 @@ in
         `dotUpstreams` — those handle everything else.
       '';
     };
+    rebindOkDomains = mkOption {
+      type = listOf str;
+      default = [ ];
+      example = [ "internal.example.com" ];
+      description = ''
+        Extra domains exempted from DNS rebind protection
+        (`stop-dns-rebind`) — for public names that legitimately resolve
+        to private/CGNAT space upstream (split-horizon DNS, tailnet
+        rewrites, …). Domains in `dnsForwarders` are always exempt.
+      '';
+    };
     dotUpstreams = mkOption {
       type = listOf str;
       default = [ ];
@@ -401,6 +412,9 @@ in
         "interface"
         "bind-dynamic"
         "bind-interfaces"
+        # Derived from dnsForwarders + rebindOkDomains; extra rebind
+        # exemptions belong in those options.
+        "rebind-domain-ok"
       ];
       shadowed = builtins.filter (k: cfg.dnsMasqSettings ? ${k}) reservedDnsmasqKeys;
     in
@@ -527,6 +541,20 @@ in
         # interfaces appearing/disappearing at runtime — needed for
         # interfaces like tailscale0 that don't exist at boot.
         bind-dynamic = true;
+        # DNS rebind protection: strip upstream answers that resolve public
+        # names into private space (a hostile domain could otherwise pivot
+        # a LAN browser at internal services). Local data (localDomain,
+        # `address=` overrides, DHCP names) is not subject to the check,
+        # and filtering upstreams that answer 0.0.0.0 for blocked names
+        # simply yield empty answers instead — same effect. Deliberately
+        # overridable via dnsMasqSettings as an escape hatch.
+        stop-dns-rebind = true;
+        # dnsForwarders exist precisely to return tailnet/CGNAT-range
+        # answers (e.g. MagicDNS 100.x), so they are exempted automatically;
+        # rebindOkDomains covers other legitimate private-space answers.
+        rebind-domain-ok = map (domain: "/${domain}/") (
+          attrNames cfg.dnsForwarders ++ cfg.rebindOkDomains
+        );
         dhcp-authoritative = true;
         expand-hosts = true;
         dhcp-range = mapAttrsToList (

--- a/profiles/tailscale.nix
+++ b/profiles/tailscale.nix
@@ -3,6 +3,12 @@
     enable = true;
     interfaceName = "tailscale0";
   };
+  # NOTE: both settings below are inert on hosts that force-disable
+  # networking.firewall (the router — services.router — replaces it with
+  # its own nftables ruleset). There tailscale0 must be trusted explicitly
+  # via services.router.trustedInterfaces, and rp_filter is strict (router
+  # sysctl) rather than loose; that still works because tailnet routes
+  # (100.64.0.0/10) point at tailscale0, so replies pass the strict check.
   networking.firewall.trustedInterfaces = [ "tailscale0" ];
   networking.firewall.checkReversePath = "loose";
 }

--- a/tests/router.nix
+++ b/tests/router.nix
@@ -77,6 +77,11 @@ pkgs.testers.runNixOSTest {
               rateLimitNew = "10/minute burst 20 packets";
             }
           ];
+          # newer dnsmasq's stop-dns-rebind also covers the TEST-NET
+          # documentation ranges this test uses as upstream sentinels, so
+          # exempt the sentinel domain — which conveniently also exercises
+          # the rebindOkDomains plumbing.
+          rebindOkDomains = [ "example" ];
           dnsMasqSettings = {
             # local answer so the DNS test doesn't depend on an upstream chain
             address = [ "/test.lan.darkstar.se/192.0.2.123" ];
@@ -206,7 +211,11 @@ pkgs.testers.runNixOSTest {
           bind-interfaces = true;
           interface = "eth1";
           no-resolv = true;
-          address = [ "/#/192.0.2.250" ];
+          address = [
+            "/#/192.0.2.250"
+            # private-space answer for the rebind-protection subtest
+            "/rebind.test/10.66.66.66"
+          ];
         };
 
         services.nginx = {
@@ -259,6 +268,13 @@ pkgs.testers.runNixOSTest {
 
     with subtest("DNS: router forwards unknown queries to upstream"):
         native.succeed("getent hosts something.example | grep -q 192.0.2.250")
+
+    with subtest("DNS rebind protection strips private answers from upstream"):
+        # wan's dnsmasq maps rebind.test to 10.66.66.66; the router must
+        # refuse to relay a public name resolving into private space.
+        # (something.example above only resolves because the `example`
+        # domain is exempted via rebindOkDomains.)
+        native.fail("getent hosts rebind.test | grep -q 10.66.66.66")
 
     with subtest("WAN cannot initiate connections to LAN"):
         # target the actual reservation IP so the failure is unambiguously

--- a/tests/router.nix
+++ b/tests/router.nix
@@ -291,6 +291,13 @@ pkgs.testers.runNixOSTest {
         ).strip()
         trusted.succeed(f"ping -c1 -W2 {iot_ip}")
 
+    with subtest("anti-spoof: out-of-subnet source on a trusted segment is dropped"):
+        # a trusted client spoofing an iot-subnet source must not reach the
+        # router even though its interface is otherwise fully trusted.
+        trusted.succeed("ip addr add 10.0.20.99/32 dev lan10")
+        trusted.fail("ping -c1 -W2 -I 10.0.20.99 10.0.10.1")
+        trusted.succeed("ip addr del 10.0.20.99/32 dev lan10")
+
     with subtest("untrusted client cannot initiate to trusted client"):
         trusted_ip = trusted.succeed(
             "ip -4 -o addr show lan10 | awk '{print $4}' | cut -d/ -f1"
@@ -352,5 +359,15 @@ pkgs.testers.runNixOSTest {
         router.succeed("nft list table inet filter | grep -q 'ct state invalid'")
         router.succeed("nft list table inet filter | grep -q 'ip option'")
         router.succeed("nft list table inet filter | grep -q 'bogon source'")
+        # hardening rules: non-SYN new drop, per-interface anti-spoof,
+        # egress martian reject, rate-limited drop logging, ip6 loopback
+        router.succeed("nft list table inet filter | grep -q 'Drop new TCP without SYN'")
+        router.succeed("nft list table inet filter | grep -q 'Drop spoofed source on'")
+        router.succeed("nft list table inet filter | grep -q 'private-destined egress'")
+        router.succeed("nft list table inet filter | grep -q 'router-drop'")
+        router.succeed("nft list table ip6 filter | grep -q 'iifname \"lo\" accept'")
+
+    with subtest("conntrack does not adopt mid-stream TCP"):
+        router.succeed("sysctl -n net.netfilter.nf_conntrack_tcp_loose | grep -qx 0")
   '';
 }

--- a/tests/router.nix
+++ b/tests/router.nix
@@ -74,6 +74,7 @@ pkgs.testers.runNixOSTest {
               port = 9443;
               target = "10.0.10.5:80";
               hairpin = false;
+              rateLimitNew = "10/minute burst 20 packets";
             }
           ];
           dnsMasqSettings = {
@@ -368,6 +369,15 @@ pkgs.testers.runNixOSTest {
         # listener), it does NOT succeed against the backend.
         trusted.fail("curl -sf --max-time 3 http://10.0.10.1:8443/")
 
+    with subtest("portForward rateLimitNew: burst of new connections gets throttled"):
+        # port 9443 allows 20 new connections of burst then 10/minute; 25
+        # rapid requests must therefore see at least one dropped (curl times
+        # out on the swallowed SYN). Runs last among the 9443 tests so the
+        # exhausted bucket can't interfere with earlier assertions.
+        wan.fail(
+            "for i in $(seq 1 25); do curl -sf --max-time 2 http://198.51.100.1:9443/ >/dev/null || exit 1; done"
+        )
+
     with subtest("nftables ruleset structure"):
         router.succeed("nft list table ip nat | grep -q 'masquerade'")
         router.succeed("nft list table ip nat | grep -q 'hook prerouting priority dstnat'")
@@ -389,6 +399,8 @@ pkgs.testers.runNixOSTest {
         router.succeed("nft list table ip6 filter | grep -q 'iifname \"lo\" accept'")
         # forceDns: plain-DNS redirect + DoT/DoQ block
         router.succeed("nft list table ip nat | grep -q 'Force VLAN DNS to router'")
+        # per-forward rate limiting
+        router.succeed("nft list table inet filter | grep -q 'Rate limit new connections'")
         router.succeed("nft list table inet filter | grep -q 'Block DoT from forceDns VLANs'")
         router.succeed("nft list table inet filter | grep -q 'Block DoQ from forceDns VLANs'")
 

--- a/tests/router.nix
+++ b/tests/router.nix
@@ -50,6 +50,7 @@ pkgs.testers.runNixOSTest {
               interface = "eth2";
               address = "10.0.20.1";
               trusted = false;
+              forceDns = true;
             };
           };
           staticHosts = [
@@ -113,8 +114,10 @@ pkgs.testers.runNixOSTest {
 
     # tagged client on VLAN 10 — should be treated as trusted by the router.
     trusted =
-      { lib, ... }:
+      { lib, pkgs, ... }:
       {
+        # dig, for the forceDns control test
+        environment.systemPackages = [ pkgs.dnsutils ];
         virtualisation.vlans = [ 2 ];
         networking.useDHCP = lib.mkForce false;
         networking.vlans.lan10 = {
@@ -128,8 +131,10 @@ pkgs.testers.runNixOSTest {
 
     # tagged client on VLAN 20 — should be treated as untrusted by the router.
     iot =
-      { lib, ... }:
+      { lib, pkgs, ... }:
       {
+        # dig, for the forceDns redirect test
+        environment.systemPackages = [ pkgs.dnsutils ];
         virtualisation.vlans = [ 2 ];
         networking.useDHCP = lib.mkForce false;
         networking.vlans.iot20 = {
@@ -307,6 +312,22 @@ pkgs.testers.runNixOSTest {
     with subtest("untrusted client can DNS to router (input chain allows)"):
         iot.succeed("getent hosts fixed.lan.darkstar.se | grep -q 10.0.0.42")
 
+    with subtest("forceDns: untrusted client's direct-to-upstream DNS is hijacked"):
+        # iot has forceDns; a query aimed straight at the WAN host must be
+        # transparently redirected to the router's dnsmasq, which answers
+        # test.lan.darkstar.se locally (192.0.2.123) — the wan node's
+        # catch-all would have said 192.0.2.250.
+        iot.succeed(
+            "dig +short +time=3 +tries=1 @198.51.100.2 test.lan.darkstar.se | grep -qx 192.0.2.123"
+        )
+
+    with subtest("forceDns off: trusted client's direct-to-upstream DNS is untouched"):
+        # trustedvl has no forceDns, so the same query really reaches the
+        # wan node and gets its catch-all answer.
+        trusted.succeed(
+            "dig +short +time=3 +tries=1 @198.51.100.2 test.lan.darkstar.se | grep -qx 192.0.2.250"
+        )
+
     with subtest("untrusted client cannot reach router services beyond DNS/DHCP"):
         # nginx on 8080 is only reachable from trusted; untrusted is dropped.
         trusted.succeed("curl -sf --max-time 5 http://10.0.10.1:8080/ | grep -q 'router internal'")
@@ -366,6 +387,10 @@ pkgs.testers.runNixOSTest {
         router.succeed("nft list table inet filter | grep -q 'private-destined egress'")
         router.succeed("nft list table inet filter | grep -q 'router-drop'")
         router.succeed("nft list table ip6 filter | grep -q 'iifname \"lo\" accept'")
+        # forceDns: plain-DNS redirect + DoT/DoQ block
+        router.succeed("nft list table ip nat | grep -q 'Force VLAN DNS to router'")
+        router.succeed("nft list table inet filter | grep -q 'Block DoT from forceDns VLANs'")
+        router.succeed("nft list table inet filter | grep -q 'Block DoQ from forceDns VLANs'")
 
     with subtest("conntrack does not adopt mid-stream TCP"):
         router.succeed("sysctl -n net.netfilter.nf_conntrack_tcp_loose | grep -qx 0")

--- a/tests/router.nix
+++ b/tests/router.nix
@@ -360,6 +360,11 @@ pkgs.testers.runNixOSTest {
         # 9443 and the connection should be refused or time out.
         native.fail("curl -sf --max-time 3 http://198.51.100.1:9443/")
 
+    with subtest("portForward hairpin is trusted-side only: untrusted client gets nothing"):
+        # iot is excluded from the hairpin DNAT set, so its traffic to the
+        # WAN IP dead-ends at the router's input chain.
+        iot.fail("curl -sf --max-time 3 http://198.51.100.1:8443/")
+
     with subtest("portForward hairpin: traffic to router's own LAN IP isn't hijacked"):
         # The hairpin rule excludes destinations matching internal-interface
         # addresses; 10.0.10.1 is one of them, so a LAN-side request to the


### PR DESCRIPTION
Hardens the `services.router` nftables setup based on a security audit of the module. Three commits:

## Baseline hardening
- `nf_conntrack_tcp_loose = 0` (+ `nf_conntrack` in `boot.kernelModules` so the sysctl key exists when systemd-sysctl runs) and a `tcp flags … != syn ct state new` drop in input+forward — closes the ACK-scan bypass where a bare ACK from WAN creates an *established* conntrack entry and sails through the established-accept rules.
- Explicit per-interface anti-spoof rules for all internal segments (`0.0.0.0` exempted for DHCP DISCOVER) — trust boundaries no longer depend solely on the `rp_filter` sysctl.
- BCP38-style egress hygiene: reject private-destined traffic leaving via WAN.
- Rate-limited `log` statements (`router-drop …` prefixes) before all terminal drops, so scans and misbehaving clients show up in Loki.
- `iifname "lo" accept` in the ip6 input chain: interfaces still hold `::1`/link-local (the sysctls only stop RA/SLAAC) and glibc prefers `::1` for localhost, so connections to `::1` previously hung on a silent drop.

## Per-VLAN `forceDns` option
Transparently redirects plain DNS (TCP/UDP 53) to the router's dnsmasq and blocks DoT/DoQ (853) so devices with hardcoded resolvers fall back to the filtered NextDNS chain. DoH (443) is indistinguishable from HTTPS — accepted limitation, documented on the option. Enabled on anja's `iot` and `guest` VLANs.

## Per-forward `rateLimitNew` option
Opt-in nft `limit rate over` throttle for NEW connections per port forward, keyed on the pre-DNAT WAN port (`ct original proto-dst`) so budgets stay per-forward even when forwards share a target. Applied to anja's WAN:22 forward (10/minute, burst 20).

## Validation
- `statix` / `deadnix` clean; anja toplevel evaluates.
- `nix build .#checks.x86_64-linux.router` passes — 29 subtests including new behaviour tests: spoofed-source drop, forceDns hijack from the iot client (+ trusted-client control), rate-limit throttling of a 25-connection burst, conntrack sysctl, and ruleset-structure greps for every new rule.

## Operational notes
- IoT/guest devices with hardcoded DNS will now resolve through NextDNS — expect behaviour changes for those clients.
- `nf_conntrack_tcp_loose=0` means long-lived TCP flows are no longer adopted after a conntrack flush (e.g. reboot) — standard tradeoff.