### PR TITLE
fix(pi): add C++ build toolchain for native addon compilation

### DIFF
--- a/users/profiles/jailed-agents-builders.nix
+++ b/users/profiles/jailed-agents-builders.nix
@@ -22,9 +22,11 @@ let
     curl
     diffutils
     fd
+    gcc
     findutils
     gawkInteractive
     git
+    gnumake
     gnugrep
     gnused
     gnutar

--- a/users/profiles/pi/node-package.nix
+++ b/users/profiles/pi/node-package.nix
@@ -18,6 +18,8 @@ pi.overrideAttrs {
     wrapProgram $out/bin/pi \
       --prefix PATH : ${
         pkgs.lib.makeBinPath [
+          pkgs.stdenv.cc
+          pkgs.gnumake
           pkgs.fd
           pkgs.ripgrep
         ]


### PR DESCRIPTION
<!-- README: https://github.com/blazed/cake/tree/main/.github/pr-template.md -->

## Problem

On NixOS, starting Pi fails with `npm install` error because `node-pty` (a native Node.js addon required by `@plannotator/pi-extension`) cannot compile — `c++: No such file or directory`. The C++ compiler and GNU Make are absent from the default runtime PATH.

## Solution

Add `pkgs.stdenv.cc` and `pkgs.gnumake` to PATH in two places:

- **`users/profiles/pi/node-package.nix`** — the wrapped `pi` binary PATH prefix (covers direct `pi` usage)
- **`users/profiles/jailed-agents-builders.nix`** — the jailed `devTools` list (covers `jailed-pi` usage)

This ensures `node-gyp` can compile native addons like `node-pty` during `npm install` for third-party Pi packages.

## Validation

- [x] `nix eval --impure` succeeds on the flake
- [x] `nix-instantiate --eval` parses both changed files
- [ ] `nix build` confirms no build regression (not run — please trigger if CI is available)
- [x] `statix check` passes on changed directories

Closes: _(issues — none filed)_