### PR TITLE
fix(anja): exempt exsules.com from DNS rebind protection (Istio outage hotfix)

### DIFF
--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -163,6 +163,13 @@
     dnsForwarders = {
       "tailef5cf.ts.net" = "100.100.100.100";
     };
+    # Public DNS carries split-horizon exsules.com records pointing into
+    # private space (e.g. vault.prd.exsules.com -> a k3s ClusterIP), which
+    # stop-dns-rebind would otherwise strip — that broke cert-manager's
+    # Vault issuer and with it Istio workload-cert renewal. Exempting our
+    # own domain is safe: rebind protection only matters for domains an
+    # attacker can answer for.
+    rebindOkDomains = [ "exsules.com" ];
     dnsMasqSettings = {
       no-resolv = true;
       bogus-priv = true;


### PR DESCRIPTION
**Incident hotfix** for the intermittent Istio `upstream connect error or disconnect/reset before headers. reset reason: connection termination` errors.

## Root cause
The DNS rebind protection deployed with the router-hardening PR strips upstream answers that resolve public names into private space. Public DNS carries split-horizon records for our own domain — `vault.prd.exsules.com` → `10.98.213.242` (a k3s ClusterIP) — so anja's dnsmasq began answering NXDOMAIN for the Vault endpoint.

Chain: cert-manager's `vault-istio-issuer` can't reach Vault (`lookup vault.prd.exsules.com … no such host`) → CertificateRequests approved but never signed → istio-csr can't issue workload certs (readiness failing for ~26h, matching deploy time) → Istio workload certs (24h TTL) expire workload-by-workload → Envoy resets on dead mTLS (`connection termination`), and new pods stick at `Init:1/2` because their sidecars can't bootstrap certs.

Verified: `dig vault.prd.exsules.com @10.0.10.1` → empty; `@1.1.1.1` → `10.98.213.242`.

## Fix
`services.router.rebindOkDomains = [ "exsules.com" ]` on anja. Exempting our own domain is safe — rebind protection only defends against domains an attacker can answer for, and `exsules.com` is ours. Protection stays active for everything else.

## Recovery after deploy
Pending CertificateRequests should sign within moments; stuck pods complete Init; workloads with expired certs recover as sidecars retry CSR. If any pod stays wedged, delete it.