### PR TITLE
feat(proton-vpn): add desktop client

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -54,6 +54,7 @@
         ".claude"
         ".codex"
         ".config/LM Studio"
+        ".config/Proton"
         ".config/Signal"
         ".config/Slack"
         ".config/WowUpCf"

--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -25,6 +25,7 @@ in
     ./nushell/default.nix
     ./pi/default.nix
     ./protonpass.nix
+    ./protonvpn.nix
     ./ssh.nix
     ./starship.nix
     ./wezterm/default.nix

--- a/users/profiles/protonvpn.nix
+++ b/users/profiles/protonvpn.nix
@@ -1,0 +1,4 @@
+{ pkgs, ... }:
+{
+  home.packages = [ pkgs.proton-vpn ];
+}


### PR DESCRIPTION
## Summary

- install the Proton VPN desktop client through Home Manager
- import the new Proton VPN profile
- persist Proton VPN configuration state

## Validation

- Nix syntax parsing for all changed files
- `statix check` for all changed files
- `nix flake check --impure --no-build`

`deadnix` was unavailable in the current environment.