### PR TITLE
chore(agents): remove agent-browser integration

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -61,8 +61,6 @@
     jail-nix.url = "sourcehut:~alexdavid/jail.nix";
     kured.flake = false;
     kured.url = "github:kubereboot/kured";
-    # Keep llm-agents on its pinned nixpkgs: its agent-browser package currently
-    # uses pnpm 11 with a fetcher version incompatible with our newer nixpkgs.
     llm-agents.url = "github:numtide/llm-agents.nix";
     mk-shell-bin.url = "github:rrbutani/nix-mk-shell-bin";
     niri.url = "github:sodiboo/niri-flake";

--- a/users/profiles/git.nix
+++ b/users/profiles/git.nix
@@ -46,7 +46,6 @@ in
       ".nvimlog" # TODO(blazed): find out why this is needed?
       ".pi/remote-pi/"
       ".pi/workflows/"
-      "pi-session*.html" # agent-browser session dumps (see users/profiles/pi)
     ];
   };
 

--- a/users/profiles/jailed-agents-builders.nix
+++ b/users/profiles/jailed-agents-builders.nix
@@ -1,12 +1,4 @@
-# Pure builders for the jailed agent wrappers.
-#
-# This is the single source of truth for the bubblewrap permission set. It is
-# consumed by the home-manager profile (./jailed-agents.nix, which installs
-# `wrappers`) and by the NixOS tests under ../../tests: jail-leak-audit.nix wraps
-# an audit payload with `permsFor agents.claude`, and jail-jj-workspace.nix
-# exercises the same sandbox from inside a jj workspace. Keeping the permissions
-# here means the tests exercise the exact sandbox the agents run in — a leaky
-# bind added to `common` would make the audit fail.
+# Shared bubblewrap definitions for jailed agents and their NixOS tests.
 { pkgs, inputs }:
 let
   inherit (pkgs.stdenv.hostPlatform) system;
@@ -14,26 +6,26 @@ let
   llm = inputs.llm-agents.packages.${system};
   piNode = import ./pi/node-package.nix { inherit pkgs inputs; };
 
-  # Tools on PATH inside every jail. Deliberately excludes gcloud/kubectl/aws/ssh
-  # so a runaway agent can't reach cloud or remote credentials.
+  # Excludes cloud and remote-access tools to keep credentials unreachable.
   devTools = with pkgs; [
     # keep-sorted start
     bashInteractive
     curl
     diffutils
     fd
-    gcc
     findutils
     gawkInteractive
+    gcc
     git
-    gnumake
     gnugrep
+    gnumake
     gnused
     gnutar
     jq
     jujutsu
     nodejs
     nushell
+    proton-pass-cli
     ps
     python3
     ripgrep
@@ -45,26 +37,15 @@ let
   cu = "${pkgs.coreutils}/bin";
   jjBin = "${pkgs.jujutsu}/bin/jj";
 
-  # Make the agent usable inside a devenv/direnv-activated project: mount the
-  # whole store read-only (so devenv-provided tools resolve) and forward the
-  # caller's environment + PATH into the jail, MINUS secret-looking variables.
-  # The agent's own API key is forwarded explicitly via each agent's `extra`.
-  # Curated devTools are prepended to PATH so they're always present, with the
-  # project's (devenv) PATH after them.
+  # Preserve project environments while filtering secrets and prepending devTools.
   forwardHostEnv =
     c: with c; [
       (ro-bind "/nix/store" "/nix/store")
       (add-runtime ''
         shopt -s nocasematch
-        # Drop secret-looking vars by NAME. Case-insensitive (nocasematch).
-        # `_PWD$` catches MySQL's documented plaintext-password var MYSQL_PWD
-        # (and DB_PWD/REDIS_PWD/…) without stripping the benign PWD/OLDPWD (no
-        # underscore before PWD there).
+        # Match secret-like names while preserving benign PWD and OLDPWD.
         __deny='^(AWS_|GH_|GITHUB_|OP_)|TOKEN|SECRET|KEY|PASSWORD|PASSWD|CREDENTIAL|_PWD$|^SSH_AUTH_SOCK$|^PATH$'
-        # Also drop by VALUE: connection strings with embedded credentials
-        # (scheme://user:pass@host — DATABASE_URL/POSTGRES_URL/MONGODB_URI/…),
-        # whatever the var is named. Requires a `:password@`, so credential-free
-        # URLs (OPENAI_BASE_URL=http://host:port) and ssh://git@host remotes stay.
+        # Also reject connection strings containing embedded passwords.
         __denyval='://[^@/]*:[^@/]+@'
         while IFS= read -r -d "" __kv; do
           __name=''${__kv%%=*}
@@ -77,19 +58,8 @@ let
       '')
     ];
 
-  # Make jj usable inside the jail. We deliberately do NOT bind the user's
-  # ~/.config/jj: it commonly enables SSH commit signing, which can't work in the
-  # jail (no ssh-keygen, and the signing key lives in ~/.ssh which we block on
-  # purpose). Instead we inject just the identity via JJ_USER/JJ_EMAIL (read from
-  # the host config) — jailed commits are unsigned; you sign on review/merge.
-  # We also force JJ_EDITOR=echo so editor-driven commands (squash/split/describe)
-  # don't hang on a missing interactive editor in the jail.
-  #
-  # When $PWD is in a jj repo we also auto-bind the workspace root, the shared
-  # repo store (resolved from the .jj/repo pointer), and the colocated .git, all
-  # rw at their real paths. This lets several agents work the same repo in
-  # separate jj workspaces; each jail sees only its own workspace's working tree
-  # plus the shared history. No-op outside a jj repo.
+  # Inject JJ identity without mounting ~/.config/jj or SSH signing keys. Bind the
+  # current workspace and shared repository store so parallel workspaces function.
   jjWorkspace =
     c: with c; [
       (add-runtime ''
@@ -97,10 +67,7 @@ let
         __jjemail=$(${jjBin} config get user.email 2>/dev/null) || __jjemail=""
         [ -n "$__jjuser" ] && RUNTIME_ARGS+=(--setenv JJ_USER "$__jjuser")
         [ -n "$__jjemail" ] && RUNTIME_ARGS+=(--setenv JJ_EMAIL "$__jjemail")
-        # Editor-driven jj commands (squash/split/describe with no -m, etc.) would
-        # block on an interactive editor in the jail; point JJ_EDITOR at a no-op so
-        # they fall back to the existing description instead of hanging. This is
-        # appended after forwardHostEnv, so it wins over any inherited JJ_EDITOR.
+        # Avoid blocking on an unavailable interactive editor.
         RUNTIME_ARGS+=(--setenv JJ_EDITOR echo)
         __ws="$PWD"
         while [ "$__ws" != "/" ] && [ ! -e "$__ws/.jj" ]; do __ws=$(${cu}/dirname "$__ws"); done
@@ -143,9 +110,7 @@ let
     ++ forwardHostEnv c
     ++ jjWorkspace c;
 
-  # Build the permission list for an agent spec: shared baseline + the agent's
-  # own read-write config paths (~ expands at runtime) + any extra combinators
-  # (e.g. forwarded API-key env vars).
+  # Combine shared permissions with agent-specific config paths and extras.
   permsFor =
     spec: c:
     common c
@@ -155,8 +120,7 @@ let
   # name -> { pkg; paths?; extra?; }
   agents = {
     claude = {
-      # github:sadjow/claude-code-nix, defaulted to YOLO mode — safe because the
-      # jail is the boundary. User args are still passed through.
+      # The jail is the permission boundary, so Claude runs without its own prompts.
       pkg = pkgs.writeShellScriptBin "claude" ''
         exec ${
           pkgs.lib.getExe inputs.claude-code.packages.${system}.default
@@ -169,7 +133,7 @@ let
       extra = c: [ (c.try-fwd-env "ANTHROPIC_API_KEY") ];
     };
     codex = {
-      # github:numtide/llm-agents.nix, defaulted to YOLO mode (jail is the boundary).
+      # The jail is the permission boundary, so Codex bypasses its sandbox.
       pkg = pkgs.writeShellScriptBin "codex" ''
         exec ${pkgs.lib.getExe llm.codex} --dangerously-bypass-approvals-and-sandbox "$@"
       '';
@@ -185,27 +149,13 @@ let
         "~/.agents"
         "~/.pi"
       ];
-      # agent-browser is installed unjailed via the pi profile, but it lives on the
-      # host's home-manager PATH (e.g. /etc/profiles/per-user/.../bin) which isn't
-      # bound in the jail, so `agent-browser` isn't found inside jailed-pi. Re-add
-      # its store bin to the in-jail PATH at runtime. This add-runtime is appended
-      # AFTER forwardHostEnv's PATH setenv (extra runs after common), so it wins; we
-      # re-include devToolsPath so the curated dev tools stay on PATH. The bundled
-      # Chromium is invoked by absolute path (wrapper env) via the ro /nix/store
-      # mount — though launching it under bubblewrap may need extra sandbox perms.
       extra = c: [
-        # Node's os.tmpdir() respects TMPDIR. Pi keeps truncated command output
-        # there for later inspection, so use the disk-backed ~/.pi mount instead
-        # of the host's small tmpfs root. The Pi profile ages these files out.
+        # Store Pi's inspectable temporary output on disk instead of tmpfs.
         (c.add-runtime ''
           ${cu}/install -d -m 0700 "$HOME/.pi/tmp"
           RUNTIME_ARGS+=(--setenv TMPDIR "$HOME/.pi/tmp")
         '')
-        (c.add-runtime ''RUNTIME_ARGS+=(--setenv PATH "${llm.agent-browser}/bin:${devToolsPath}:$PATH")'')
-        # pi-web-access's web_search uses Exa. The jail can't read /run/agenix, but
-        # this wrapper runs on the HOST before bwrap — so read the exa-api-key
-        # agenix secret here and inject it as EXA_API_KEY (env overrides the
-        # ~/.pi/web-search.json provider config). Best-effort: only if present.
+        # Inject the host's agenix-managed Exa key when available.
         (c.add-runtime ''
           if [ -r /run/agenix/exa-api-key ]; then
             RUNTIME_ARGS+=(--setenv EXA_API_KEY "$(${cu}/cat /run/agenix/exa-api-key)")
@@ -220,9 +170,7 @@ let
   ) agents;
   wrappers = pkgs.lib.attrValues wrappersByName;
 
-  # Derive the launcher's `new <agent>` dispatch from wrappersByName so adding an
-  # agent to `agents` above auto-extends the launcher — no hardcoded claude|codex|
-  # pi arms to drift out of sync. agentNames feeds the usage/error messages.
+  # Generate launcher dispatch from the configured agents.
   agentNames = pkgs.lib.concatStringsSep "|" (builtins.attrNames agents);
   agentArms = pkgs.lib.concatStringsSep "\n" (
     pkgs.lib.mapAttrsToList (
@@ -230,16 +178,7 @@ let
     ) wrappersByName
   );
 
-  # Manage per-feature jj workspaces for jailed agents. Subcommands:
-  #   jailed-agent-ws new <agent> <feature> [agent args...]   (agent ∈ agents)
-  #       create (or reuse) a sibling workspace <repo>-<feature>, activate its
-  #       own devenv via direnv (built on the host), then launch the jailed agent
-  #   jailed-agent-ws rm <feature> [--force]
-  #       forget the workspace and delete its dir. Refuses if the workspace head
-  #       isn't reachable from a bookmark or a remote bookmark (i.e. unsaved
-  #       work), unless --force. Commits stay in the op log regardless.
-  #   jailed-agent-ws ls
-  #       list workspaces and their on-disk dirs
+  # Create, list, and safely remove per-feature JJ workspaces for jailed agents.
   launcher = pkgs.writeShellApplication {
     name = "jailed-agent-ws";
     runtimeInputs = with pkgs; [
@@ -249,8 +188,7 @@ let
       gnugrep
     ];
     text = ''
-            # Resolve the MAIN repo root so subcommands work from any workspace (a
-            # workspace's .jj/repo is a pointer file to <main>/.jj/repo).
+            # Resolve the main repository from any workspace.
             mainroot() {
               local root ptr store
               root=$(jj workspace root 2>/dev/null) || return 1
@@ -284,8 +222,7 @@ let
                   jj workspace add --name "$name" "$ws"
                 fi
                 cd "$ws" || exit 1
-                # Activate the workspace's own devenv (builds on the host, where nix
-                # works) then jail; the agent forwards the resulting env minus secrets.
+                # Activate devenv on the host before entering the jail.
                 if [ -f .envrc ]; then
                   direnv allow . || true
                   exec direnv exec "$PWD" "$bin" "$@"
@@ -322,10 +259,7 @@ let
                   exit 1
                 fi
                 if [ "$force" -ne 1 ]; then
-                  # commits unique to this workspace's head that aren't reachable from
-                  # any (local or remote) bookmark — i.e. work that only lives here.
-                  # Fail CLOSED: if jj log errors (locked repo, bad head, …) we must not
-                  # fall through to rm -rf and lose the working copy. --force overrides.
+                  # Fail closed if unique, unbookmarked commits cannot be checked.
                   if ! unsaved=$(jj log --no-graph --ignore-working-copy \
                     -r "(::$name@ ~ ::(bookmarks() | remote_bookmarks())) ~ empty()" \
                     -T '"x"' 2>/dev/null); then

--- a/users/profiles/jailed-agents.nix
+++ b/users/profiles/jailed-agents.nix
@@ -1,13 +1,6 @@
-# Jailed AI coding agents: claude/codex/pi wrapped in bubblewrap (jail.nix) so
-# they only see the CWD, their own config dir, the network, the (read-only) Nix
-# store, and a curated dev toolset — not SSH keys, cloud creds, or the rest of
-# $HOME. The caller's environment + PATH are forwarded (minus secret-looking
-# vars) so the agent inherits an active devenv shell. Adds parallel `jailed-*`
-# commands alongside the unjailed ones, plus `jailed-agent-ws` to launch an
-# agent in a per-feature jj workspace.
-#
-# The sandbox permission set lives in ./jailed-agents-builders.nix (shared with
-# the NixOS tests tests/jail-leak-audit.nix and tests/jail-jj-workspace.nix).
+# Install bubblewrap-wrapped Claude, Codex, and Pi commands plus the JJ workspace
+# launcher. Shared permissions and test-visible definitions live in
+# jailed-agents-builders.nix.
 { pkgs, inputs, ... }:
 let
   agents = import ./jailed-agents-builders.nix { inherit pkgs inputs; };

--- a/users/profiles/pi/AGENTS.md
+++ b/users/profiles/pi/AGENTS.md
@@ -22,6 +22,3 @@ These rules apply to commands shown to the user, not to Pi's internal `bash` too
 ## Web access
 
 For reading or searching the web, prefer **pi-web-access** (`web_search`, `fetch_content`) — pure HTTP, works inside the jail.
-
-`agent-browser` is also installed for interactive browser automation. Its Chrome is Nix-provided, so ignore `agent-browser doctor`'s "No Chrome binary found" warning and **never run `agent-browser install`**; downloaded Chrome builds cannot run on NixOS. Browsing works unjailed, but in jailed Pi it can fail with "CDP response channel closed" — use pi-web-access there.
-

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -1,19 +1,5 @@
-# Pi coding agent (https://pi.dev, from inputs.llm-agents) as an extensible,
-# first-class harness profile. Installs the plain `pi` command alongside the
-# existing `jailed-pi` wrapper (jailed-agents-builders.nix).
-#
-# Layout under ~/.pi/agent/ (paths in settings.json resolve relative to it):
-#   settings.json - generated from Nix; installed as a WRITABLE copy because Pi
-#                   appends a cosmetic `lastChangelogVersion` at runtime
-#                   (re-copied on each switch, so Nix stays authoritative).
-#   mcp.json / models.json / AGENTS.md - Nix-managed read-only store symlinks
-#                   (Pi only reads them).
-#   skills/ extensions/ - self-authored, per-file symlinks (recursive) so the
-#                   dirs stay writable and coexist with third-party auto-installs.
-#   auth.json     - UNMANAGED: written 0600 by `pi /login`, persisted via
-#                   impermanence (profiles/state.nix). Never touched here.
-#   tmp/          - Pi/Node temporary files, kept off the tmpfs root and cleaned
-#                   after seven days by the user tmpfiles timer.
+# Pi coding-agent profile with declarative settings, packages, skills, extensions,
+# themes, and the disk-backed temporary directory used by Pi.
 {
   pkgs,
   inputs,
@@ -23,20 +9,11 @@
 }:
 let
   system = pkgs.stdenv.hostPlatform.system;
-  llm = inputs.llm-agents.packages.${system};
   piNode = import ./node-package.nix { inherit pkgs inputs; };
 
-  # Browser-automation CLI for agents (Vercel Labs). The llm-agents build bundles
-  # a Nix Chromium, so it works on NixOS with no Chrome download / nix-ld.
-  inherit (llm) agent-browser;
-
-  # ---- Declarative extensibility knobs --------------------------------------
-  # THIRD-PARTY packages Pi auto-installs (settings.packages):
+  # Packages installed by Pi through settings.packages.
   thirdPartyPackages =
-    # remote-pi imports @napi-rs/keyring during extension loading. Install its
-    # platform binding directly so npm's optional-dependency bug cannot omit it
-    # during an incremental remote-pi update. Keep this version aligned with
-    # the @napi-rs/keyring version required by remote-pi.
+    # Work around npm omitting remote-pi's optional native keyring dependency.
     lib.optionals (system == "x86_64-linux") [
       {
         source = "npm:@napi-rs/keyring-linux-x64-gnu@1.3.0";
@@ -51,28 +28,20 @@ let
       "npm:@juicesharp/rpiv-ask-user-question@2.1.0"
       "npm:@juicesharp/rpiv-todo@2.1.0"
       "npm:@plannotator/pi-extension@0.24.2"
-      "npm:pi-hashline-readmap@0.11.1"
+      "npm:pi-hashline-edit@0.8.3"
       "npm:pi-web-access@0.14.0"
       "npm:remote-pi@0.5.5"
     ];
 
-  # Extra SKILL dirs beyond the auto-discovered ~/.pi/agent/skills + ~/.agents/skills:
-  extraSkillDirs = [
-    # Official agent-browser skill, shipped inside the package and version-matched
-    # to the CLI. A discovery stub that loads real workflows on demand via
-    # `agent-browser skills get core`.
-    "${agent-browser}/share/agent-browser/skills"
-    # "~/.claude/skills"   # reuse Claude Code skills, if wanted
-  ];
+  extraSkillDirs = [ ];
 
-  # Local extension FS paths outside the auto-discovered dir (rarely needed):
   localExtensionPaths = [ ];
 
   themeName = "catppuccin-frappe";
   settings = {
     defaultProvider = "openai-codex";
     defaultModel = "gpt-5.6-sol";
-    defaultThinkingLevel = "xhigh";
+    defaultThinkingLevel = "medium";
     enableInstallTelemetry = false;
     enableSkillCommands = true;
     extensions = localExtensionPaths;
@@ -106,9 +75,7 @@ let
     mcpServers = { };
   };
 
-  # Custom providers/models. llama-swap exposes an OpenAI-compatible API over
-  # Tailscale HTTPS; Qwen models use llama.cpp's Qwen chat-template thinking
-  # control, which Pi enables via compat.thinkingFormat = "qwen-chat-template".
+  # llama-swap exposes Qwen models through an OpenAI-compatible Tailscale endpoint.
   models = {
     providers = {
       "margot" = {
@@ -160,7 +127,7 @@ let
 
   webSearch = {
     provider = "exa";
-    allowBrowserCookies = false; # keep it pure-HTTP; never spawn Chromium
+    allowBrowserCookies = false;
     workflow = "none";
   };
 
@@ -196,19 +163,14 @@ let
   };
 in
 {
-  home.packages = [
-    piWithExa
-    agent-browser
-  ];
+  home.packages = [ piWithExa ];
 
-  # Pi preserves truncated command output in TMPDIR so it can show the full-output
-  # path in the transcript. Keep it on the persistent disk rather than the 16 GiB
-  # tmpfs root, then age it out automatically.
+  # Keep Pi's inspectable temporary output off the tmpfs root and expire it.
   systemd.user.tmpfiles.rules = [
     "d %h/.pi/tmp 0700 - - 7d"
   ];
 
-  # Self-authored skills & extensions (per-file symlinks; parent dirs writable).
+  # Keep these directories writable alongside third-party installations.
   home.file.".pi/agent/skills" = {
     source = ./skills;
     recursive = true;
@@ -219,15 +181,14 @@ in
     recursive = true;
   };
 
-  # Read-only Nix-managed config (Pi only reads these).
+  # Read-only Nix-managed configuration.
   home.file.".pi/agent/AGENTS.md".source = ./AGENTS.md;
   home.file.".pi/agent/mcp.json".text = builtins.toJSON mcp;
   home.file.".pi/agent/models.json".text = builtins.toJSON models;
   home.file.".pi/web-search.json".text = builtins.toJSON webSearch;
   home.file.".pi/agent/themes/${themeName}.json".source = ./themes/${themeName}.json;
 
-  # settings.json must be WRITABLE (Pi appends lastChangelogVersion). Install a
-  # real copy from the generated store file; re-copied each switch so Nix wins.
+  # Pi writes lastChangelogVersion, so install a writable settings copy.
   home.activation.piSettings = lib.hm.dag.entryAfter [ "writeBoundary" ] ''
     run install -D -m0644 ${settingsJson} "${config.home.homeDirectory}/.pi/agent/settings.json"
   '';


### PR DESCRIPTION
## Summary

- remove agent-browser from the Pi package and skill configuration
- remove its jailed PATH wiring, documentation, and generated-file ignore
- include the Pi defaults, jailed toolset, and comment cleanups from the working change

## Validation

- `statix check .`
- `nix run nixpkgs#deadnix -- -f flake.nix users/profiles/git.nix users/profiles/pi/default.nix users/profiles/jailed-agents-builders.nix users/profiles/jailed-agents.nix`
- `nix eval path:.#nixosConfigurations.amelia.config.system.build.toplevel.drvPath --raw`