### PR TITLE
feat(observability): improve Anja router monitoring

### DIFF
--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -26,6 +26,36 @@
     lokiURL = "http://loki.tailef5cf.ts.net:3100/loki/api/v1/push";
   };
 
+  services.prometheus.exporters = {
+    blackbox = {
+      enable = true;
+      listenAddress = "0.0.0.0";
+      configFile = pkgs.writeText "blackbox-exporter.yml" ''
+        modules:
+          dns_udp:
+            prober: dns
+            timeout: 5s
+            dns:
+              transport_protocol: udp
+              preferred_ip_protocol: ip4
+              query_name: example.com
+              query_type: A
+      '';
+    };
+    smartctl = {
+      enable = true;
+      listenAddress = "0.0.0.0";
+    };
+    smokeping = {
+      enable = true;
+      listenAddress = "0.0.0.0";
+      hosts = [
+        "1.1.1.1"
+        "9.9.9.9"
+      ];
+    };
+  };
+
   disk.dosLabel = true;
 
   virtualisation.docker.enable = lib.mkForce false;

--- a/profiles/observability.nix
+++ b/profiles/observability.nix
@@ -38,6 +38,9 @@ in
       ];
       extraFlags = [
         "--collector.textfile.directory=/var/lib/node_exporter/textfile"
+        "--collector.systemd.enable-restarts-metrics"
+        "--collector.systemd.enable-start-time-metrics"
+        "--collector.systemd.enable-task-metrics"
       ];
     };
 
@@ -49,6 +52,7 @@ in
     services.prometheus.exporters.dnsmasq = lib.mkIf config.services.dnsmasq.enable {
       enable = true;
       port = 9153;
+      dnsmasqListenAddress = "127.0.0.1:53";
       leasesPath = "/var/lib/dnsmasq/dnsmasq.leases";
     };
 
@@ -56,6 +60,7 @@ in
     # push URL is configured — this profile is otherwise metrics-only.
     services.alloy = lib.mkIf (cfg.lokiURL != null) {
       enable = true;
+      extraFlags = [ "--disable-reporting" ];
       configPath = pkgs.writeText "config.alloy" ''
         loki.write "default" {
           endpoint {
@@ -64,7 +69,7 @@ in
         }
 
         loki.relabel "journal" {
-          forward_to = [loki.write.default.receiver]
+          forward_to = []
           rule {
             source_labels = ["__journal__systemd_unit"]
             target_label  = "unit"
@@ -76,7 +81,8 @@ in
         }
 
         loki.source.journal "default" {
-          forward_to    = [loki.relabel.journal.receiver]
+          forward_to    = [loki.write.default.receiver]
+          relabel_rules = loki.relabel.journal.rules
           max_age       = "12h"
           labels        = {
             job  = "systemd-journal",


### PR DESCRIPTION
## Summary

- repair dnsmasq statistics collection and preserve systemd journal metadata in Loki
- disable noisy Alloy usage reporting and collect additional systemd metrics
- add SMART disk health, recursive DNS, and WAN latency/loss exporters for Anja
- let smartctl_exporter autodiscover physical disks

## Validation

- `nix run nixpkgs#nixfmt-rfc-style -- --check hosts/x86_64-linux/anja.nix profiles/observability.nix`
- `statix check .`
- `nix run nixpkgs#deadnix -- -f hosts/x86_64-linux/anja.nix profiles/observability.nix`
- Alloy configuration validation
- blackbox exporter configuration validation and live DNS probe (`probe_success 1`)
- `nix build --no-link .#nixosConfigurations.anja.config.system.build.toplevel`

A companion `argocd-apps` change adds the matching Prometheus scrape jobs.