### PR TITLE
fix(proton-pass): use D-Bus keyring backend

### DIFF
--- a/users/profiles/protonpass.nix
+++ b/users/profiles/protonpass.nix
@@ -1,4 +1,11 @@
 { pkgs, ... }:
 {
-  home.packages = [ pkgs.proton-pass-cli ];
+  home = {
+    packages = [ pkgs.proton-pass-cli ];
+
+    sessionVariables = {
+      PROTON_PASS_KEY_PROVIDER = "keyring";
+      PROTON_PASS_LINUX_KEYRING = "dbus";
+    };
+  };
 }


### PR DESCRIPTION
## Summary

- configure Proton Pass CLI to use keyring storage
- select the D-Bus Secret Service backend for persistent, accessible key storage

## Validation

- `nix-instantiate --parse users/profiles/protonpass.nix`