### PR TITLE
feat(desktop): update compositor shortcuts and enable Vesktop

### DIFF
--- a/users/profiles/niri.nix
+++ b/users/profiles/niri.nix
@@ -28,10 +28,16 @@ let
     runtimeInputs = [
       pkgs.slurp
       pkgs.grim
+      pkgs.wl-clipboard
     ];
     text = ''
-      mkdir -p ~/Pictures/screenshots
-      slurp | grim -g - ~/Pictures/screenshots/"$(date +'%Y-%m-%dT%H%M%S.png')"
+      selection="$(slurp)"
+      if [ "$#" -gt 0 ] && [ "$1" = "--clipboard" ]; then
+        grim -g "$selection" - | wl-copy --type image/png
+      else
+        mkdir -p "$HOME/Pictures/screenshots"
+        grim -g "$selection" "$HOME/Pictures/screenshots/$(date +'%Y-%m-%dT%H%M%S.png')"
+      fi
     '';
   };
 
@@ -196,6 +202,11 @@ in
           "start"
           "--always-new-process"
         ];
+        "Mod+Shift+S".action.spawn = [
+          "${screenshot}/bin/screenshot"
+          "--clipboard"
+        ];
+        "Mod+Ctrl+S".action.spawn = "${screenshot}/bin/screenshot";
 
         "XF86AudioRaiseVolume" = {
           allow-when-locked = true;
@@ -245,37 +256,23 @@ in
 
         "Mod+Shift+Q".action.close-window = [ ];
 
-        "Mod+Left".action.focus-column-left = [ ];
-        "Mod+Down".action.focus-window-or-workspace-down = [ ];
-        "Mod+Up".action.focus-window-or-workspace-up = [ ];
-        "Mod+Right".action.focus-column-right = [ ];
         "Mod+H".action.focus-column-left = [ ];
         "Mod+J".action.focus-window-down = [ ];
         "Mod+K".action.focus-window-up = [ ];
         "Mod+L".action.focus-column-right = [ ];
 
-        "Mod+Ctrl+Left".action.move-column-left = [ ];
-        "Mod+Ctrl+Down".action.move-window-down = [ ];
-        "Mod+Ctrl+Up".action.move-window-up = [ ];
-        "Mod+Ctrl+Right".action.move-column-right = [ ];
         "Mod+Ctrl+H".action.move-column-left = [ ];
         "Mod+Ctrl+J".action.move-window-down = [ ];
         "Mod+Ctrl+K".action.move-window-up = [ ];
         "Mod+Ctrl+L".action.move-column-right = [ ];
 
-        "Mod+Page_Down".action.focus-workspace-down = [ ];
-        "Mod+Page_Up".action.focus-workspace-up = [ ];
-        "Mod+U".action.focus-workspace-down = [ ];
-        "Mod+I".action.focus-workspace-up = [ ];
-        "Mod+Ctrl+Page_Down".action.move-column-to-workspace-down = [ ];
-        "Mod+Ctrl+Page_Up".action.move-column-to-workspace-up = [ ];
-        "Mod+Ctrl+U".action.move-column-to-workspace-down = [ ];
-        "Mod+Ctrl+I".action.move-column-to-workspace-up = [ ];
+        "Mod+I".action.focus-workspace-down = [ ];
+        "Mod+U".action.focus-workspace-up = [ ];
+        "Mod+Ctrl+I".action.move-column-to-workspace-down = [ ];
+        "Mod+Ctrl+U".action.move-column-to-workspace-up = [ ];
 
-        "Mod+Shift+Page_Down".action.move-workspace-down = [ ];
-        "Mod+Shift+Page_Up".action.move-workspace-up = [ ];
-        "Mod+Shift+U".action.move-workspace-down = [ ];
-        "Mod+Shift+I".action.move-workspace-up = [ ];
+        "Mod+Shift+J".action.move-workspace-down = [ ];
+        "Mod+Shift+K".action.move-workspace-up = [ ];
         "Mod+Space".action.swap-window-left = [ ];
         "Mod+Shift+Space".action.swap-window-right = [ ];
 
@@ -297,30 +294,28 @@ in
           cooldown-ms = 150;
         };
 
-        MouseForward.action.toggle-overview = [ ];
+        "Mod+ParenLeft".action.focus-workspace = 1;
+        "Mod+ParenRight".action.focus-workspace = 2;
+        "Mod+BraceRight".action.focus-workspace = 3;
+        "Mod+Plus".action.focus-workspace = 4;
+        "Mod+BraceLeft".action.focus-workspace = 5;
+        "Mod+BracketRight".action.focus-workspace = 6;
+        "Mod+BracketLeft".action.focus-workspace = 7;
+        "Mod+Exclam".action.focus-workspace = 8;
+        "Mod+Equal".action.focus-workspace = 9;
 
-        "Mod+1".action.focus-workspace = 1;
-        "Mod+2".action.focus-workspace = 2;
-        "Mod+3".action.focus-workspace = 3;
-        "Mod+4".action.focus-workspace = 4;
-        "Mod+5".action.focus-workspace = 5;
-        "Mod+6".action.focus-workspace = 6;
-        "Mod+7".action.focus-workspace = 7;
-        "Mod+8".action.focus-workspace = 8;
-        "Mod+9".action.focus-workspace = 9;
+        "Mod+Shift+1".action.move-column-to-workspace = 1;
+        "Mod+Shift+2".action.move-column-to-workspace = 2;
+        "Mod+Shift+3".action.move-column-to-workspace = 3;
+        "Mod+Shift+4".action.move-column-to-workspace = 4;
+        "Mod+Shift+5".action.move-column-to-workspace = 5;
+        "Mod+Shift+6".action.move-column-to-workspace = 6;
+        "Mod+Shift+7".action.move-column-to-workspace = 7;
+        "Mod+Shift+8".action.move-column-to-workspace = 8;
+        "Mod+Shift+9".action.move-column-to-workspace = 9;
 
-        "Mod+Ctrl+1".action.move-column-to-workspace = 1;
-        "Mod+Ctrl+2".action.move-column-to-workspace = 2;
-        "Mod+Ctrl+3".action.move-column-to-workspace = 3;
-        "Mod+Ctrl+4".action.move-column-to-workspace = 4;
-        "Mod+Ctrl+5".action.move-column-to-workspace = 5;
-        "Mod+Ctrl+6".action.move-column-to-workspace = 6;
-        "Mod+Ctrl+7".action.move-column-to-workspace = 7;
-        "Mod+Ctrl+8".action.move-column-to-workspace = 8;
-        "Mod+Ctrl+9".action.move-column-to-workspace = 9;
-
-        "Mod+BracketLeft".action.consume-or-expel-window-left = [ ];
-        "Mod+BracketRight".action.consume-or-expel-window-right = [ ];
+        "Mod+Ctrl+BracketLeft".action.consume-or-expel-window-left = [ ];
+        "Mod+Ctrl+BracketRight".action.consume-or-expel-window-right = [ ];
 
         "Mod+Comma".action.consume-window-into-column = [ ];
         "Mod+Period".action.expel-window-from-column = [ ];

--- a/users/profiles/sway.nix
+++ b/users/profiles/sway.nix
@@ -28,10 +28,16 @@ let
     runtimeInputs = [
       pkgs.slurp
       pkgs.grim
+      pkgs.wl-clipboard
     ];
     text = ''
-      mkdir -p ~/Pictures/screenshots
-      slurp | grim -g - ~/Pictures/screenshots/"$(date +'%Y-%m-%dT%H%M%S.png')"
+      selection="$(slurp)"
+      if [ "$#" -gt 0 ] && [ "$1" = "--clipboard" ]; then
+        grim -g "$selection" - | wl-copy --type image/png
+      else
+        mkdir -p "$HOME/Pictures/screenshots"
+        grim -g "$selection" "$HOME/Pictures/screenshots/$(date +'%Y-%m-%dT%H%M%S.png')"
+      fi
     '';
   };
 

--- a/users/profiles/vesktop.nix
+++ b/users/profiles/vesktop.nix
@@ -1,0 +1,3 @@
+{
+  programs.vesktop.enable = true;
+}

--- a/users/profiles/workstation.nix
+++ b/users/profiles/workstation.nix
@@ -19,6 +19,7 @@ in
     ./niri.nix
     ./obs.nix
     ./sway.nix
+    ./vesktop.nix
   ];
 
   home.packages = with pkgs; [


### PR DESCRIPTION
## Summary

- add clipboard-aware screenshot commands for Niri and Sway
- revise Niri navigation and workspace shortcuts
- enable Vesktop in workstation profiles

## Validation

- `statix check .`
- `nix-instantiate --parse` for all changed Nix files
- `nix run nixpkgs#deadnix -- -f .` *(reports existing unused declarations outside these changes)*