### PR TITLE
feat(pi): adopt subagents extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ yubikey-identity.txt
 !/secrets/**/*.age
 !/secrets/**/*.pub
 !/secrets/allowed_signers
+node_modules/

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -10,6 +10,7 @@
 let
   system = pkgs.stdenv.hostPlatform.system;
   piNode = import ./node-package.nix { inherit pkgs inputs; };
+  piPackageDir = "${piNode}/lib/node_modules/@earendil-works/pi-coding-agent";
 
   # Packages installed by Pi through settings.packages.
   thirdPartyPackages =
@@ -150,6 +151,51 @@ let
     workflow = "none";
   };
 
+  subagentsExtension = pkgs.buildNpmPackage {
+    pname = "pi-subagents-extension";
+    version = "0-unstable";
+    src = ./extensions/subagents;
+    npmDepsHash = "sha256-X0fJ3rmZUPuXjzrHjfAML4xph/IoHH1svavMJ7YCgVI=";
+
+    buildPhase = ''
+      runHook preBuild
+
+      test -d ${piPackageDir}/node_modules/@earendil-works/pi-ai
+      test -d ${piPackageDir}/node_modules/@earendil-works/pi-tui
+      test -d ${piPackageDir}/node_modules/typebox
+      mkdir -p node_modules/@earendil-works
+      ln -s ${piPackageDir} node_modules/@earendil-works/pi-coding-agent
+      ln -s ${piPackageDir}/node_modules/@earendil-works/pi-ai \
+        node_modules/@earendil-works/pi-ai
+      ln -s ${piPackageDir}/node_modules/@earendil-works/pi-tui \
+        node_modules/@earendil-works/pi-tui
+      ln -s ${piPackageDir}/node_modules/typebox node_modules/typebox
+
+      npm run check
+      npm test
+
+      runHook postBuild
+    '';
+
+    installPhase = ''
+      runHook preInstall
+
+      npm prune --omit=dev --ignore-scripts --offline
+      rm -rf \
+        node_modules/@earendil-works \
+        node_modules/typebox \
+        docs \
+        *.test.ts \
+        package-lock.json \
+        tsconfig.json \
+        src/backends/stub.ts
+      mkdir -p $out
+      cp -r index.ts package.json src node_modules $out/
+
+      runHook postInstall
+    '';
+  };
+
   acornVendor =
     let
       src = pkgs.fetchurl {
@@ -166,6 +212,7 @@ let
   piExtensions = pkgs.runCommand "pi-extensions" { } ''
     cp -r ${./extensions}/. $out
     chmod -R u+w $out
+    rm -rf $out/subagents
     install -Dm444 ${acornVendor}/acorn.mjs $out/dynamic-workflows/vendor/acorn.mjs
     install -Dm444 ${acornVendor}/ACORN-LICENSE $out/dynamic-workflows/vendor/ACORN-LICENSE
   '';
@@ -199,6 +246,10 @@ in
     source = piExtensions;
     recursive = true;
   };
+
+  # Keep the dependency-heavy extension as one directory symlink instead of
+  # asking Home Manager to create a link for every file in node_modules.
+  home.file.".pi/agent/extensions/subagents".source = subagentsExtension;
 
   # Read-only Nix-managed configuration.
   home.file.".pi/agent/AGENTS.md".source = ./AGENTS.md;

--- a/users/profiles/pi/extensions/subagents/by-the-way.test.ts
+++ b/users/profiles/pi/extensions/subagents/by-the-way.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  BTW_TITLE_MAX_LENGTH,
+  deriveBtwTitle,
+  isModelVisible,
+} from "./src/by-the-way.ts";
+
+test("deriveBtwTitle uses the first non-empty line and bounds the title", () => {
+  assert.equal(
+    deriveBtwTitle("\n   Why   does this work?   \nignore me"),
+    "Why does this work?",
+  );
+  assert.equal(deriveBtwTitle(" \n\t"), "by the way");
+
+  const title = deriveBtwTitle("x".repeat(BTW_TITLE_MAX_LENGTH + 10));
+  assert.equal(title.length, BTW_TITLE_MAX_LENGTH);
+  assert.equal(title, `${"x".repeat(BTW_TITLE_MAX_LENGTH - 1)}…`);
+
+  const emojiTitle = deriveBtwTitle(
+    `${"x".repeat(BTW_TITLE_MAX_LENGTH - 2)}😀 more`,
+  );
+  assert.equal(emojiTitle, `${"x".repeat(BTW_TITLE_MAX_LENGTH - 2)}😀…`);
+});
+
+test("only model-origin snapshots are visible to model-facing tools", () => {
+  assert.equal(isModelVisible({ origin: "model" }), true);
+  assert.equal(isModelVisible({ origin: "btw" }), false);
+});

--- a/users/profiles/pi/extensions/subagents/claude.test.ts
+++ b/users/profiles/pi/extensions/subagents/claude.test.ts
@@ -1,0 +1,119 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Effect } from "effect";
+import { SubagentManager } from "./src/manager.ts";
+import { claudeBackend } from "./src/backends/claude.ts";
+import type { ParentContext, SpawnTask } from "./src/domain.ts";
+import { createSubagentRuntime, runTool } from "./src/runtime.ts";
+
+const parent: ParentContext = {
+  parentCwd: process.cwd(),
+  projectTrusted: false,
+};
+
+function task(prompt: string): SpawnTask {
+  return {
+    prompt,
+    title: "live Claude test",
+    cwd: process.cwd(),
+    model: "haiku",
+    reasoningEffort: "off",
+    parent,
+  };
+}
+
+async function claudeAvailable() {
+  return Effect.runPromise(claudeBackend.available);
+}
+
+/** Rejecting deadline so a hung wait still reaches finally() and disposes. */
+function deadline<A>(operation: Promise<A>, timeoutMs: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(
+      () => reject(new Error(`Live Claude test exceeded ${timeoutMs}ms`)),
+      timeoutMs,
+    );
+  });
+  return Promise.race([operation, timeout]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+test(
+  "Claude backend completes a live manager run",
+  { timeout: 60_000 },
+  async (t) => {
+    if (!(await claudeAvailable())) {
+      t.skip("Claude Code executable is unavailable");
+      return;
+    }
+
+    const runtime = createSubagentRuntime();
+    try {
+      const manager = await runtime.runPromise(SubagentManager);
+      const started = await runTool(
+        runtime,
+        manager.spawn("claude", task("Reply with exactly: hello claude")),
+      );
+      await deadline(runTool(runtime, manager.waitFor([started.id])), 45_000);
+
+      const done = manager.view.get(started.id);
+      assert.equal(done?.status, "done");
+      assert.match(done?.finalText ?? "", /hello claude/i);
+      assert.ok(done?.meta.nativeSessionId);
+      assert.ok(done?.meta.sessionFilePath?.endsWith(".jsonl"));
+    } finally {
+      await runtime.dispose();
+    }
+  },
+);
+
+test(
+  "Claude backend interrupt settles a live run as aborted",
+  { timeout: 60_000 },
+  async (t) => {
+    if (!(await claudeAvailable())) {
+      t.skip("Claude Code executable is unavailable");
+      return;
+    }
+
+    const runtime = createSubagentRuntime();
+    try {
+      const manager = await runtime.runPromise(SubagentManager);
+      const started = await runTool(
+        runtime,
+        manager.spawn(
+          "claude",
+          task(
+            "Write a detailed 10,000-word essay about the history of computing.",
+          ),
+        ),
+      );
+
+      // Wait for streamed output so cancellation definitely lands mid-run and
+      // exercises the SDK's normal interrupt receipt/result path.
+      const streamDeadline = Date.now() + 15_000;
+      while (
+        manager.view.get(started.id)?.status === "running" &&
+        !manager.view.get(started.id)?.liveAssistant?.text &&
+        Date.now() < streamDeadline
+      ) {
+        await new Promise((resolve) => setTimeout(resolve, 20));
+      }
+      assert.equal(manager.view.get(started.id)?.status, "running");
+      assert.ok(manager.view.get(started.id)?.liveAssistant?.text);
+
+      const report = await deadline(
+        runTool(runtime, manager.cancel([started.id])),
+        20_000,
+      );
+
+      assert.equal(report[0]?.cancelled, true);
+      assert.equal(manager.view.get(started.id)?.status, "error");
+      assert.equal(manager.view.get(started.id)?.errorText, "Run was aborted");
+    } finally {
+      await runtime.dispose();
+    }
+  },
+);

--- a/users/profiles/pi/extensions/subagents/context-usage.test.ts
+++ b/users/profiles/pi/extensions/subagents/context-usage.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { contextOccupancyTokens } from "./src/backends/claude.ts";
+
+// --- Claude: per-request occupancy, never the run aggregate ------------------
+
+test("Claude occupancy sums one request's input, cache, and output tokens", () => {
+  assert.equal(
+    contextOccupancyTokens({
+      input_tokens: 12,
+      cache_read_input_tokens: 45_000,
+      cache_creation_input_tokens: 3_000,
+      output_tokens: 700,
+    }),
+    48_712,
+  );
+});
+
+test("Claude occupancy treats null cache/output counts as zero", () => {
+  assert.equal(
+    contextOccupancyTokens({
+      input_tokens: 9_000,
+      cache_read_input_tokens: null,
+      cache_creation_input_tokens: null,
+      output_tokens: 250,
+    }),
+    9_250,
+  );
+});
+
+test("Claude occupancy is unknown without a usable per-request usage", () => {
+  assert.equal(contextOccupancyTokens(undefined), undefined);
+  assert.equal(contextOccupancyTokens(null), undefined);
+  assert.equal(
+    contextOccupancyTokens({ input_tokens: null, output_tokens: 5 }),
+    undefined,
+  );
+});
+
+test("Claude occupancy from the last request stays below the window where the run aggregate would not", () => {
+  // A 10-request tool loop over a mostly-cached 150k prompt: the aggregate
+  // usage (what SDKResultMessage.usage reports) re-counts the cache per
+  // request and blows past the 200k window; the final request's usage is the
+  // true occupancy.
+  const perRequest = {
+    input_tokens: 500,
+    cache_read_input_tokens: 150_000,
+    cache_creation_input_tokens: 0,
+    output_tokens: 400,
+  };
+  const aggregate = {
+    input_tokens: 500 * 10,
+    cache_read_input_tokens: 150_000 * 10,
+    cache_creation_input_tokens: 0,
+    output_tokens: 400 * 10,
+  };
+  const occupancy = contextOccupancyTokens(perRequest);
+  assert.ok(occupancy !== undefined && occupancy < 200_000);
+  const misleading = contextOccupancyTokens(aggregate);
+  assert.ok(misleading !== undefined && misleading > 200_000);
+});
+

--- a/users/profiles/pi/extensions/subagents/docs/effect-v4-extension-guide.md
+++ b/users/profiles/pi/extensions/subagents/docs/effect-v4-extension-guide.md
@@ -1,0 +1,354 @@
+# Building a pi extension on the Effect v4 setup
+
+> Practical, migration-oriented companion to [`effect-v4-notes.md`](./effect-v4-notes.md).
+> That file is the Effect API cheat-sheet (v3→v4 renames, child processes, concurrency);
+> **this** file is how to stand up _one pi extension_ on the same toolchain and where to
+> draw the line between "wrap in Effect" and "leave as plain TS".
+>
+> **Verified against** `effect@4.0.0-beta.98`, `@effect/platform-node@4.0.0-beta.98`,
+> `@effect/tsgo@0.19.0`, `typescript@7.0.2` (checked 2026-07-13, in `extensions/subagents`).
+> `npm run check` there passes clean — use it as the reference implementation.
+>
+> Audience: the agents migrating `firecrawl-search`, `ask-user`, `model-info`,
+> `git-info`, `ui-customization`, and `copy-all`.
+
+---
+
+## 0. The one rule: Effect is for the async core, not the whole file
+
+A pi extension's public surface is **plain callbacks** the host calls:
+`export default function (pi: ExtensionAPI)`, `pi.registerTool({ …, async execute() })`,
+`pi.registerCommand`, `pi.on(...)`, renderers. None of that changes. Effect lives _inside_
+those callbacks — you run an effect at the top of `execute` and return its value.
+
+Reach for Effect only where you actually get something from it:
+
+- **Yes:** async work that needs typed errors, cancellation via the tool `AbortSignal`,
+  timeouts, retries/polling, or a resource whose lifetime must outlive one call
+  (child process, subscription) → child processes (`git-info`, `copy-all`), the
+  Firecrawl SDK calls (`firecrawl-search`), git/gh polling (`git-info`).
+- **No / barely:** pure TUI popups and rendering (`ask-user`, `ui-customization`),
+  cross-extension channel plumbing, cost/token bookkeeping (`model-info`). These are
+  synchronous or already-Promise UI code; wrapping them in Effect adds ceremony and no
+  safety. Migrate them by keeping the logic and only touching whatever genuinely async
+  part benefits (usually nothing).
+
+If an extension has no async core worth typing, the "migration" may be just adopting the
+toolchain (§1) and leaving the body plain. Don't invent an Effect layer to have one.
+
+---
+
+## 1. Per-extension toolchain (copy this exactly)
+
+Each extension is its own npm package with its own `node_modules`. Replicate the pinned
+setup — do **not** float the versions.
+
+`package.json`:
+
+```jsonc
+{
+  "name": "<ext>",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit -p .",
+    "prepare": "effect-tsgo patch", // patches the Effect LS into the tsgo binary
+  },
+  "dependencies": {
+    "effect": "4.0.0-beta.98", // EXACT pin, no ^
+    "@effect/platform-node": "4.0.0-beta.98", // only if you touch fs / child processes
+  },
+  "devDependencies": {
+    "@effect/tsgo": "^0.19.0",
+    "typescript": "^7.0.2",
+  },
+}
+```
+
+`tsconfig.json` (extends the repo root, adds the Effect language-service plugin):
+
+```jsonc
+{
+  "extends": "../../tsconfig.json",
+  "compilerOptions": {
+    "plugins": [{ "name": "@effect/language-service" }],
+  },
+  "include": ["index.ts", "src/**/*.ts", "*.test.ts"],
+}
+```
+
+The root `tsconfig.json` already sets `strict`, `module`/`moduleResolution: NodeNext`,
+`verbatimModuleSyntax`, `allowImportingTsExtensions`, `target: ES2022`, `types: ["node"]`.
+Keep local `.ts` imports written **with the `.ts` extension** (`./src/manager.ts`), matching
+the house style.
+
+### The LSP / language-service, precisely
+
+- `typescript@7` is the **native (tsgo) TypeScript** — its `tsc` is a Go binary, and it's
+  what `npm run check` runs.
+- `@effect/language-service` is **not an installed npm package** here (you won't find it in
+  `node_modules`). It's delivered by `effect-tsgo patch`, run automatically by the `prepare`
+  lifecycle script on `npm install`. The patch injects the Effect Language Service into the
+  tsgo binary; the tsconfig `plugins` entry then turns on Effect-aware editor diagnostics and
+  quickfixes (e.g. "yield missing services", floating effects).
+- Practical sequence for a fresh/edited extension: `npm install` (runs the patch) →
+  `npm run check`. If editor diagnostics look stale, re-run `npx effect-tsgo patch`;
+  `npx effect-tsgo get-exe-path` prints the patched binary it resolved.
+- The plugin drives the _editor_; it does not change `tsc` exit codes. `npm run check` is
+  still your ground-truth green/red signal.
+
+---
+
+## 2. The async boundary: one `ManagedRuntime` + a `runTool` helper
+
+Every extension that uses Effect needs exactly this shape. Build **one** runtime lazily,
+dispose it on shutdown, and funnel every tool handler through a single helper that turns
+Effect exits into what pi expects (a value, or a thrown `Error`; interruption → a friendly
+message). This is lifted verbatim from `src/runtime.ts` — reuse it.
+
+```ts
+// src/runtime.ts
+import { Cause, Exit, Layer, ManagedRuntime, type Effect } from "effect";
+import { NodeServices } from "@effect/platform-node"; // only if you need fs / processes
+
+// Compose your services here (see §3). NodeServices.layer =
+// ChildProcessSpawner | FileSystem | Path | Crypto | Stdio | Terminal.
+const AppLayer = Layer.mergeAll(NodeServices.layer /*, MyServiceLive */);
+
+export function createRuntime() {
+  return ManagedRuntime.make(AppLayer);
+}
+export type ExtRuntime = ReturnType<typeof createRuntime>;
+
+/** Run an effect from an async handler: value on success, thrown Error otherwise. */
+export async function runTool<A, E>(
+  runtime: ExtRuntime,
+  effect: Effect.Effect<A, E>,
+  options: { signal?: AbortSignal; interruptMessage?: string } = {},
+) {
+  const exit = await runtime.runPromiseExit(
+    effect,
+    options.signal ? { signal: options.signal } : undefined,
+  );
+  if (Exit.isSuccess(exit)) return exit.value;
+  if (Cause.hasInterruptsOnly(exit.cause)) {
+    throw new Error(options.interruptMessage ?? "Operation was aborted.");
+  }
+  const [first] = Cause.prettyErrors(exit.cause);
+  throw new Error(first?.message ?? Cause.pretty(exit.cause));
+}
+```
+
+Wire it into the extension lifecycle (lazy build, dispose on shutdown):
+
+```ts
+// index.ts
+export default function (pi: ExtensionAPI) {
+  let runtime: ExtRuntime | undefined;
+  const getRuntime = () => (runtime ??= createRuntime());
+
+  pi.registerTool({
+    name: "my_tool",
+    parameters: Type.Object({/* typebox */}),
+    async execute(_id, params, signal) {
+      return await runTool(getRuntime(), myEffect(params), {
+        signal,
+        interruptMessage: "Cancelled.",
+      });
+    },
+  });
+
+  pi.on("session_shutdown", async () => {
+    const closing = runtime;
+    runtime = undefined;
+    await closing?.dispose(); // runs all finalizers: kills scoped child processes, etc.
+  });
+}
+```
+
+Key facts:
+
+- `runPromiseExit(effect, { signal })` — passing the tool's `AbortSignal` makes cancelling
+  the tool interrupt the fiber; scoped resources (child processes) are torn down.
+- `runtime.runFork(effect)` for fire-and-forget background work (polling loops, §5).
+- `dispose()` is the single teardown hook — put resource cleanup in Effect finalizers, not
+  in ad-hoc `session_shutdown` code.
+- If an extension has **no** services (pure `Effect.tryPromise` calls, no fs/process), you
+  can skip `NodeServices.layer` and even skip `ManagedRuntime` — `Effect.runPromiseExit(effect, { signal })`
+  works standalone. Add the runtime only when you have a `Layer` to share.
+
+---
+
+## 3. Services, layers, errors (house style)
+
+Mirror the subagents code. Class-style `Context.Service`, `Layer.effect`/`Layer.sync`,
+`Data.TaggedError` for domain errors.
+
+```ts
+import { Context, Data, Effect, Layer } from "effect";
+
+// Domain error — yieldable, tag-narrowable with Effect.catchTag:
+export class GitError extends Data.TaggedError("GitError")<{
+  readonly message: string;
+}> {}
+
+// Service: the class value is the key AND the type.
+export interface GitShape {
+  readonly status: Effect.Effect<string, GitError>;
+}
+export class Git extends Context.Service<Git, GitShape>()("gitinfo/Git") {}
+
+// Layer building it (Layer.effect can use scoped resources; Layer.sync for pure):
+export const GitLive: Layer.Layer<Git, never, ChildProcessSpawner> =
+  Layer.effect(
+    Git,
+    Effect.gen(function* () {
+      const spawner = yield* ChildProcessSpawner; // dependency, provided by NodeServices.layer
+      return Git.of({
+        status: spawner
+          .string(ChildProcess.make("git", ["status", "--porcelain"]))
+          .pipe(
+            Effect.mapError(
+              (cause) => new GitError({ message: String(cause) }),
+            ),
+          ),
+      });
+    }),
+  );
+```
+
+Provide dependencies with `Layer.provide`, compose with `Layer.mergeAll` (see §2 `AppLayer`).
+Full rename table (`Effect.fork`→`forkChild`, `catchAll`→`catch`, `Either`→`Result`, …) and
+the child-process / concurrency APIs live in `effect-v4-notes.md` — don't re-derive them.
+
+---
+
+## 4. Recipe: wrapping a Promise SDK (firecrawl-search)
+
+The Firecrawl client is Promise-based. Wrap each call in `Effect.tryPromise` with a typed
+error; the callback receives an `AbortSignal` tied to fiber interruption — forward it to any
+SDK that accepts one so tool cancellation propagates.
+
+```ts
+import { Data, Effect } from "effect";
+
+class FirecrawlError extends Data.TaggedError("FirecrawlError")<{
+  readonly cause: unknown;
+}> {}
+
+const search = (client: Firecrawl, query: string) =>
+  Effect.tryPromise({
+    try: (signal) => client.search(query, {/* …, signal? if supported */}),
+    catch: (cause) => new FirecrawlError({ cause }),
+  });
+```
+
+There's no `Layer` here unless you want the client as a service. For a single tool this is
+fine to call directly through `runTool` (or even plain `Effect.runPromiseExit`, §2). Keep the
+existing `.env`/API-key reading and result truncation as plain TS — no reason to Effect-ify
+string trimming.
+
+---
+
+## 5. Recipe: child processes + timeout + polling (git-info, copy-all)
+
+`git-info` shells out to `git`/`gh` with per-command timeouts and polls on an interval;
+`copy-all` pipes text into `pbcopy`. Two viable levels — pick the lightest that fits.
+
+**Simple, one-shot, small:** if all you do is "run a command, capture stdout, with a
+timeout," the Effect win is `Effect.timeout` + interruption killing the child. Use the
+spawner service:
+
+```ts
+import { Effect } from "effect";
+import { ChildProcess } from "effect/unstable/process";
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
+
+const gitStatus = Effect.gen(function* () {
+  const spawner = yield* ChildProcessSpawner;
+  return yield* spawner
+    .string(ChildProcess.make("git", ["status", "--porcelain"], { cwd }))
+    .pipe(Effect.timeout("3 seconds")); // fails with Cause.TimeoutError (tag "TimeoutError")
+});
+```
+
+Note the import gotcha: `ChildProcessSpawner` the **class** comes from the
+`.../ChildProcessSpawner` submodule; the `effect/unstable/process` index gives you the
+namespace. Provide `NodeServices.layer` (or `ChildProcessSpawner.layer`). Full command
+builder / streaming / kill semantics are in `effect-v4-notes.md §6`.
+
+**Polling on an interval:** replace `setInterval` with a forked, scheduled effect so it
+cancels cleanly on dispose:
+
+```ts
+import { Effect, Schedule } from "effect";
+
+const pollLoop = refresh.pipe(
+  Effect.catchCause(() => Effect.void), // don't let one failure kill the loop
+  Effect.repeat(Schedule.spaced("3 seconds")),
+);
+const fiber = runtime.runFork(pollLoop); // interrupted by runtime.dispose()
+```
+
+**When to stay plain:** `copy-all` spawning `pbcopy` is a trivial one-shot with no
+cancellation need — the existing `node:child_process` + Promise wrapper is honestly fine.
+Migrate it only for consistency; if you do, `Effect.callback` around `child.once("exit", …)`
+(see notes §4) is the minimal wrapper. Don't add a service/layer for a clipboard write.
+
+---
+
+## 6. Recipe: UI popups & rendering (ask-user, ui-customization, model-info)
+
+These are the "leave it mostly plain" cases.
+
+- `ask-user` is a TUI popup that resolves a Promise when the user picks. That Promise already
+  models the one async thing. Effect adds nothing; if you want uniformity, wrap the final
+  await in `Effect.tryPromise` at the boundary and stop there. Do **not** build a service.
+- `ui-customization` and `model-info` are renderers / event bookkeepers driven by
+  `pi.on(...)` and cross-extension channels (`shared/dashboard-state.ts`). Channels are a
+  pi-native mechanism — keep them. State counting and formatting stay synchronous TS.
+- If `model-info` has a periodic "live update" tick, the §5 polling pattern applies; but a
+  plain timer here is also acceptable since there's no resource to tear down.
+
+The migration bar for these: adopt the toolchain (§1) so they typecheck under TS7 + the
+Effect LS, and only touch runtime code that has a real async/resource concern.
+
+---
+
+## 7. Verify — scoped to the one extension
+
+Run everything from inside the extension directory so you never trigger a root/global build
+or format:
+
+```bash
+cd extensions/<ext>
+npm install        # first time / after dep or script edits — runs `prepare` (effect-tsgo patch)
+npm run check      # tsc --noEmit -p .  ← ground-truth green/red
+npm run test       # only if the extension defines tests; keep them minimal
+```
+
+`extensions/subagents` is the known-green reference: `npm run check` there exits 0 against
+the pinned versions. If a migrated extension fails `check` with `Effect.fork`/`ServiceMap`/
+`Either` errors, it's using stale v3/early-beta APIs — consult the rename table in
+`effect-v4-notes.md`.
+
+---
+
+## 8. Don'ts (keep it lean)
+
+1. **Don't float versions.** Pin `effect` and `@effect/platform-node` to the exact same
+   `4.0.0-beta.98`; `unstable/*` can break between betas.
+2. **Don't Effect-ify pure/UI code.** No service or layer for a clipboard write, a string
+   truncation, or a popup. §0 is the test: is there a typed-error / cancellation / resource /
+   retry concern? If not, leave it.
+3. **Don't guess APIs.** If it's not in this guide or `effect-v4-notes.md` and you haven't
+   grepped it in `node_modules/effect/dist/*.d.ts`, don't write it. Watch for hallucinated
+   `ServiceMap` (reverted to `Context`), `Effect.fork` (→ `forkChild`), `Effect.either`
+   (→ `Effect.result`).
+4. **Don't hand-roll teardown.** Put cleanup in Effect finalizers and let `runtime.dispose()`
+   in `session_shutdown` run them.
+5. **Don't over-test.** A `check` that passes plus one focused runtime test (where behavior
+   is non-obvious) beats a wall of defensive unit tests.
+6. **Don't run root scripts.** No repo-root `tsc`, `prettier`, or `npm run format`; stay
+inside `extensions/<ext>`.
+</content>

--- a/users/profiles/pi/extensions/subagents/docs/effect-v4-notes.md
+++ b/users/profiles/pi/extensions/subagents/docs/effect-v4-notes.md
@@ -1,0 +1,571 @@
+# Effect v4 — Practical Notes for the Subagents Extension
+
+> **Building a new pi extension on this stack?** Start with the migration-oriented
+> [`effect-v4-extension-guide.md`](./effect-v4-extension-guide.md) (toolchain setup, the
+> `ManagedRuntime` + `runTool` boundary, when *not* to use Effect, per-extension recipes).
+> This file is the deeper Effect API reference it points back to.
+
+> **Verified against:** `effect@4.0.0-beta.98` and `@effect/platform-node@4.0.0-beta.98`
+> (npm dist-tag `beta`, checked 2026-07-13). Every snippet in this doc was type-checked
+> with `tsc --strict` against these packages, and the process-spawning / runtime snippets
+> were executed with Node 24. v4 source lives in the **`Effect-TS/effect-smol`** repo
+> (not `Effect-TS/effect`); the official migration guide is
+> [`effect-smol/MIGRATION.md`](https://github.com/Effect-TS/effect-smol/blob/main/MIGRATION.md)
+> plus the `migration/*.md` files next to it (including a machine-readable
+> `migration/v3-to-v4.md` rename map).
+
+## Install
+
+```bash
+npm install effect@beta @effect/platform-node@beta
+```
+
+Big structural facts:
+
+- **One version number for everything.** All ecosystem packages release together at
+  `4.0.0-beta.N`. `@effect/platform-node` must match `effect` exactly.
+- **`@effect/platform` is gone — merged into core `effect`.** `FileSystem`, `Path`,
+  `PlatformError`, `Terminal`, `Stdio` are now top-level `effect` modules.
+  `@effect/platform-node` remains as the Node *implementation* package.
+- **`effect/unstable/*` namespace.** Modules that may break in minor releases:
+  `effect/unstable/process` (child processes — the one we need), `http`, `rpc`, `cli`,
+  `ai`, `workers`, etc. Everything outside `unstable/` follows strict semver.
+- **`"type": "module"`**, ESM-first. Works with `moduleResolution: NodeNext` or `Bundler`.
+- Runtime keep-alive is built in now: a fiber suspended on `Deferred.await` etc. keeps
+  the Node process alive without `NodeRuntime.runMain` (v3 needed runMain for that).
+
+## Cheat sheet: v3 → v4 renames you will actually hit
+
+| v3 | v4 |
+| --- | --- |
+| `Context.Tag` / `Effect.Service` | `Context.Service` (`Effect.Service` is **gone**) |
+| `Effect.fork` | `Effect.forkChild` |
+| `Effect.forkDaemon` | `Effect.forkDetach` |
+| `Effect.async` | `Effect.callback` |
+| `Effect.catchAll` | `Effect.catch` |
+| `Effect.catchAllCause` / `catchAllDefect` | `Effect.catchCause` / `catchDefect` |
+| `Effect.zipRight` / `zipLeft` | `Effect.andThen` / `Effect.tap` |
+| `Effect.either` | `Effect.result` |
+| `Either` module | `Result` (`Result.succeed` / `Result.fail`) |
+| `Layer.scoped` | `Layer.effect` (all layers are scoped-capable now) |
+| `Mailbox` | `Queue` (Queue absorbed Mailbox: done/fail signalling built in) |
+| `FiberRef` | `Context.Reference` (module `effect/References`) |
+| `Scope.extend` | `Scope.provide` |
+| `Stream.async*` (all 4 variants) | `Stream.callback` |
+| `Stream.fromChunk(s)` | `Stream.fromArray` / `Stream.fromArrays` (Chunk de-emphasized; arrays used) |
+| `Schema.TaggedError` | `Schema.TaggedErrorClass` |
+| `@effect/platform/Command` | `effect/unstable/process` → `ChildProcess` |
+| `@effect/platform/CommandExecutor` | `effect/unstable/process` → `ChildProcessSpawner` |
+| `@effect/platform/FileSystem` | `effect/FileSystem` |
+| `Runtime.runPromise(runtime)(...)` | gone — use `ManagedRuntime` methods directly |
+| `UnknownException` (tryPromise default) | `Cause.UnknownError` |
+
+Removed with no replacement: `Effect.forkAll`, `Effect.forkWithErrorHandler`.
+Early v4 betas renamed `Context` → `ServiceMap`; **that was reverted** — beta.98 uses
+`Context` again (ignore older blog posts/AI answers mentioning `ServiceMap`).
+
+---
+
+## 1. Basics: `Effect.gen`, running, the Promise boundary
+
+Unchanged in spirit from v3. `Effect<A, E, R>` = success `A`, typed error `E`,
+required services `R`.
+
+```ts
+import { Effect, Exit } from "effect"
+
+const double = (n: number) => Effect.succeed(n * 2)
+
+const program = Effect.gen(function* () {
+  const a = yield* Effect.succeed(1)
+  const b = yield* double(a)
+  yield* Effect.log(`result: ${b}`)
+  return b
+})
+
+// Entry-point conversion — only at the outermost layer (tool handlers):
+const p: Promise<number> = Effect.runPromise(program)          // rejects on failure/defect
+const pe: Promise<Exit.Exit<number, never>> = Effect.runPromiseExit(program) // never rejects
+const s: number = Effect.runSync(program)                       // throws if async
+const fiber = Effect.runFork(program)                           // fire-and-forget fiber
+```
+
+`runPromise` only accepts `Effect<A, E, never>` — all services must be provided first
+(or use a `ManagedRuntime`, §8). `runPromiseExit` is the right choice inside tool
+handlers when you want to convert failures to structured results instead of throws.
+
+`Effect.fn` gives you named, traced effect functions (nice stack traces):
+
+```ts
+const spawnJob = Effect.fn("spawnJob")(function* (name: string) {
+  yield* Effect.log(`spawning ${name}`)
+  return name
+})
+// spawnJob("x") : Effect<string>
+```
+
+## 2. Services & Layers
+
+`Context.Tag` and the v3 `Effect.Service` helper class are **both gone**. The single
+API is `Context.Service`, in two forms:
+
+```ts
+import { Context, Effect, Layer } from "effect"
+
+// Class-style (recommended — class value doubles as the key):
+class Clock extends Context.Service<Clock, {
+  readonly now: Effect.Effect<number>
+}>()("app/Clock") {}
+
+// Function-style key:
+const Random = Context.Service<{ next: Effect.Effect<number> }>("app/Random")
+
+// Yielding the key retrieves the service (keys are Effects):
+const use = Effect.gen(function* () {
+  const clock = yield* Clock
+  return yield* clock.now
+})
+```
+
+Layers work like v3 (`Layer.scoped` merged into `Layer.effect` — every `Layer.effect`
+build can use scoped resources):
+
+```ts
+const ClockLive = Layer.succeed(Clock, { now: Effect.sync(() => Date.now()) })
+
+const RandomLive = Layer.effect(
+  Random,
+  Effect.gen(function* () {
+    yield* Effect.log("building Random")
+    return { next: Effect.sync(() => Math.random()) }
+  })
+)
+
+// Dependencies between layers:
+class Ids extends Context.Service<Ids, { readonly nextId: Effect.Effect<string> }>()("app/Ids") {}
+
+const IdsLive = Layer.effect(
+  Ids,
+  Effect.gen(function* () {
+    const random = yield* Random
+    return Ids.of({ nextId: Effect.map(random.next, (n) => `id-${n}`) })
+  })
+)
+
+const AppLayer = Layer.mergeAll(ClockLive, IdsLive.pipe(Layer.provide(RandomLive)))
+
+const runnable = use.pipe(Effect.provide(AppLayer)) // R = never
+
+// One-off service injection without a layer:
+const withTestClock = use.pipe(Effect.provideService(Clock, { now: Effect.succeed(0) }))
+```
+
+Also useful:
+
+- `Context.Reference("key", { defaultValue: () => ... })` — a service **with a default**
+  (this replaces `FiberRef`); no layer needed, override with `Effect.provideService`.
+- **Layer memoization changed:** layers are memoized *globally across separate
+  `Effect.provide` calls* by default in v4 (per-runtime MemoMap), so providing the same
+  layer to two effects builds it once.
+
+## 3. Error handling
+
+`Data.TaggedError` survives unchanged; `Schema.TaggedError` is now
+`Schema.TaggedErrorClass`. Errors are yieldable directly.
+
+```ts
+import { Data, Effect, Schema } from "effect"
+
+class SpawnError extends Data.TaggedError("SpawnError")<{
+  readonly command: string
+  readonly cause: unknown
+}> {}
+
+class TimeoutError extends Data.TaggedError("TimeoutError")<{ readonly ms: number }> {}
+
+// Schema-validated variant:
+class NotFound extends Schema.TaggedErrorClass<NotFound>()("NotFound", {
+  id: Schema.Number
+}) {}
+
+const risky: Effect.Effect<string, SpawnError | TimeoutError> = Effect.gen(function* () {
+  if (somethingBad) return yield* new SpawnError({ command: "worker", cause: "enoent" })
+  return "ok"
+})
+
+// catchTag narrows the error union:
+const handled: Effect.Effect<string, TimeoutError> = risky.pipe(
+  Effect.catchTag("SpawnError", (e) => Effect.succeed(`spawn failed: ${e.command}`))
+)
+
+const handledAll: Effect.Effect<string> = risky.pipe(
+  Effect.catchTags({
+    SpawnError: (e) => Effect.succeed(`spawn: ${e.command}`),
+    TimeoutError: (e) => Effect.succeed(`timeout ${e.ms}ms`)
+  })
+)
+```
+
+Renames: `catchAll` → `Effect.catch`, `catchAllCause` → `catchCause`,
+`catchAllDefect` → `catchDefect`, `tapErrorCause` → `tapCause`, `Effect.either` →
+`Effect.result` (returns `Result`, the renamed `Either`). `Effect.match`,
+`Effect.exit`, `Effect.orDie`, `Effect.mapError`, `Effect.tapError` all still exist.
+The `Cause` data structure was **flattened** (no nested `Sequential`/`Parallel` trees;
+a cause is now a flat list of failures — simpler to render in job status output).
+
+## 4. Promise / async / callback interop
+
+```ts
+import { Cause, Data, Effect } from "effect"
+
+// Promise that "can't" reject — rejection becomes a defect:
+const a = Effect.promise(() => Promise.resolve(42))
+
+// Promise that may reject — default error type is Cause.UnknownError (v3: UnknownException):
+const b = Effect.tryPromise((signal) => fetch("https://x", { signal }))
+
+// Typed error:
+class HttpError extends Data.TaggedError("HttpError")<{ cause: unknown }> {}
+const c = Effect.tryPromise({
+  try: (signal) => fetch("https://x", { signal }),
+  catch: (cause) => new HttpError({ cause })
+})
+```
+
+Both forms receive an `AbortSignal` that fires on fiber interruption — pass it to SDKs
+(claude SDK, fetch, etc.) so interrupting a subagent fiber cancels the underlying call.
+
+Callback APIs — `Effect.async` is now **`Effect.callback`**:
+
+```ts
+// signature: Effect.callback<A, E, R>((resume, signal) => void | cleanupEffect)
+const waitForExit = (child: import("node:child_process").ChildProcess) =>
+  Effect.callback<number>((resume) => {
+    child.once("exit", (code) => resume(Effect.succeed(code ?? -1)))
+  })
+
+// cleanup on interruption via the AbortSignal:
+const sleepy = Effect.callback<number>((resume, signal) => {
+  const t = setTimeout(() => resume(Effect.succeed(1)), 1000)
+  signal.addEventListener("abort", () => clearTimeout(t))
+})
+```
+
+## 5. Scopes & resource management
+
+Same shape as v3. Relevant rename: `Scope.extend` → `Scope.provide`.
+
+```ts
+import { Effect, Exit, Scope } from "effect"
+
+const managedProc = Effect.acquireRelease(
+  acquireEffect,                            // acquire (uninterruptible)
+  (proc, exit) => Effect.sync(() => proc.kill()) // release, gets the Exit
+)
+
+// Scoped region: release runs when the region ends
+const useIt = Effect.scoped(
+  Effect.gen(function* () {
+    const proc = yield* managedProc
+    return proc.pid
+  })
+)
+
+// addFinalizer:
+Effect.scoped(Effect.gen(function* () {
+  yield* Effect.addFinalizer((exit) => Effect.log(`closing, ok=${Exit.isSuccess(exit)}`))
+}))
+```
+
+**Key pattern for background subagents** — a manually-controlled scope so the process
+outlives the spawning tool call, and killing the job = closing the scope:
+
+```ts
+const startJob = Effect.gen(function* () {
+  const scope = yield* Scope.make()
+  const handle = yield* Scope.provide(managedProc, scope) // resource lives in `scope`
+  // store `scope` in your job registry; later, from any fiber:
+  // yield* Scope.close(scope, Exit.void)   // runs finalizers -> kills process
+  return { handle, scope }
+})
+```
+
+`Effect.acquireUseRelease(acquire, use, release)` for one-shot bracketing.
+
+## 6. Child processes & FileSystem (the important part)
+
+The v3 `@effect/platform` `Command`/`CommandExecutor` modules were redesigned into
+**`effect/unstable/process`** with `ChildProcess` (command builder) and
+`ChildProcessSpawner` (the service). The Node implementation comes from
+`@effect/platform-node`.
+
+Import gotcha: `import { ChildProcessSpawner } from "effect/unstable/process"` gives you
+the **module namespace**, not the service class. Import the class from the submodule:
+
+```ts
+import { ChildProcess } from "effect/unstable/process"
+import { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner"
+import { NodeServices, NodeFileSystem } from "@effect/platform-node"
+```
+
+`NodeServices.layer` provides everything at once:
+`ChildProcessSpawner | Crypto | FileSystem | Path | Stdio | Terminal`.
+
+### Building commands
+
+```ts
+// Template literal form:
+const cmd1 = ChildProcess.make`echo hello`
+// Options + template:
+const cmd2 = ChildProcess.make({ cwd: "/tmp" })`ls -la`
+// Array form (best for dynamic args — no shell parsing):
+const cmd = ChildProcess.make("agent", ["run", "--json", prompt], {
+  cwd: workDir,
+  env: { AGENT_API_KEY: key },   // merged over process.env when extendEnv: true
+  extendEnv: true,
+  stdin: "pipe",                 // "pipe" | "inherit" | "ignore" | a Stream<Uint8Array>
+  stdout: "pipe",                // "pipe" | "inherit" | "ignore" | a Sink
+  stderr: "pipe"
+})
+// pipelines: cmdA.pipe(ChildProcess.pipeTo(cmdB, { from: "stderr" }))
+// modifiers: ChildProcess.setCwd, ChildProcess.setEnv, ChildProcess.prefix
+```
+
+Note `detached` defaults to **true on non-Windows** — the child gets its own process
+group (good: killing it kills the group).
+
+### Running: two styles
+
+**Style A — via the spawner service (simple, non-interactive):**
+
+```ts
+const simple = Effect.gen(function* () {
+  const spawner = yield* ChildProcessSpawner
+  const text  = yield* spawner.string(cmd)                    // full stdout as string
+  const lines = yield* spawner.lines(cmd)                     // string[]
+  const code  = yield* spawner.exitCode(cmd)                  // ExitCode (branded number)
+  const lineStream = spawner.streamLines(cmd, { includeStderr: true }) // Stream<string>
+})
+```
+
+**Style B — the Command IS an Effect.** Yielding a command spawns it and returns a
+`ChildProcessHandle`, with the process lifetime tied to the ambient `Scope`
+(`Command extends Effect<ChildProcessHandle, PlatformError, ChildProcessSpawner | Scope>`):
+
+```ts
+import { Effect, Stream } from "effect"
+
+const streaming = Effect.scoped(
+  Effect.gen(function* () {
+    const handle = yield* cmd                 // <-- spawns; killed when scope closes
+    handle.pid                                // ProcessId (branded number)
+
+    // stdout is Stream<Uint8Array, PlatformError>; decode + split lines:
+    yield* handle.stdout.pipe(
+      Stream.decodeText(),
+      Stream.splitLines,
+      Stream.runForEach((line) => Effect.log(`out: ${line}`))
+    )
+
+    // stdin is a Sink<void, Uint8Array>; write by running a stream into it:
+    yield* Stream.fromArray([new TextEncoder().encode("hello\n")]).pipe(
+      Stream.run(handle.stdin)
+    )
+
+    // handle.stderr, handle.all (stdout+stderr interleaved) also available
+    const code = yield* handle.exitCode       // waits for exit
+    const running = yield* handle.isRunning
+    yield* handle.kill({ killSignal: "SIGTERM", forceKillAfter: "5 seconds" })
+    return code
+  })
+)
+```
+
+Verified at runtime: interrupting a fiber that spawned a process inside its scope
+(e.g. `Fiber.interrupt` on a fiber running `Effect.scoped(...)` around `sleep 30`)
+kills the child process. This is the backbone of subagent cancellation.
+
+There's also `handle.unref` for letting the parent exit independently, and
+`additionalFds` for extra file descriptor channels (fd3+).
+
+### FileSystem / Path (now core)
+
+```ts
+import { Effect, FileSystem, Path } from "effect"
+
+const files = Effect.gen(function* () {
+  const fs = yield* FileSystem.FileSystem
+  const path = yield* Path.Path
+  const content = yield* fs.readFileString("/tmp/in.txt")
+  yield* fs.writeFileString(path.join("/tmp", "out.txt"), content)
+})
+// provide NodeFileSystem.layer, or NodeServices.layer for everything
+```
+
+## 7. Concurrency toolbox for a job manager
+
+All verified compiling + running:
+
+```ts
+import {
+  Cause, Deferred, Effect, Fiber, FiberMap, PubSub, Queue, Ref, Stream, Exit
+} from "effect"
+
+const forking = Effect.gen(function* () {
+  const f1 = yield* Effect.forkChild(work)   // v3 fork  — dies with parent
+  const f2 = yield* Effect.forkScoped(work)  // tied to ambient Scope
+  const f3 = yield* Effect.forkDetach(work)  // v3 forkDaemon — outlives parent ✅ for background jobs
+  // all fork variants accept { startImmediately?: boolean, uninterruptible?: boolean | "inherit" }
+
+  const r: number = yield* Fiber.join(f1)                  // propagates failure
+  const exit: Exit.Exit<number> = yield* Fiber.await(f3)   // failure as data
+  yield* Fiber.interrupt(f2)
+  // fiber.pollUnsafe() -> Exit | undefined for sync status checks
+})
+```
+
+**Deferred** — one-shot completion signal (job finished):
+
+```ts
+const done = yield* Deferred.make<Result, JobError>()
+yield* Effect.forkDetach(job.pipe(Effect.exit, Effect.flatMap((e) => Deferred.done(done, e))))
+const result = yield* Deferred.await(done)   // keeps Node process alive in v4, no runMain needed
+```
+
+**Ref** — shared job-table state: `Ref.make({})`, `Ref.update`, `Ref.get`, `Ref.set`.
+(`SynchronizedRef` for effectful updates.)
+
+**Queue** — absorbed v3's `Mailbox`: it can be ended/failed, and converts to a Stream.
+To use `Queue.end`, the error type must include `Cause.Done`:
+
+```ts
+const q = yield* Queue.make<string, Cause.Done>()   // capacity/strategy via options
+yield* Queue.offer(q, "line")
+yield* Queue.offerAll(q, ["a", "b"])
+yield* Queue.end(q)                                 // signal "no more items"
+const asStream = Stream.fromQueue(q)                // ends when queue ends
+// Queue.take / takeAll / takeN / poll for direct consumption
+```
+
+**PubSub** — broadcast (e.g. multiple watchers of one job's output):
+
+```ts
+const ps = yield* PubSub.unbounded<string>()
+const sub = yield* PubSub.subscribe(ps)      // scoped acquisition
+yield* PubSub.publish(ps, "event")
+const msg = yield* PubSub.take(sub)          // function call, not sub.take
+// Stream.fromPubSub(ps) for stream consumption
+```
+
+**FiberMap / FiberSet / FiberHandle** — keyed fiber registries, ideal for a subagent
+manager (auto-interrupts everything when its scope closes; adding under an existing key
+interrupts the old fiber):
+
+```ts
+const jobsDemo = Effect.scoped(Effect.gen(function* () {
+  const jobs = yield* FiberMap.make<string>()          // FiberMap<string> (keys)
+  yield* FiberMap.run(jobs, "job-1", work)             // fork into the map
+  const fiber = yield* FiberMap.get(jobs, "job-1")
+  yield* FiberMap.remove(jobs, "job-1")                // interrupts it
+}))
+```
+
+**Stream** essentials for process output: `Stream.decodeText()`, `Stream.splitLines`,
+`Stream.runForEach`, `Stream.runCollect`, `Stream.run(sink)`, `Stream.fromQueue`,
+`Stream.fromPubSub`, `Stream.toAsyncIterable`, `Stream.callback` (v3 `Stream.async`),
+`Stream.fromArray` (v3 `fromChunk` — v4 uses plain arrays, Chunk is de-emphasized).
+Also `Stream.mkString` to collect into one string.
+
+Combinators: `Effect.all([...], { concurrency: n })`, `Effect.race`,
+`Effect.timeout("5 seconds")` (fails with `Cause.TimeoutError`, tag `"TimeoutError"`),
+`Semaphore.make(n)` (moved out of `Effect.makeSemaphore`), `Latch.make()`.
+
+## 8. ManagedRuntime — the entry-point pattern for the extension
+
+v3's `Runtime.runPromise(runtime)(effect)` API is gone; `effect/Runtime` now only holds
+`runMain` plumbing. **`ManagedRuntime` is the way** to share layers across async entry
+points:
+
+```ts
+import { Context, Effect, Layer, ManagedRuntime } from "effect"
+import { NodeServices } from "@effect/platform-node"
+
+class JobStore extends Context.Service<JobStore, {
+  readonly list: Effect.Effect<Array<string>>
+}>()("app/JobStore") {}
+
+const JobStoreLive = Layer.sync(JobStore, () => ({ list: Effect.succeed([]) }))
+
+const AppLayer = Layer.mergeAll(JobStoreLive, NodeServices.layer)
+
+// Build ONCE at extension activation. Layers are built lazily on first run.
+const runtime = ManagedRuntime.make(AppLayer)
+
+// pi tool handler — the only place we touch Promises:
+export async function handleToolCall() {
+  return await runtime.runPromise(
+    Effect.gen(function* () {
+      const store = yield* JobStore
+      return yield* store.list
+    })
+  )
+}
+
+// fire-and-forget background work from a sync/async context:
+const fiber = runtime.runFork(backgroundEffect)
+
+// extension deactivation — closes the runtime scope, runs ALL finalizers
+// (i.e. kills any still-scoped child processes):
+export async function shutdown() {
+  await runtime.dispose()
+}
+```
+
+`ManagedRuntime` also exposes `runSync`, `runSyncExit`, `runPromiseExit`, `runCallback`,
+a `memoMap` (share layer memoization between multiple runtimes), and `.scope`.
+Prefer `runPromiseExit` in tool handlers if you want to map typed failures to
+tool-result errors instead of catching thrown `Cause` wrappers.
+
+---
+
+## Architecture sketch for subagents
+
+```
+ManagedRuntime.make(Layer.mergeAll(NodeServices.layer, SubagentManagerLive))
+        │  built once at extension init; dispose() on shutdown
+        ▼
+SubagentManager service (Context.Service):
+  - Ref<HashMap<JobId, JobEntry>>            job table
+  - start(cmd):  Scope.make() → Scope.provide(ChildProcess handle, scope)
+                 → Effect.forkDetach(pump stdout → Queue<string, Cause.Done>)
+                 → Deferred<ExitCode> completed on exit
+  - status(id):  Deferred.isDone / handle.isRunning / Ref lookup
+  - output(id):  drain Queue (takeAll) or Stream.fromQueue for tailing
+  - kill(id):    Scope.close(scope, Exit.void)  → finalizer kills the process
+Tool handlers: async fns calling runtime.runPromise(Effect.gen(...))
+```
+
+## Surprises & gotchas (learned the hard way)
+
+1. **`effect/unstable/process` exports module namespaces.** The
+   `ChildProcessSpawner` class must be imported from
+   `"effect/unstable/process/ChildProcessSpawner"` (or use
+   `ChildProcessSpawner.ChildProcessSpawner` off the namespace).
+2. **`Effect.fork` does not exist** — code (or an LLM) writing v3-style `Effect.fork`
+   fails to compile. Use `forkChild` / `forkScoped` / `forkDetach` / `forkIn`.
+3. **`Queue.end` needs `Cause.Done` in the queue's error type** —
+   `Queue.make<A>()` defaults to `E = never` and won't accept `end`.
+4. **Early-beta content mentioning `ServiceMap` is stale** — it was renamed back to
+   `Context` during the beta. Similarly, some AI-generated content mentions APIs that
+   never shipped.
+5. **`Either` is `Result`**, `Effect.either` is `Effect.result`.
+6. **`Data.TaggedError` errors are yieldable** — `yield* new SpawnError({...})` fails
+   the effect directly, no `Effect.fail` wrapper needed (works in v3 too, but idiomatic
+   in v4 docs).
+7. **Chunk → Array**: stream element groups are plain arrays (`Stream.fromArray`,
+   `runCollect` returns `Array<A>`), not `Chunk`.
+8. `tryPromise` default error is `Cause.UnknownError` (was `UnknownException`).
+9. `unstable/*` modules can break between v4 minors — pin exact versions
+   (`4.0.0-beta.98`) and keep `effect` and `@effect/platform-node` in lockstep.
+10. Scratch workspace with all verified test files: `/tmp/effect-v4-scratch`
+    (`test1-basics.ts` … `test8-runtime.ts`, `smoke.mts` executed successfully).

--- a/users/profiles/pi/extensions/subagents/index.ts
+++ b/users/profiles/pi/extensions/subagents/index.ts
@@ -1,0 +1,774 @@
+/**
+ * Subagents — spawn background Pi or Claude Code agents behind one unified
+ * Effect service interface.
+ *
+ * Tools (for the parent LLM):
+ * - subagent_spawn: fire-and-forget spawn (prompt, title, agent, working_dir,
+ *   model, reasoning_effort). Max 4 running at once across all backends.
+ * - subagent_wait: block until the listed subagents settle, return results.
+ * - subagent_cancel: stop one or more running subagents.
+ * - subagent_check: peek at a subagent's status and recent activity.
+ * - subagent_list: list all subagents.
+ *
+ * Unawaited subagents queue their result as a follow-up message when they
+ * settle. `/subagents` opens a picker + full interactive takeover view.
+ *
+ * Architecture: Effect v4 generators throughout (backends -> manager ->
+ * runtime); this file is the async boundary where tool handlers run effects
+ * against one shared ManagedRuntime. Pi runs in-process SDK sessions, while
+ * Claude uses the Claude Agent SDK.
+ */
+
+import * as fs from "node:fs";
+import * as path from "node:path";
+import { StringEnum } from "@earendil-works/pi-ai";
+import type {
+  ExtensionAPI,
+  ExtensionCommandContext,
+  ExtensionContext,
+  ExtensionUIContext,
+} from "@earendil-works/pi-coding-agent";
+import {
+  DEFAULT_MAX_BYTES,
+  DEFAULT_MAX_LINES,
+  formatSize,
+  getAgentDir,
+  getMarkdownTheme,
+  ProjectTrustStore,
+  truncateHead,
+} from "@earendil-works/pi-coding-agent";
+import { Markdown, Text } from "@earendil-works/pi-tui";
+import { Type } from "typebox";
+import { deriveBtwTitle, isModelVisible } from "./src/by-the-way.ts";
+import {
+  BACKEND_NAMES,
+  formatElapsed,
+  latestText,
+  REASONING_EFFORTS,
+  type SubagentSnapshot,
+} from "./src/domain.ts";
+import {
+  formatActivityStatus,
+  formatContextUtilization,
+} from "./src/format.ts";
+import { SubagentManager, type SubagentManagerShape } from "./src/manager.ts";
+import {
+  buildSubagentResultMessage,
+  buildSubagentSpawnResult,
+  SUBAGENT_CANCEL_PARAMETER_DESCRIPTIONS,
+  SUBAGENT_CANCEL_TOOL_DESCRIPTION,
+  SUBAGENT_CHECK_PARAMETER_DESCRIPTIONS,
+  SUBAGENT_CHECK_TOOL_DESCRIPTION,
+  SUBAGENT_LIST_TOOL_DESCRIPTION,
+  SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS,
+  SUBAGENT_SPAWN_PROMPT_GUIDELINES,
+  SUBAGENT_SPAWN_PROMPT_SNIPPET,
+  SUBAGENT_SPAWN_TOOL_DESCRIPTION,
+  SUBAGENT_WAIT_PARAMETER_DESCRIPTIONS,
+  SUBAGENT_WAIT_TOOL_DESCRIPTION,
+} from "./src/prompt.ts";
+import { createDeferredResultDelivery } from "./src/result-delivery.ts";
+import {
+  createSubagentRuntime,
+  runTool,
+  type SubagentRuntime,
+} from "./src/runtime.ts";
+import { openSubagentPicker, openSubagentTakeover } from "./src/ui/takeover.ts";
+
+const SUBAGENT_OUTPUT_MAX_BYTES = 24 * 1024;
+const WAIT_OUTPUT_MAX_BYTES = 48 * 1024;
+const WAIT_PER_AGENT_MAX_BYTES = 16 * 1024;
+const MAX_DELIVERED_RESULTS = 64;
+
+interface BtwResultData {
+  readonly id: string;
+  readonly title: string;
+  readonly status: SubagentSnapshot["status"];
+  readonly errorText?: string;
+  readonly prompt: string;
+  readonly answer: string;
+  readonly sessionFilePath?: string;
+}
+
+function describeSubagent(snap: SubagentSnapshot) {
+  const details = [
+    `${snap.backend}: ${snap.meta.modelLabel ?? "?"}`,
+    formatContextUtilization(snap.usage),
+    formatElapsed(snap),
+    snap.cwd,
+  ].filter(Boolean);
+  return `${snap.id} [${snap.status}] "${snap.title}" (${details.join(", ")})`;
+}
+
+function truncatedOutput(
+  snap: SubagentSnapshot,
+  maxBytes = SUBAGENT_OUTPUT_MAX_BYTES,
+): string {
+  const output = snap.finalText || "(no output)";
+  const truncation = truncateHead(output, {
+    maxBytes: Math.min(maxBytes, DEFAULT_MAX_BYTES),
+    maxLines: Math.min(600, DEFAULT_MAX_LINES),
+  });
+  let text = truncation.content;
+  if (truncation.truncated) {
+    text += `\n\n[Output truncated: ${formatSize(truncation.outputBytes)} of ${formatSize(truncation.totalBytes)} shown. Full transcript in session file: ${snap.meta.sessionFilePath ?? "?"}]`;
+  }
+  return text;
+}
+
+/**
+ * Same-directory children inherit the live parent decision. An alternate cwd
+ * is trusted only when pi's persisted trust store explicitly trusts it (or a
+ * containing directory); unreadable/invalid trust data fails closed.
+ */
+function resolveChildProjectTrust(options: {
+  parentCwd: string;
+  childCwd: string;
+  parentTrusted: boolean;
+}) {
+  if (path.resolve(options.childCwd) === path.resolve(options.parentCwd)) {
+    return options.parentTrusted;
+  }
+  try {
+    const trustStore = new ProjectTrustStore(getAgentDir());
+    return trustStore.get(options.childCwd) === true;
+  } catch {
+    return false;
+  }
+}
+
+export default function (pi: ExtensionAPI) {
+  let runtime: SubagentRuntime | undefined;
+  let managerPromise: Promise<SubagentManagerShape> | undefined;
+  let sessionContext: ExtensionContext | undefined;
+  let ui: ExtensionUIContext | undefined;
+  let unsubStatus: (() => void) | undefined;
+  let statusTimer: ReturnType<typeof setTimeout> | undefined;
+  const deliveredResults = new Map<string, number>();
+  const resultDelivery = createDeferredResultDelivery<SubagentSnapshot>();
+
+  const getRuntime = () => (runtime ??= createSubagentRuntime());
+
+  /** Resolve the manager service once per runtime and wire the extension hooks. */
+  const getManager = () => {
+    managerPromise ??= getRuntime()
+      .runPromise(SubagentManager)
+      .then((manager) => {
+        manager.view.setOnSettled(onSettled);
+        unsubStatus?.();
+        unsubStatus = manager.view.subscribe(() => scheduleStatus(manager));
+        updateStatus(manager);
+        return manager;
+      });
+    return managerPromise;
+  };
+
+  const scheduleStatus = (manager: SubagentManagerShape) => {
+    if (statusTimer) return;
+    statusTimer = setTimeout(() => {
+      statusTimer = undefined;
+      updateStatus(manager);
+    }, 150);
+  };
+
+  const updateStatus = (manager: SubagentManagerShape) => {
+    if (!ui) return;
+    const subs = manager.view.list();
+    if (subs.length === 0) {
+      ui.setStatus("subagents", undefined);
+      return;
+    }
+    const running = subs.filter((snap) => snap.status === "running").length;
+    const failed = subs.filter((snap) => snap.status === "error").length;
+    const done = subs.length - running - failed;
+    ui.setStatus(
+      "subagents",
+      formatActivityStatus(ui.theme, { running, done, failed }),
+    );
+  };
+
+  const deliverResult = (snap: SubagentSnapshot) => {
+    pi.sendMessage(
+      {
+        customType: "subagent-result",
+        content: buildSubagentResultMessage({
+          id: snap.id,
+          title: snap.title,
+          status: snap.status,
+          errorText: snap.errorText,
+          output: truncatedOutput(snap),
+        }),
+        display: true,
+        details: { id: snap.id, title: snap.title, status: snap.status },
+      },
+      { deliverAs: "followUp", triggerTurn: true },
+    );
+    deliveredResults.delete(snap.id);
+    deliveredResults.set(snap.id, snap.settlement);
+    if (deliveredResults.size > MAX_DELIVERED_RESULTS) {
+      const oldest = deliveredResults.keys().next().value;
+      if (oldest !== undefined) deliveredResults.delete(oldest);
+    }
+  };
+
+  const flushResults = () => {
+    for (const snap of resultDelivery.drain()) deliverResult(snap);
+  };
+
+  const deliverBtwResult = (snap: SubagentSnapshot) => {
+    // appendEntry is a synchronous SessionManager operation and emits an
+    // entry_appended event, so it is safe while the parent is streaming and
+    // never enters the model's context or follow-up queue.
+    pi.appendEntry<BtwResultData>("btw-result", {
+      id: snap.id,
+      title: snap.title,
+      status: snap.status,
+      errorText: snap.errorText,
+      prompt: snap.prompt,
+      answer: truncatedOutput(snap),
+      sessionFilePath: snap.meta.sessionFilePath,
+    });
+    ui?.notify(
+      snap.status === "error"
+        ? `by the way “${snap.title}” failed — reopen it with /subagents`
+        : `by the way “${snap.title}” answered — reopen it with /subagents`,
+      snap.status === "error" ? "error" : "info",
+    );
+  };
+
+  const onSettled = (snap: SubagentSnapshot, consumed: boolean) => {
+    // A shutdown can settle children while disposing their scopes. Never
+    // append into a session whose extension runtime is already closing.
+    if (!sessionContext) return;
+    if (snap.origin === "btw") {
+      deliverBtwResult({ ...snap, meta: { ...snap.meta } });
+      return;
+    }
+    if (consumed) {
+      resultDelivery.consume([snap.id]);
+      return;
+    }
+    // Keep the result retractable while the parent is working. A later
+    // subagent_wait can consume it before agent_settled flushes follow-ups.
+    // Defer a copy: the live snapshot keeps mutating if the subagent is
+    // restarted before the deferred result flushes.
+    resultDelivery.defer({ ...snap, meta: { ...snap.meta } });
+    if (sessionContext?.isIdle()) flushResults();
+  };
+
+  pi.on("session_start", (_event, ctx) => {
+    sessionContext = ctx;
+    if (ctx.hasUI) ui = ctx.ui;
+  });
+
+  pi.on("agent_settled", flushResults);
+
+  pi.on("session_shutdown", async () => {
+    sessionContext = undefined;
+    resultDelivery.clear();
+    deliveredResults.clear();
+    if (statusTimer) clearTimeout(statusTimer);
+    statusTimer = undefined;
+    unsubStatus?.();
+    unsubStatus = undefined;
+    ui?.setStatus("subagents", undefined);
+    ui = undefined;
+    const closing = runtime;
+    runtime = undefined;
+    managerPromise = undefined;
+    // Disposing the runtime runs the manager finalizer, which tears down all
+    // subagent scopes (and, later, their real child processes).
+    await closing?.dispose();
+  });
+
+  // --- Tools -------------------------------------------------------------
+
+  pi.registerTool({
+    name: "subagent_spawn",
+    label: "Spawn Subagent",
+    description: SUBAGENT_SPAWN_TOOL_DESCRIPTION,
+    promptSnippet: SUBAGENT_SPAWN_PROMPT_SNIPPET,
+    promptGuidelines: SUBAGENT_SPAWN_PROMPT_GUIDELINES,
+    parameters: Type.Object({
+      prompt: Type.String({
+        description: SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS.prompt,
+      }),
+      name: Type.String({
+        description: SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS.name,
+      }),
+      harness: StringEnum(BACKEND_NAMES, {
+        description: SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS.harness,
+      }),
+      working_dir: Type.Optional(
+        Type.String({
+          description: SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS.workingDir,
+        }),
+      ),
+      model: Type.Optional(
+        Type.String({
+          description: SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS.model,
+        }),
+      ),
+      reasoning_effort: Type.Optional(
+        StringEnum(REASONING_EFFORTS, {
+          description: SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS.reasoningEffort,
+        }),
+      ),
+    }),
+    async execute(_toolCallId, params, signal, _onUpdate, ctx) {
+      const manager = await getManager();
+      const harness = params.harness;
+
+      const cwd = path.resolve(ctx.cwd, params.working_dir ?? ".");
+      if (!fs.existsSync(cwd) || !fs.statSync(cwd).isDirectory()) {
+        throw new Error(`working_dir is not a directory: ${cwd}`);
+      }
+
+      const title = params.name.trim().slice(0, 160) || "subagent";
+      const snap = await runTool(
+        getRuntime(),
+        manager.spawn(harness, {
+          prompt: params.prompt,
+          title,
+          cwd,
+          model: params.model,
+          reasoningEffort: params.reasoning_effort,
+          parent: {
+            parentCwd: ctx.cwd,
+            projectTrusted: resolveChildProjectTrust({
+              parentCwd: ctx.cwd,
+              childCwd: cwd,
+              parentTrusted: ctx.isProjectTrusted(),
+            }),
+            inheritedModel: ctx.model
+              ? { provider: ctx.model.provider, id: ctx.model.id }
+              : undefined,
+            inheritedThinkingLevel: pi.getThinkingLevel(),
+            modelRegistry: ctx.modelRegistry,
+          },
+        }),
+        { signal, interruptMessage: "Subagent spawn aborted." },
+      );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: buildSubagentSpawnResult({
+              id: snap.id,
+              title: snap.title,
+              harness,
+              modelLabel: snap.meta.modelLabel ?? "?",
+              cwd,
+            }),
+          },
+        ],
+        details: {
+          id: snap.id,
+          title: snap.title,
+          cwd,
+          harness,
+          model: snap.meta.modelLabel,
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "subagent_wait",
+    label: "Wait for Subagents",
+    description: SUBAGENT_WAIT_TOOL_DESCRIPTION,
+    parameters: Type.Object({
+      ids: Type.Array(Type.String(), {
+        maxItems: 64,
+        description: SUBAGENT_WAIT_PARAMETER_DESCRIPTIONS.ids,
+      }),
+    }),
+    async execute(_toolCallId, params, signal, onUpdate) {
+      const manager = await getManager();
+      const ids = [...new Set(params.ids)];
+      if (ids.length === 0)
+        throw new Error("Provide at least one subagent id.");
+      const known = manager.view
+        .list()
+        .filter(isModelVisible)
+        .map((snap) => snap.id);
+      const unknown = ids.filter((id) => {
+        const snap = manager.view.get(id);
+        return !snap || !isModelVisible(snap);
+      });
+      if (unknown.length > 0) {
+        throw new Error(
+          `Unknown subagent id(s): ${unknown.join(", ")}. Known: ${known.join(", ") || "none"}.`,
+        );
+      }
+
+      await runTool(
+        getRuntime(),
+        manager.waitFor(ids, (pending) => {
+          onUpdate?.({
+            content: [
+              { type: "text", text: `Waiting for ${pending.join(", ")}...` },
+            ],
+            details: { pending },
+          });
+        }),
+        { signal, interruptMessage: "Wait aborted. Subagents keep running." },
+      );
+
+      // Settlement may have happened before this wait began. Remove any
+      // deferred automatic delivery now that the tool is returning the result.
+      resultDelivery.consume(ids);
+
+      const sections: string[] = [];
+      let remainingBytes = WAIT_OUTPUT_MAX_BYTES;
+      for (const id of ids) {
+        const snap = manager.view.get(id);
+        if (!snap) {
+          sections.push(`## ${id}\n\n(no longer tracked)`);
+          continue;
+        }
+        if (
+          deliveredResults.has(id) &&
+          deliveredResults.get(id) === snap.settlement
+        ) {
+          sections.push(
+            `## ${snap.id} "${snap.title}"\n\n[result already delivered automatically above]`,
+          );
+          continue;
+        }
+        const verb = snap.status === "error" ? "failed" : "finished";
+        let section = `## ${snap.id} "${snap.title}" ${verb}`;
+        if (snap.errorText) section += `\nError: ${snap.errorText}`;
+        const headerBytes = Buffer.byteLength(section, "utf8") + 2;
+        const outputBudget = Math.max(
+          512,
+          Math.min(WAIT_PER_AGENT_MAX_BYTES, remainingBytes - headerBytes),
+        );
+        section += `\n\n${truncatedOutput(snap, outputBudget)}`;
+        const sectionBytes = Buffer.byteLength(section, "utf8");
+        if (sectionBytes > remainingBytes) {
+          sections.push(
+            `## ${snap.id} "${snap.title}"\n\n[omitted: total wait output limit reached]`,
+          );
+          break;
+        }
+        sections.push(section);
+        remainingBytes -= sectionBytes;
+      }
+
+      const combined = sections.join("\n\n---\n\n");
+      const bounded = truncateHead(combined, {
+        maxBytes: WAIT_OUTPUT_MAX_BYTES - 128,
+        maxLines: DEFAULT_MAX_LINES,
+      });
+      const text = bounded.truncated
+        ? `${bounded.content}\n\n[wait output truncated at the total output limit]`
+        : bounded.content;
+      return {
+        content: [{ type: "text", text }],
+        details: {
+          results: ids.map((id) => {
+            const snap = manager.view.get(id);
+            return { id, title: snap?.title, status: snap?.status };
+          }),
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "subagent_cancel",
+    label: "Cancel Subagents",
+    description: SUBAGENT_CANCEL_TOOL_DESCRIPTION,
+    parameters: Type.Object({
+      ids: Type.Array(Type.String(), {
+        description: SUBAGENT_CANCEL_PARAMETER_DESCRIPTIONS.ids,
+      }),
+    }),
+    async execute(_toolCallId, params, signal) {
+      const manager = await getManager();
+      const ids = [...new Set(params.ids)];
+      if (ids.length === 0)
+        throw new Error("Provide at least one subagent id.");
+
+      const known = manager.view
+        .list()
+        .filter(isModelVisible)
+        .map((snap) => snap.id);
+      const unknown = ids.filter((id) => {
+        const snap = manager.view.get(id);
+        return !snap || !isModelVisible(snap);
+      });
+      if (unknown.length > 0) {
+        throw new Error(
+          `Unknown subagent id(s): ${unknown.join(", ")}. Known: ${known.join(", ") || "none"}.`,
+        );
+      }
+
+      const report = await runTool(getRuntime(), manager.cancel(ids), {
+        signal,
+        interruptMessage: "Subagent cancellation aborted.",
+      });
+
+      const lines = report.map((entry) =>
+        entry.cancelled
+          ? `Cancelled ${entry.id} "${entry.title}".`
+          : `${entry.id} "${entry.title}" was already ${entry.status}.`,
+      );
+
+      return {
+        content: [{ type: "text", text: lines.join("\n") }],
+        details: {
+          results: report.map((entry) => ({
+            id: entry.id,
+            title: entry.title,
+            status: entry.status,
+          })),
+        },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "subagent_check",
+    label: "Check Subagent",
+    description: SUBAGENT_CHECK_TOOL_DESCRIPTION,
+    parameters: Type.Object({
+      id: Type.String({
+        description: SUBAGENT_CHECK_PARAMETER_DESCRIPTIONS.id,
+      }),
+    }),
+    async execute(_toolCallId, params) {
+      const manager = await getManager();
+      const snap = manager.view.get(params.id);
+      if (!snap || !isModelVisible(snap)) {
+        const known = manager.view
+          .list()
+          .filter(isModelVisible)
+          .map((s) => s.id);
+        throw new Error(
+          `Unknown subagent id "${params.id}". Known: ${known.join(", ") || "none"}.`,
+        );
+      }
+
+      let text = `${describeSubagent(snap)}\nTurns: ${snap.turns}`;
+      if (snap.errorText) text += `\nError: ${snap.errorText}`;
+
+      const output = latestText(snap);
+      if (output) {
+        const preview = truncateHead(output, { maxBytes: 2048, maxLines: 20 });
+        text += `\n\nLatest output:\n${preview.content}`;
+        if (preview.truncated) text += "\n[...]";
+      } else if (snap.status === "running") {
+        text += "\n\n(no text output yet)";
+      }
+
+      return {
+        content: [{ type: "text", text }],
+        details: { id: snap.id, status: snap.status, turns: snap.turns },
+      };
+    },
+  });
+
+  pi.registerTool({
+    name: "subagent_list",
+    label: "List Subagents",
+    description: SUBAGENT_LIST_TOOL_DESCRIPTION,
+    parameters: Type.Object({}),
+    async execute() {
+      const manager = await getManager();
+      const subs = manager.view.list().filter(isModelVisible);
+      const text =
+        subs.length === 0
+          ? "No subagents."
+          : subs.map((snap) => describeSubagent(snap)).join("\n");
+      return {
+        content: [{ type: "text", text }],
+        details: {
+          subagents: subs.map((snap) => ({
+            id: snap.id,
+            title: snap.title,
+            harness: snap.backend,
+            status: snap.status,
+          })),
+        },
+      };
+    },
+  });
+
+  // --- Result message rendering ------------------------------------------
+
+  pi.registerMessageRenderer(
+    "subagent-result",
+    (message, { expanded }, theme) => {
+      const details = (message.details ?? {}) as {
+        id?: string;
+        title?: string;
+        status?: string;
+      };
+      const failed = details.status === "error";
+      const icon = failed ? theme.fg("error", "x") : theme.fg("success", "■");
+      const header =
+        `${icon} ` +
+        theme.fg("accent", theme.bold(`subagent ${details.id ?? "?"}`)) +
+        theme.fg(
+          "muted",
+          ` · ${details.title ?? ""} · ${failed ? "failed" : "finished"}`,
+        );
+
+      const content =
+        typeof message.content === "string" ? message.content : "";
+      // Remove only the summary line. The following Error line (when present)
+      // is part of the actual result and must remain visible.
+      const body = content.split("\n").slice(1).join("\n").trim();
+
+      if (expanded) {
+        const md = new Markdown(`${body}`, 0, 0, getMarkdownTheme());
+        const container = new Text(header, 0, 0);
+        return {
+          render: (width: number) => [
+            ...container.render(width),
+            ...md.render(width),
+          ],
+          invalidate: () => {
+            container.invalidate();
+            md.invalidate();
+          },
+        };
+      }
+
+      const previewLines = body.split("\n").slice(0, 8);
+      let text = header;
+      for (const line of previewLines)
+        text += `\n${theme.fg("toolOutput", line)}`;
+      if (body.split("\n").length > 8)
+        text += `\n${theme.fg("dim", "... (ctrl+o to expand)")}`;
+      return new Text(text, 0, 0);
+    },
+  );
+
+  pi.registerEntryRenderer<BtwResultData>(
+    "btw-result",
+    (entry, { expanded }, theme) => {
+      const data = entry.data;
+      const failed = data?.status === "error";
+      const icon = failed ? theme.fg("error", "x") : theme.fg("success", "■");
+      const header =
+        `${icon} ` +
+        theme.fg("accent", theme.bold(`by the way · ${data?.title ?? "?"}`)) +
+        theme.fg(
+          "muted",
+          ` · ${failed ? "failed" : "answered"} · ${data?.id ?? "?"}`,
+        );
+      const body = [
+        data?.errorText ? `Error: ${data.errorText}` : "",
+        data?.answer ?? "(no answer)",
+      ]
+        .filter(Boolean)
+        .join("\n\n");
+
+      if (expanded) {
+        const md = new Markdown(body, 0, 0, getMarkdownTheme());
+        const container = new Text(header, 0, 0);
+        return {
+          render: (width: number) => [
+            ...container.render(width),
+            ...md.render(width),
+          ],
+          invalidate: () => {
+            container.invalidate();
+            md.invalidate();
+          },
+        };
+      }
+
+      const lines = body.split("\n");
+      let text = header;
+      for (const line of lines.slice(0, 8))
+        text += `\n${theme.fg("toolOutput", line)}`;
+      if (lines.length > 8)
+        text += `\n${theme.fg("dim", "... (ctrl+o to expand)")}`;
+      return new Text(text, 0, 0);
+    },
+  );
+
+  // --- Commands -----------------------------------------------------------
+
+  const runByTheWay = async (rawArgs: string, ctx: ExtensionCommandContext) => {
+    if (ctx.mode !== "tui") {
+      if (ctx.hasUI)
+        ctx.ui.notify("by the way is only available in the TUI", "error");
+      return;
+    }
+
+    let prompt = rawArgs.trim();
+    if (!prompt) {
+      const input = await ctx.ui.input("by the way", "Ask a one-off question…");
+      prompt = input?.trim() ?? "";
+      if (!prompt) return;
+    }
+
+    const manager = await getManager();
+    let snap: SubagentSnapshot;
+    try {
+      snap = await runTool(
+        getRuntime(),
+        manager.spawn("pi", {
+          origin: "btw",
+          prompt,
+          title: deriveBtwTitle(prompt),
+          cwd: ctx.cwd,
+          parent: {
+            parentCwd: ctx.cwd,
+            projectTrusted: ctx.isProjectTrusted(),
+            inheritedModel: ctx.model
+              ? { provider: ctx.model.provider, id: ctx.model.id }
+              : undefined,
+            inheritedThinkingLevel: pi.getThinkingLevel(),
+            modelRegistry: ctx.modelRegistry,
+          },
+        }),
+      );
+    } catch (error) {
+      ctx.ui.notify(
+        error instanceof Error ? error.message : String(error),
+        "error",
+      );
+      return;
+    }
+
+    await openSubagentTakeover(ctx, manager.view, snap.id, {
+      badge: "by the way",
+    });
+  };
+
+  pi.registerCommand("btw", {
+    description:
+      "Ask a one-off side question while the main agent keeps working",
+    handler: runByTheWay,
+  });
+
+  pi.registerCommand("subagents", {
+    description: "List, inspect, and take over subagents",
+    handler: async (_args, ctx) => {
+      if (ctx.mode !== "tui") {
+        if (ctx.hasUI)
+          ctx.ui.notify(
+            "Subagent takeover is only available in the TUI",
+            "error",
+          );
+        return;
+      }
+      const manager = await getManager();
+      if (manager.view.size() === 0) {
+        ctx.ui.notify(
+          "No subagents yet. The agent spawns them with subagent_spawn.",
+          "info",
+        );
+        return;
+      }
+      await openSubagentPicker(ctx, manager.view);
+    },
+  });
+}

--- a/users/profiles/pi/extensions/subagents/manager.test.ts
+++ b/users/profiles/pi/extensions/subagents/manager.test.ts
@@ -1,0 +1,278 @@
+/**
+ * End-to-end smoke tests: manager behavior through a real ManagedRuntime,
+ * exactly as the tool handlers drive it. The registry is test-only: scripted
+ * stub Claude sessions (the production backend launches a real process),
+ * plus the real pi backend for its cheap registry precondition.
+ */
+
+import assert from "node:assert/strict";
+import test from "node:test";
+import { Effect, Layer, ManagedRuntime } from "effect";
+import { BackendRegistry, type SubagentBackend } from "./src/backend.ts";
+import { piBackend } from "./src/backends/pi.ts";
+import { makeStubBackend } from "./src/backends/stub.ts";
+import type { BackendName, ParentContext, SpawnTask } from "./src/domain.ts";
+import {
+  makeChangeSignal,
+  SubagentManager,
+  SubagentManagerLive,
+  type SubagentManagerShape,
+} from "./src/manager.ts";
+import { runTool } from "./src/runtime.ts";
+
+const TestRegistryLive = Layer.sync(BackendRegistry, () => {
+  const backends: SubagentBackend[] = [
+    piBackend,
+    makeStubBackend({
+      backend: "claude",
+      defaultModelLabel: "claude/sonnet",
+      contextWindow: 200_000,
+      toolName: "Bash",
+      cadenceMs: 40,
+    }),
+  ];
+  return new Map<BackendName, SubagentBackend>(
+    backends.map((backend) => [backend.name, backend]),
+  );
+});
+
+const createTestRuntime = () =>
+  ManagedRuntime.make(
+    SubagentManagerLive.pipe(Layer.provide(TestRegistryLive)),
+  );
+
+const parent: ParentContext = {
+  parentCwd: process.cwd(),
+  projectTrusted: false,
+};
+
+function task(prompt: string): SpawnTask {
+  return { prompt, title: "test", cwd: process.cwd(), parent };
+}
+
+async function withManager(
+  run: (
+    manager: SubagentManagerShape,
+    runtime: ReturnType<typeof createTestRuntime>,
+  ) => Promise<void>,
+) {
+  const runtime = createTestRuntime();
+  try {
+    const manager = await runtime.runPromise(SubagentManager);
+    await run(manager, runtime);
+  } finally {
+    await runtime.dispose();
+  }
+}
+
+test("stub subagent completes and delivers a final result", async () => {
+  await withManager(async (manager, runtime) => {
+    const settled: Array<{ id: string; consumed: boolean }> = [];
+    manager.view.setOnSettled((snap, consumed) =>
+      settled.push({ id: snap.id, consumed }),
+    );
+
+    const snap = await runTool(
+      runtime,
+      manager.spawn("claude", task("Say hello to the tests")),
+    );
+    assert.equal(snap.status, "running");
+    assert.equal(snap.backend, "claude");
+    assert.ok(snap.meta.sessionFilePath);
+
+    await runTool(runtime, manager.waitFor([snap.id]));
+    const done = manager.view.get(snap.id);
+    assert.ok(done);
+    assert.equal(done.status, "done");
+    assert.match(
+      done.finalText,
+      /\[stub:claude\] completed: Say hello to the tests/,
+    );
+    assert.ok(done.turns >= 2);
+    assert.ok(done.transcript.some((item) => item.kind === "toolResult"));
+    // The waitFor marked the settle as consumed.
+    assert.deepEqual(settled, [{ id: snap.id, consumed: true }]);
+  });
+});
+
+test("FAIL: prompts settle as errors; unconsumed settles are delivered", async () => {
+  await withManager(async (manager, runtime) => {
+    const settled: Array<{ id: string; consumed: boolean }> = [];
+    manager.view.setOnSettled((snap, consumed) =>
+      settled.push({ id: snap.id, consumed }),
+    );
+
+    const snap = await runTool(
+      runtime,
+      manager.spawn("claude", task("FAIL: blow up please")),
+    );
+    // Poll without wait-interest so the settle is delivered unconsumed.
+    while (manager.view.get(snap.id)?.status === "running") {
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    const failed = manager.view.get(snap.id);
+    assert.equal(failed?.status, "error");
+    assert.match(failed?.errorText ?? "", /task failed/);
+    assert.deepEqual(settled, [{ id: snap.id, consumed: false }]);
+  });
+});
+
+test("cancel interrupts a running stub subagent", async () => {
+  await withManager(async (manager, runtime) => {
+    const snap = await runTool(
+      runtime,
+      manager.spawn("claude", task("Long running task")),
+    );
+    const report = await runTool(runtime, manager.cancel([snap.id]));
+    assert.deepEqual(report, [
+      { id: snap.id, title: "test", status: "error", cancelled: true },
+    ]);
+    assert.equal(manager.view.get(snap.id)?.errorText, "Run was aborted");
+  });
+});
+
+test("spawn origin propagates to ids, snapshots, and settlement", async () => {
+  await withManager(async (manager, runtime) => {
+    const settled: Array<{ id: string; origin: string }> = [];
+    manager.view.setOnSettled((snap) =>
+      settled.push({ id: snap.id, origin: snap.origin }),
+    );
+
+    const model = await runTool(
+      runtime,
+      manager.spawn("claude", task("model task")),
+    );
+    const btw = await runTool(
+      runtime,
+      manager.spawn("claude", { ...task("side question"), origin: "btw" }),
+    );
+
+    assert.match(model.id, /^sa-/);
+    assert.equal(model.origin, "model");
+    assert.match(btw.id, /^btw-/);
+    assert.equal(btw.origin, "btw");
+
+    await runTool(runtime, manager.cancel([model.id, btw.id]));
+    assert.deepEqual(
+      settled.sort((a, b) => a.id.localeCompare(b.id)),
+      [
+        { id: btw.id, origin: "btw" },
+        { id: model.id, origin: "model" },
+      ].sort((a, b) => a.id.localeCompare(b.id)),
+    );
+  });
+});
+
+test("the global concurrency cap includes by-the-way sessions", async () => {
+  await withManager(async (manager, runtime) => {
+    const tasks: SpawnTask[] = [
+      { ...task("side question"), origin: "btw" },
+      task("Task 2"),
+      task("Task 3"),
+      task("Task 4"),
+    ];
+    const spawns = await runTool(
+      runtime,
+      Effect.forEach(tasks, (spawnTask) => manager.spawn("claude", spawnTask), {
+        concurrency: "unbounded",
+      }),
+    );
+    assert.equal(spawns.length, 4);
+    await assert.rejects(
+      runTool(
+        runtime,
+        manager.spawn("claude", {
+          ...task("another side question"),
+          origin: "btw",
+        }),
+      ),
+      /Max 4 subagents/,
+    );
+  });
+});
+
+test("the concurrency cap rejects a fifth running subagent", async () => {
+  await withManager(async (manager, runtime) => {
+    const spawns = await runTool(
+      runtime,
+      Effect.forEach(
+        [1, 2, 3, 4],
+        (n) => manager.spawn("claude", task(`Task ${n}`)),
+        { concurrency: "unbounded" },
+      ),
+    );
+    assert.equal(spawns.length, 4);
+    await assert.rejects(
+      runTool(runtime, manager.spawn("claude", task("Task 5"))),
+      /Max 4 subagents/,
+    );
+  });
+});
+
+test("pi spawn fails fast without the parent model registry", async () => {
+  await withManager(async (manager, runtime) => {
+    await assert.rejects(
+      runTool(runtime, manager.spawn("pi", task("needs a registry"))),
+      /model registry/,
+    );
+    // The failed spawn must release its concurrency reservation.
+    const snap = await runTool(runtime, manager.spawn("claude", task("ok")));
+    assert.equal(snap.backend, "claude");
+  });
+});
+
+test("idle restarts respect the concurrency cap", async () => {
+  await withManager(async (manager, runtime) => {
+    // Settle one subagent, then fill all four slots with running ones.
+    const settled = await runTool(
+      runtime,
+      manager.spawn("claude", task("early finisher")),
+    );
+    await runTool(runtime, manager.waitFor([settled.id]));
+    await runTool(
+      runtime,
+      Effect.forEach(
+        [1, 2, 3, 4],
+        (n) => manager.spawn("claude", task(`Task ${n}`)),
+        { concurrency: "unbounded" },
+      ),
+    );
+    // Restarting the settled one would be a fifth concurrent run.
+    await assert.rejects(
+      runTool(runtime, manager.send(settled.id, "go again")),
+      /Max 4 subagents/,
+    );
+    assert.equal(manager.view.get(settled.id)?.status, "done");
+  });
+});
+
+test("send steers an idle subagent into another turn", async () => {
+  await withManager(async (manager, runtime) => {
+    const snap = await runTool(
+      runtime,
+      manager.spawn("claude", task("First turn")),
+    );
+    await runTool(runtime, manager.waitFor([snap.id]));
+    const afterFirst = manager.view.get(snap.id);
+    assert.equal(afterFirst?.status, "done");
+
+    await runTool(runtime, manager.send(snap.id, "Second turn"));
+    // The fresh run flips the status back to running...
+    while (manager.view.get(snap.id)?.status !== "running") {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    await runTool(runtime, manager.waitFor([snap.id]));
+    const afterSecond = manager.view.get(snap.id);
+    assert.equal(afterSecond?.status, "done");
+    assert.match(afterSecond?.finalText ?? "", /Second turn/);
+  });
+});
+
+test("change signal closes the check-before-wait race", async () => {
+  const changes = makeChangeSignal();
+  const observed = changes.version();
+  // Simulate settlement after the caller checked state but before the Effect
+  // callback that registers the waiter begins executing.
+  changes.notify();
+  await Effect.runPromise(changes.wait(observed));
+});

--- a/users/profiles/pi/extensions/subagents/package-lock.json
+++ b/users/profiles/pi/extensions/subagents/package-lock.json
@@ -1,0 +1,2262 @@
+{
+  "name": "subagents",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "subagents",
+      "dependencies": {
+        "@anthropic-ai/claude-agent-sdk": "^0.3.216",
+        "effect": "4.0.0-beta.101"
+      },
+      "devDependencies": {
+        "@effect/tsgo": "^0.24.2",
+        "@types/node": "^26.1.1",
+        "typescript": "^7.0.2"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk/-/claude-agent-sdk-0.3.218.tgz",
+      "integrity": "sha512-lbVOmgdzjBdSUCTbxElpoTxxP/u9jY8gpG/3cr5l1jSSvSY5FrANdRcze/z6gM330xo32SHH6WPGFd4+K0fMoQ==",
+      "license": "SEE LICENSE IN README.md",
+      "engines": {
+        "node": ">=18.0.0"
+      },
+      "optionalDependencies": {
+        "@anthropic-ai/claude-agent-sdk-darwin-arm64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-darwin-x64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-arm64-musl": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-x64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-linux-x64-musl": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-win32-arm64": "0.3.218",
+        "@anthropic-ai/claude-agent-sdk-win32-x64": "0.3.218"
+      },
+      "peerDependencies": {
+        "@anthropic-ai/sdk": ">=0.93.0",
+        "@modelcontextprotocol/sdk": "^1.29.0",
+        "zod": "^4.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-arm64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-arm64/-/claude-agent-sdk-darwin-arm64-0.3.218.tgz",
+      "integrity": "sha512-foTI71ua2r5lJo7sfcw/3UafBCJYjxPmOXZ98wOz1UWIJxaP/Oq9Xp4sUavBd1efFVRxPnAcRnrZ5yrmXK1xUw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-darwin-x64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-darwin-x64/-/claude-agent-sdk-darwin-x64-0.3.218.tgz",
+      "integrity": "sha512-rAdlR2ukJd01Osfsb7nPPv31MCVJBennBDaL7ZP/bv+dednwNuY6thuPO5PMFJUM+54Gbnziqm+hqoNTgndqDg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64/-/claude-agent-sdk-linux-arm64-0.3.218.tgz",
+      "integrity": "sha512-Y6vFEnz6wwd+rYpVGsPqgeXZuZP7NvQg6vjkC+N6cs1+I41LdKjfs+F+WG3daIqgt+vJBz/EB5Q0PByABkwufA==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-arm64-musl": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-arm64-musl/-/claude-agent-sdk-linux-arm64-musl-0.3.218.tgz",
+      "integrity": "sha512-qfFBwOf0uh/mAtNGEkBJlLWt1XIgFqcQeeX966g2NexasCdSJGnwfc0YWA0QOeAAU/5xk6tSCW/Nn0zHGBO/3A==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64/-/claude-agent-sdk-linux-x64-0.3.218.tgz",
+      "integrity": "sha512-gCq/i7yRXeuoQXidGQynuiw5AeczQXSIifxH5Vpr9OFDyHCBNotS1mQ8qutuclZeFpLOPkJ2ic/nvEgHJvfXdg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-linux-x64-musl": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-linux-x64-musl/-/claude-agent-sdk-linux-x64-musl-0.3.218.tgz",
+      "integrity": "sha512-e47oi8dYWnS0wx2/F6FL3YhaD2HedMd2nhI/nududP4PBzytuXeaDE/sJ0eIqtUVkl6/bn5uBhtIEHHWoj37JQ==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-arm64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-arm64/-/claude-agent-sdk-win32-arm64-0.3.218.tgz",
+      "integrity": "sha512-D0UKI8jOpEsWO1A+i0DlIrgjXFKEZX3RrID2l49S4pShUlLsnSLJGMTPy4nQt6CCl5MzPqWiJDE/lCpImFTDcg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/claude-agent-sdk-win32-x64": {
+      "version": "0.3.218",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/claude-agent-sdk-win32-x64/-/claude-agent-sdk-win32-x64-0.3.218.tgz",
+      "integrity": "sha512-pgE39WnKPPSRsiRJ2pm5NETxQgtVhrquqg7UByZxne0xQw2gNS0Qy+9ZumrsNBNlfrrnQCVDU1I2ks3ZLrEa8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "SEE LICENSE IN LICENSE.md",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.114.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.114.0.tgz",
+      "integrity": "sha512-zRFGTVMFEm77gt70Q0B+CDRKa9AcguydCcp6bD/dXWv8UkfsVFqCbaqU8+4B/pob3+Vy434LgtrBmwSvxfKr3g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1",
+        "standardwebhooks": "^1.0.0"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@effect/tsgo": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo/-/tsgo-0.24.3.tgz",
+      "integrity": "sha512-WQxKU3MFzWzI38GbE9cf0POkVX4y0xahD8QqDjLfixW1AEValuHNfOQvyKM2MDWOLdGff4hP8VnIOeduwQt66A==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "effect-tsgo": "dist/effect-tsgo.js"
+      },
+      "optionalDependencies": {
+        "@effect/tsgo-darwin-arm64": "0.24.3",
+        "@effect/tsgo-darwin-x64": "0.24.3",
+        "@effect/tsgo-linux-arm": "0.24.3",
+        "@effect/tsgo-linux-arm64": "0.24.3",
+        "@effect/tsgo-linux-x64": "0.24.3",
+        "@effect/tsgo-win32-arm64": "0.24.3",
+        "@effect/tsgo-win32-x64": "0.24.3"
+      }
+    },
+    "node_modules/@effect/tsgo-darwin-arm64": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo-darwin-arm64/-/tsgo-darwin-arm64-0.24.3.tgz",
+      "integrity": "sha512-eO83D7ZmpAsocA5WJQ8SSAPnAOZ+dEduFIozg9c2SmH36PCHG1Eb++I0UiQml+2LAr4o/QE2wKdWj7LExebjZA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@effect/tsgo-darwin-x64": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo-darwin-x64/-/tsgo-darwin-x64-0.24.3.tgz",
+      "integrity": "sha512-ksX9BdCM8289RRuN0lWhtzuvstH1frxwdxhoW08rrGW3ryER3udEFqEtgtveP0cYvK9gTlV5lXbQPNGktQ2sTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@effect/tsgo-linux-arm": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo-linux-arm/-/tsgo-linux-arm-0.24.3.tgz",
+      "integrity": "sha512-0TzebGLMNZkHOGSK0w1B4zuvHGlA+Od4LdElWeHHP6iMPEiEWPq17If787+oc+Y67yITPJ9DZcibu69eI9mZhg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@effect/tsgo-linux-arm64": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo-linux-arm64/-/tsgo-linux-arm64-0.24.3.tgz",
+      "integrity": "sha512-CMiThuURi14rT5Ikag5pVnUC3tx4IcmPpRR4WBQkHxAbOf5a1Lo1NUF82zY0azhLW2WszBamTSZP5Tcv4uks2A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@effect/tsgo-linux-x64": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo-linux-x64/-/tsgo-linux-x64-0.24.3.tgz",
+      "integrity": "sha512-R4jl1JWoYEldUU1rtCG1fXWW2ywj/rgY1xaCzK8HSb8fQhQ71WRLLAyAe8ewROuseWQ9Ip+IbbfAeXQOpmpdDA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@effect/tsgo-win32-arm64": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo-win32-arm64/-/tsgo-win32-arm64-0.24.3.tgz",
+      "integrity": "sha512-DOJ4oa8pk8qxEQwKHpJOqtjOfB9iOMuc6Cnb2ZbTG32PBfhqeRYv6YFGhFtgAojXyxfuRP2gCJVpFfjzHJh7nQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@effect/tsgo-win32-x64": {
+      "version": "0.24.3",
+      "resolved": "https://registry.npmjs.org/@effect/tsgo-win32-x64/-/tsgo-win32-x64-0.24.3.tgz",
+      "integrity": "sha512-6GpENpPn3mXldmJoM+Z7qi+8fe39xJYB2bLD5jqCFWl14vFp1AeJvYwHYQak8HRm1FiPz72Ninslv8DjHYtZgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@hono/node-server": {
+      "version": "1.19.15",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.15.tgz",
+      "integrity": "sha512-Za2ai6TLdKjUvnur+eenO6nuYYipVAEhyCAdaV8IRvmU9kK8crOZUSYvIXn72E4f8fJqyAbpcJuTsYYmZp9Deg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.14.1"
+      },
+      "peerDependencies": {
+        "hono": "^4"
+      }
+    },
+    "node_modules/@modelcontextprotocol/sdk": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
+      "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@hono/node-server": "^1.19.9",
+        "ajv": "^8.17.1",
+        "ajv-formats": "^3.0.1",
+        "content-type": "^1.0.5",
+        "cors": "^2.8.5",
+        "cross-spawn": "^7.0.5",
+        "eventsource": "^3.0.2",
+        "eventsource-parser": "^3.0.0",
+        "express": "^5.2.1",
+        "express-rate-limit": "^8.2.1",
+        "hono": "^4.11.4",
+        "jose": "^6.1.3",
+        "json-schema-typed": "^8.0.2",
+        "pkce-challenge": "^5.0.0",
+        "raw-body": "^3.0.0",
+        "zod": "^3.25 || ^4.0",
+        "zod-to-json-schema": "^3.25.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@cfworker/json-schema": "^4.1.1",
+        "zod": "^3.25 || ^4.0"
+      },
+      "peerDependenciesMeta": {
+        "@cfworker/json-schema": {
+          "optional": true
+        },
+        "zod": {
+          "optional": false
+        }
+      }
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-arm64/-/msgpackr-extract-darwin-arm64-3.0.4.tgz",
+      "integrity": "sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-darwin-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-darwin-x64/-/msgpackr-extract-darwin-x64-3.0.4.tgz",
+      "integrity": "sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm/-/msgpackr-extract-linux-arm-3.0.4.tgz",
+      "integrity": "sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-arm64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-arm64/-/msgpackr-extract-linux-arm64-3.0.4.tgz",
+      "integrity": "sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-linux-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-linux-x64/-/msgpackr-extract-linux-x64-3.0.4.tgz",
+      "integrity": "sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@msgpackr-extract/msgpackr-extract-win32-x64": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@msgpackr-extract/msgpackr-extract-win32-x64/-/msgpackr-extract-win32-x64-3.0.4.tgz",
+      "integrity": "sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@stablelib/base64": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@stablelib/base64/-/base64-1.0.1.tgz",
+      "integrity": "sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "26.1.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-26.1.2.tgz",
+      "integrity": "sha512-Vu4a5UFA9rIIFJ7rB/Vaafh9lrCQszopTCx6KjFboXTGQbPNasehVR5TEiithSDGyd1DEiUByggTZsg8jukeIg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~8.3.0"
+      }
+    },
+    "node_modules/@typescript/typescript-aix-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-aix-ppc64/-/typescript-aix-ppc64-7.0.2.tgz",
+      "integrity": "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-arm64/-/typescript-darwin-arm64-7.0.2.tgz",
+      "integrity": "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-darwin-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-darwin-x64/-/typescript-darwin-x64-7.0.2.tgz",
+      "integrity": "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-arm64/-/typescript-freebsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-freebsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-freebsd-x64/-/typescript-freebsd-x64-7.0.2.tgz",
+      "integrity": "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm/-/typescript-linux-arm-7.0.2.tgz",
+      "integrity": "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-arm64/-/typescript-linux-arm64-7.0.2.tgz",
+      "integrity": "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-loong64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-loong64/-/typescript-linux-loong64-7.0.2.tgz",
+      "integrity": "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-mips64el": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-mips64el/-/typescript-linux-mips64el-7.0.2.tgz",
+      "integrity": "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-ppc64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-ppc64/-/typescript-linux-ppc64-7.0.2.tgz",
+      "integrity": "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-riscv64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-riscv64/-/typescript-linux-riscv64-7.0.2.tgz",
+      "integrity": "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-s390x": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-s390x/-/typescript-linux-s390x-7.0.2.tgz",
+      "integrity": "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-linux-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-linux-x64/-/typescript-linux-x64-7.0.2.tgz",
+      "integrity": "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-arm64/-/typescript-netbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-netbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-netbsd-x64/-/typescript-netbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-arm64/-/typescript-openbsd-arm64-7.0.2.tgz",
+      "integrity": "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-openbsd-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-openbsd-x64/-/typescript-openbsd-x64-7.0.2.tgz",
+      "integrity": "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-sunos-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-sunos-x64/-/typescript-sunos-x64-7.0.2.tgz",
+      "integrity": "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-arm64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-arm64/-/typescript-win32-arm64-7.0.2.tgz",
+      "integrity": "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/@typescript/typescript-win32-x64": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/@typescript/typescript-win32-x64/-/typescript-win32-x64-7.0.2.tgz",
+      "integrity": "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-2.0.0.tgz",
+      "integrity": "sha512-5cvg6CtKwfgdmVqY1WIiXKc3Q1bkRqGLi+2W/6ao+6Y7gu/RCwRuAhGEzh5B4KlszSuTLgZYuqFqo5bImjNKng==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-types": "^3.0.0",
+        "negotiator": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/ajv": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
+      "integrity": "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "fast-uri": "^3.0.1",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-2.3.0.tgz",
+      "integrity": "sha512-2cGmJupaNgg+QUwVLAucDuWuoMZ6EX9iHDRswZ5lsNYEmwPaRknMPCLZz07yTzVq/83p4o/wzbDZbBrTvGGTIw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "^3.1.2",
+        "content-type": "^2.0.0",
+        "debug": "^4.4.3",
+        "http-errors": "^2.0.1",
+        "iconv-lite": "^0.7.2",
+        "on-finished": "^2.4.1",
+        "qs": "^6.15.2",
+        "raw-body": "^3.0.2",
+        "type-is": "^2.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/body-parser/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/bytes": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
+      "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.4.tgz",
+      "integrity": "sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "get-intrinsic": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/content-disposition": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.1.0.tgz",
+      "integrity": "sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/content-type": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
+      "integrity": "sha512-nTjqfcBFEipKdXCv4YDQWCfmcLZKm81ldF0pAopTvyrFGVbcR6P/VAAd5G7N+0tTr8QqiU0tFadD6FK4NtJwOA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
+      "integrity": "sha512-D76uU73ulSXrD1UXF4KE2TMxVVwhsnCgfAyTg9k8P6KGZjlXKrOLe4dJQKI3Bxi5wjesZoFXJWElNWBjPZMbhg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6.6.0"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.6",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
+      "integrity": "sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/effect": {
+      "version": "4.0.0-beta.101",
+      "resolved": "https://registry.npmjs.org/effect/-/effect-4.0.0-beta.101.tgz",
+      "integrity": "sha512-HjowumlIo+orthn4jMlEJPuzIYPBV+uq/XiciHWhiedLsXQpWHdNJHO5d59BVDP5s1LPuvERcktwFqRXnJqnhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
+        "fast-check": "^4.9.0",
+        "find-my-way-ts": "^0.1.6",
+        "ini": "^7.0.0",
+        "kubernetes-types": "^1.30.0",
+        "msgpackr": "^2.0.4",
+        "multipasta": "^0.2.8",
+        "toml": "^4.1.2",
+        "uuid": "^14.0.1",
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/eventsource": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
+      "integrity": "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "eventsource-parser": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/eventsource-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/eventsource-parser/-/eventsource-parser-3.1.0.tgz",
+      "integrity": "sha512-kJezFj9YFAMLeORyi7aCLxLbD5/qWMQnoMVlVPyHIll7lgRJCc3JVln9Vgl9nwQi0YkMnhdGTMNn7CkRRAptMg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/express": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/express/-/express-5.2.1.tgz",
+      "integrity": "sha512-hIS4idWWai69NezIdRt2xFVofaF4j+6INOpJlVOLDO8zXGpUVEVzIYk12UUi2JzjEzWL3IOAxcTubgz9Po0yXw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "accepts": "^2.0.0",
+        "body-parser": "^2.2.1",
+        "content-disposition": "^1.0.0",
+        "content-type": "^1.0.5",
+        "cookie": "^0.7.1",
+        "cookie-signature": "^1.2.1",
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "finalhandler": "^2.1.0",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.0",
+        "merge-descriptors": "^2.0.0",
+        "mime-types": "^3.0.0",
+        "on-finished": "^2.4.1",
+        "once": "^1.4.0",
+        "parseurl": "^1.3.3",
+        "proxy-addr": "^2.0.7",
+        "qs": "^6.14.0",
+        "range-parser": "^1.2.1",
+        "router": "^2.2.0",
+        "send": "^1.1.0",
+        "serve-static": "^2.2.0",
+        "statuses": "^2.0.1",
+        "type-is": "^2.0.1",
+        "vary": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/express-rate-limit": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.0.tgz",
+      "integrity": "sha512-XKJXDsASUOo0LLtFwW5hCcQGH0N4WQc/Rn8/Pvoia+TJFOkkFPvrtW9lZOeeNcxQJspvOIERMwiRLsVFlhHEkA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "ip-address": "^10.2.0"
+      },
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/express-rate-limit"
+      },
+      "peerDependencies": {
+        "express": ">= 4.11"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "4.9.0",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-4.9.0.tgz",
+      "integrity": "sha512-7ms6T7SybUev/PQITciI0yLM2pOSFy5zpG8Ty7tQofcVaQUvrMXp6CBwqF6fThLCLOrfBtuHAtwq6Yu4XPCllg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "pure-rand": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=12.17.0"
+      }
+    },
+    "node_modules/fast-deep-equal": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/fast-sha256": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/fast-sha256/-/fast-sha256-1.3.0.tgz",
+      "integrity": "sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==",
+      "license": "Unlicense",
+      "peer": true
+    },
+    "node_modules/fast-uri": {
+      "version": "3.1.4",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+      "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/fastify"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fastify"
+        }
+      ],
+      "license": "BSD-3-Clause",
+      "peer": true
+    },
+    "node_modules/finalhandler": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.1.tgz",
+      "integrity": "sha512-S8KoZgRZN+a5rNwqTxlZZePjT/4cnm0ROV70LedRHZ0p8u9fRID0hJUZQpkKLzro8LfmC8sx23bY6tVNxv8pQA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "on-finished": "^2.4.1",
+        "parseurl": "^1.3.3",
+        "statuses": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 18.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/find-my-way-ts": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/find-my-way-ts/-/find-my-way-ts-0.1.6.tgz",
+      "integrity": "sha512-a85L9ZoXtNAey3Y6Z+eBWW658kO/MwR7zIafkIUPUMf3isZG0NCs2pjW2wtjxAKuJPxMAsHUIP4ZPGv0o5gyTA==",
+      "license": "MIT"
+    },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-2.0.0.tgz",
+      "integrity": "sha512-Rx/WycZ60HOaqLKAi6cHRKKI7zxWbJ31MhntmtwMoaTeF7XFH9hhBp8vITaMidfljRQ6eYWCKkaTK+ykVJHP2A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/hono": {
+      "version": "4.12.31",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.31.tgz",
+      "integrity": "sha512-zJIHFrl6bq3RDd2YusFNCDlM8qUprxKswyi/OPzPyzKDdyBXDqWx8bZlZ7R+saTdSTatUmb3O7K4SspGPaEOQg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.9.0"
+      }
+    },
+    "node_modules/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "depd": "~2.0.0",
+        "inherits": "~2.0.4",
+        "setprototypeof": "~1.2.0",
+        "statuses": "~2.0.2",
+        "toidentifier": "~1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.7.3.tgz",
+      "integrity": "sha512-IKXpvIzjnC9XTAUbVBcMfGS0EPaIXtW6v+zr+RRp+hqULEpo0owZax6wyRwPOJbWbzjYspQwusTsfVr0ifh4uQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/ini": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-7.0.0.tgz",
+      "integrity": "sha512-ifK0CgjALofS5bkrcTy4RaQ9Vx2Knf/eLeIO+NaswQEpH1UblrtTSCIvN71qQDMq0PeQ/SSPojvEJp9vvvfr+w==",
+      "license": "ISC",
+      "engines": {
+        "node": "^22.22.2 || ^24.15.0 || >=26.0.0"
+      }
+    },
+    "node_modules/ip-address": {
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 12"
+      }
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-promise": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
+      "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/jose": {
+      "version": "6.2.4",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.2.4.tgz",
+      "integrity": "sha512-N8acGzVsQy6M/fjFcxtysNc4Q379TcM5dM/qKkNtsHFji88yANnXTr7BLeP75iPnFwBfQzM/jg2BZ9+HZrHCZA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
+      }
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/json-schema-typed": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/json-schema-typed/-/json-schema-typed-8.0.2.tgz",
+      "integrity": "sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==",
+      "license": "BSD-2-Clause",
+      "peer": true
+    },
+    "node_modules/kubernetes-types": {
+      "version": "1.30.0",
+      "resolved": "https://registry.npmjs.org/kubernetes-types/-/kubernetes-types-1.30.0.tgz",
+      "integrity": "sha512-Dew1okvhM/SQcIa2rcgujNndZwU8VnSapDgdxlYoB84ZlpAD43U6KLAFqYo17ykSFGHNPrg0qry0bP+GJd9v7Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-1.1.1.tgz",
+      "integrity": "sha512-yz3xRaG20c6/BOzvYoDaGtPmGscs7YivItZEEqe6GbwNfHuxu9YNmvnEkMzKldAGY4/80pRcQRZSEnhquk9XuQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-2.0.0.tgz",
+      "integrity": "sha512-Snk314V5ayFLhp3fkUREub6WtjBfPdCPY1Ln8/8munuLuiYhsABgBVWsozAG+MWMbVEvcdcpbi9R7ww22l9Q3g==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/msgpackr": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr/-/msgpackr-2.0.4.tgz",
+      "integrity": "sha512-o1C5KRmuRt+apqMr1HuGSqWStZoRBUpEsCsl15uM9VdAF1qHLtvMOU2En747EnTyEl6c4pzPewRMFF31s1CNbA==",
+      "license": "MIT",
+      "optionalDependencies": {
+        "msgpackr-extract": "^3.0.4"
+      }
+    },
+    "node_modules/msgpackr-extract": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/msgpackr-extract/-/msgpackr-extract-3.0.4.tgz",
+      "integrity": "sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-gyp-build-optional-packages": "5.2.2"
+      },
+      "bin": {
+        "download-msgpackr-prebuilds": "bin/download-prebuilds.js"
+      },
+      "optionalDependencies": {
+        "@msgpackr-extract/msgpackr-extract-darwin-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-darwin-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-arm64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-linux-x64": "3.0.4",
+        "@msgpackr-extract/msgpackr-extract-win32-x64": "3.0.4"
+      }
+    },
+    "node_modules/multipasta": {
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/multipasta/-/multipasta-0.2.8.tgz",
+      "integrity": "sha512-ZPWuMKyv0cSO29f7hozp+k6+crZbQijV8ipMvxNxRf2SwtYGTX1ZX89Kd20VV4H9Znonx+EQn+iy1wGQsJ+b+Q==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-1.0.0.tgz",
+      "integrity": "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-gyp-build-optional-packages": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/node-gyp-build-optional-packages/-/node-gyp-build-optional-packages-5.2.2.tgz",
+      "integrity": "sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.1"
+      },
+      "bin": {
+        "node-gyp-build-optional-packages": "bin.js",
+        "node-gyp-build-optional-packages-optional": "optional.js",
+        "node-gyp-build-optional-packages-test": "build-test.js"
+      }
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.4",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
+      "integrity": "sha512-W67iLl4J2EXEGTbfeHCffrjDfitvLANg0UlX3wFUUSTx92KXRFegMHUVgSqE+wvhAbi4WqjGg9czysTV2Epbew==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-8.4.2.tgz",
+      "integrity": "sha512-qRcuIdP69NPm4qbACK+aDogI5CBDMi1jKe0ry5rSQJz8JVLsC7jV8XpiJjGRLLol3N+R5ihGYcrPLTno6pAdBA==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/pkce-challenge": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/pkce-challenge/-/pkce-challenge-5.0.1.tgz",
+      "integrity": "sha512-wQ0b/W4Fr01qtpHlqSqspcj3EhBvimsdh0KlHhH8HRZnMsEa0ea2fTULOXOS9ccQr3om+GcGRk4e+isrZWV8qQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=16.20.0"
+      }
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "8.4.2",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-8.4.2.tgz",
+      "integrity": "sha512-vvuOGgcuPJAirlHvuQw1TrOiw7ptaIXXmIbNuiNOY6lNGJJH49PQ1Kj4nd783nPdQhQdicgOjVI2yI/9BD6/Ng==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.15.3",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
+      "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.3.0.tgz",
+      "integrity": "sha512-hek2mFQpPuI4E1BBKrSto+BU3e3x4xuarsbiwr3+lf7p44juvFMV0XFWQAP3xUyqXA4RrXLIoaSUGbSt056ZMw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/raw-body": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-3.0.2.tgz",
+      "integrity": "sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "bytes": "~3.1.2",
+        "http-errors": "~2.0.1",
+        "iconv-lite": "~0.7.0",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/router": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
+      "integrity": "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.0",
+        "depd": "^2.0.0",
+        "is-promise": "^4.0.0",
+        "parseurl": "^1.3.3",
+        "path-to-regexp": "^8.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/send": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/send/-/send-1.2.1.tgz",
+      "integrity": "sha512-1gnZf7DFcoIcajTjTwjwuDjzuz4PPcY2StKPlsGAQ1+YH20IRVrBaXSWmdjowTJ6u8Rc01PoYOGHXfP1mYcZNQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "debug": "^4.4.3",
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "etag": "^1.8.1",
+        "fresh": "^2.0.0",
+        "http-errors": "^2.0.1",
+        "mime-types": "^3.0.2",
+        "ms": "^2.1.3",
+        "on-finished": "^2.4.1",
+        "range-parser": "^1.2.1",
+        "statuses": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/serve-static": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-2.2.1.tgz",
+      "integrity": "sha512-xRXBn0pPqQTVQiC8wyQrKs2MOlX24zQ0POGaj0kultvoOCstBQM5yvOhAVSUwOMjQtTvsPWoNCHfPGwaaQJhTw==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "encodeurl": "^2.0.0",
+        "escape-html": "^1.0.3",
+        "parseurl": "^1.3.3",
+        "send": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/setprototypeof": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
+      "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.4"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/standardwebhooks": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/standardwebhooks/-/standardwebhooks-1.0.0.tgz",
+      "integrity": "sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@stablelib/base64": "^1.0.0",
+        "fast-sha256": "^1.3.0"
+      }
+    },
+    "node_modules/statuses": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
+      "integrity": "sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/toidentifier": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
+      "integrity": "sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=0.6"
+      }
+    },
+    "node_modules/toml": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/toml/-/toml-4.3.0.tgz",
+      "integrity": "sha512-lVb8X9BsPVuH0M4BKeS91tXAmJvCjQ5UIyAbQFaxkKGyUFK2RPkhwaFSQH8vbpl1d23eu/IBH+dwVMHWaq9A5A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/type-is": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-2.1.0.tgz",
+      "integrity": "sha512-faYHw0anBbc/kWF3zFTEnxSFOAGUX9GFbOBthvDdLsIlEoWOFOtS0zgCiQYwIskL9iGXZL3kAXD8OoZ4GmMATA==",
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "content-type": "^2.0.0",
+        "media-typer": "^1.1.0",
+        "mime-types": "^3.0.0"
+      },
+      "engines": {
+        "node": ">= 18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/type-is/node_modules/content-type": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
+      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-7.0.2.tgz",
+      "integrity": "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc"
+      },
+      "engines": {
+        "node": ">=16.20.0"
+      },
+      "optionalDependencies": {
+        "@typescript/typescript-aix-ppc64": "7.0.2",
+        "@typescript/typescript-darwin-arm64": "7.0.2",
+        "@typescript/typescript-darwin-x64": "7.0.2",
+        "@typescript/typescript-freebsd-arm64": "7.0.2",
+        "@typescript/typescript-freebsd-x64": "7.0.2",
+        "@typescript/typescript-linux-arm": "7.0.2",
+        "@typescript/typescript-linux-arm64": "7.0.2",
+        "@typescript/typescript-linux-loong64": "7.0.2",
+        "@typescript/typescript-linux-mips64el": "7.0.2",
+        "@typescript/typescript-linux-ppc64": "7.0.2",
+        "@typescript/typescript-linux-riscv64": "7.0.2",
+        "@typescript/typescript-linux-s390x": "7.0.2",
+        "@typescript/typescript-linux-x64": "7.0.2",
+        "@typescript/typescript-netbsd-arm64": "7.0.2",
+        "@typescript/typescript-netbsd-x64": "7.0.2",
+        "@typescript/typescript-openbsd-arm64": "7.0.2",
+        "@typescript/typescript-openbsd-x64": "7.0.2",
+        "@typescript/typescript-sunos-x64": "7.0.2",
+        "@typescript/typescript-win32-arm64": "7.0.2",
+        "@typescript/typescript-win32-x64": "7.0.2"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "8.3.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-8.3.0.tgz",
+      "integrity": "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/unpipe": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
+      "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "14.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.1.tgz",
+      "integrity": "sha512-6ZxzVpzDXDa3bJWaHilVayA+BH/1zmxCJoVgvmqJnid/gPoKHxUrS/aC/T6LGQtNHT+XHG9fXPJB4d+IrU30Ew==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist-node/bin/uuid"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "peer": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC",
+      "peer": true
+    },
+    "node_modules/yaml": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
+      "integrity": "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==",
+      "license": "ISC",
+      "bin": {
+        "yaml": "bin.mjs"
+      },
+      "engines": {
+        "node": ">= 14.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/eemeli"
+      }
+    },
+    "node_modules/zod": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
+      }
+    },
+    "node_modules/zod-to-json-schema": {
+      "version": "3.25.2",
+      "resolved": "https://registry.npmjs.org/zod-to-json-schema/-/zod-to-json-schema-3.25.2.tgz",
+      "integrity": "sha512-O/PgfnpT1xKSDeQYSCfRI5Gy3hPf91mKVDuYLUHZJMiDFptvP41MSnWofm8dnCm0256ZNfZIM7DSzuSMAFnjHA==",
+      "license": "ISC",
+      "peer": true,
+      "peerDependencies": {
+        "zod": "^3.25.28 || ^4"
+      }
+    }
+  }
+}

--- a/users/profiles/pi/extensions/subagents/package.json
+++ b/users/profiles/pi/extensions/subagents/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "subagents",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "check": "tsc --noEmit -p .",
+    "prepare": "effect-tsgo patch",
+    "test": "node --test --experimental-strip-types manager.test.ts pi-backend.test.ts result-delivery.test.ts context-usage.test.ts takeover.test.ts by-the-way.test.ts",
+    "test:live": "node --test --experimental-strip-types claude.test.ts"
+  },
+  "dependencies": {
+    "@anthropic-ai/claude-agent-sdk": "^0.3.216",
+    "effect": "4.0.0-beta.101"
+  },
+  "devDependencies": {
+    "@effect/tsgo": "^0.24.2",
+    "@types/node": "^26.1.1",
+    "typescript": "^7.0.2"
+  }
+}

--- a/users/profiles/pi/extensions/subagents/pi-backend.test.ts
+++ b/users/profiles/pi/extensions/subagents/pi-backend.test.ts
@@ -1,0 +1,62 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  finalOutput,
+  indexAfterMessageBoundary,
+} from "./src/backends/pi.ts";
+
+function fakeSession(messages: unknown[]) {
+  return { messages } as unknown as Parameters<typeof finalOutput>[0];
+}
+
+test("Pi final output is bounded to the current run", () => {
+  const session = fakeSession([
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "answer from the previous turn" }],
+    },
+    { role: "user", content: "new turn" },
+    {
+      role: "assistant",
+      content: [{ type: "thinking", thinking: "failed before answering" }],
+    },
+  ]);
+
+  assert.equal(finalOutput(session), "answer from the previous turn");
+  assert.equal(finalOutput(session, 1), "");
+});
+
+test("Pi final output still returns text produced in the current run", () => {
+  const session = fakeSession([
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "old" }],
+    },
+    { role: "user", content: "new turn" },
+    {
+      role: "assistant",
+      content: [{ type: "text", text: "new" }],
+    },
+  ]);
+
+  assert.equal(finalOutput(session, 1), "new");
+});
+
+test("Pi run boundary follows message identity across compaction", () => {
+  const boundary = { role: "assistant", content: [] };
+  const retained = [
+    { role: "assistant", content: [] },
+    boundary,
+    { role: "user", content: "new turn" },
+  ];
+  assert.equal(indexAfterMessageBoundary(retained, boundary), 2);
+
+  // Compaction replaced the array and discarded the boundary. Length alone
+  // cannot detect this when the replacement is equally long or longer.
+  const replaced = [
+    { role: "compactionSummary" },
+    { role: "user", content: "new turn" },
+    { role: "assistant", content: [] },
+  ];
+  assert.equal(indexAfterMessageBoundary(replaced, boundary), 0);
+});

--- a/users/profiles/pi/extensions/subagents/result-delivery.test.ts
+++ b/users/profiles/pi/extensions/subagents/result-delivery.test.ts
@@ -1,0 +1,27 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { createDeferredResultDelivery } from "./src/result-delivery.ts";
+
+test("a result consumed by a later wait is not delivered", () => {
+  const delivery = createDeferredResultDelivery<{
+    id: string;
+    output: string;
+  }>();
+
+  delivery.defer({ id: "sa-1", output: "done" });
+  delivery.consume(["sa-1"]);
+
+  assert.deepEqual(delivery.drain(), []);
+});
+
+test("unconsumed results are delivered once in settlement order", () => {
+  const delivery = createDeferredResultDelivery<{ id: string }>();
+  const first = { id: "sa-1" };
+  const second = { id: "sa-2" };
+
+  delivery.defer(first);
+  delivery.defer(second);
+
+  assert.deepEqual(delivery.drain(), [first, second]);
+  assert.deepEqual(delivery.drain(), []);
+});

--- a/users/profiles/pi/extensions/subagents/src/backend.ts
+++ b/users/profiles/pi/extensions/subagents/src/backend.ts
@@ -1,0 +1,61 @@
+/**
+ * Unified backend interface for in-process Pi and Claude Code sessions.
+ * Both produce the same `SubagentSession` shape consumed by the manager.
+ */
+
+import type { Effect, Scope, Stream } from "effect";
+import { Context } from "effect";
+import type {
+  BackendName,
+  SendError,
+  SpawnError,
+  SpawnTask,
+  SubagentEvent,
+  SubagentMeta,
+} from "./domain.ts";
+
+
+/**
+ * A live subagent session. The manager is the single consumer of `events`;
+ * it folds them into the `SubagentSnapshot` everything else reads.
+ */
+export interface SubagentSession {
+  /** Current metadata snapshot. Updates also arrive as MetaChanged events. */
+  readonly meta: Effect.Effect<SubagentMeta>;
+  /**
+   * All activity, normalized. Ends when the session's scope closes. Every
+   * run started within the session terminates with a RunSettled event.
+   */
+  readonly events: Stream.Stream<SubagentEvent>;
+  /**
+   * Steer the active run, or start a fresh run when idle (v1 `manager.send`
+   * semantics — the "is a run active" decision is backend-native state).
+   */
+  send(text: string): Effect.Effect<void, SendError>;
+  /**
+   * Interrupt the active run. Resolves once the backend acknowledges; the
+   * corresponding RunSettled(Interrupted) arrives on `events`. Callers bound
+   * this with a timeout and fall back to closing the session scope.
+   */
+  readonly interrupt: Effect.Effect<void>;
+}
+
+export interface SubagentBackend {
+  readonly name: BackendName;
+  /** Probe availability (binary on PATH, SDK importable, credentials). */
+  readonly available: Effect.Effect<boolean>;
+  /**
+   * Spawn a session. Scoped: closing the scope interrupts/kills the
+   * underlying session or process and ends `events`. Fire-and-forget
+   * semantics (background fibers, result delivery) live in the manager.
+   */
+  spawn(
+    task: SpawnTask,
+  ): Effect.Effect<SubagentSession, SpawnError, Scope.Scope>;
+}
+
+/** Registry of all wired backends, keyed by name. */
+export class BackendRegistry extends Context.Service<
+  BackendRegistry,
+  ReadonlyMap<BackendName, SubagentBackend>
+>()("subagents/BackendRegistry") {}

--- a/users/profiles/pi/extensions/subagents/src/backends/claude.ts
+++ b/users/profiles/pi/extensions/subagents/src/backends/claude.ts
@@ -1,0 +1,716 @@
+/**
+ * Claude Code backend — real implementation over the Claude Agent SDK.
+ *
+ * One SDK `query()` and one streaming-input bridge live for the whole scoped
+ * session. User sends are pushed into that bridge, while the query iterator is
+ * pumped in the background and translated to normalized SubagentEvents. The
+ * CLI therefore owns conversation continuity, tool execution, and persisted
+ * `~/.claude/projects` transcripts; this file only owns lifecycle guarantees
+ * and the normalized view consumed by the manager.
+ */
+
+import { randomUUID } from "node:crypto";
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import {
+  query,
+  type SDKAssistantMessage,
+  type SDKMessage,
+  type SDKResultMessage,
+  type SDKUserMessage,
+} from "@anthropic-ai/claude-agent-sdk";
+import type { Cause, Scope } from "effect";
+import { Effect, Queue, Stream } from "effect";
+import type { SubagentBackend, SubagentSession } from "../backend.ts";
+import type {
+  QueuedMessage,
+  ReasoningEffort,
+  RunOutcome,
+  SpawnTask,
+  SubagentEvent,
+  SubagentMeta,
+  TranscriptPart,
+} from "../domain.ts";
+import { SendError, SpawnError } from "../domain.ts";
+
+const CLAUDE_CONTEXT_WINDOW = 200_000;
+const INTERRUPT_TIMEOUT_MS = 2_000;
+const PREVIEW_MAX_LENGTH = 4_096;
+const SUBMITTED_UUID_LIMIT = 256;
+
+// --- Binary resolution --------------------------------------------------------
+
+let cachedClaudeBinary: string | undefined;
+
+function executable(file: string) {
+  try {
+    fs.accessSync(file, fs.constants.X_OK);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Prefer a user-installed CLI when present; cache only successful resolution
+ * so installing or removing Claude during a Pi session is observed.
+ */
+function resolveClaudeBinary() {
+  if (cachedClaudeBinary && executable(cachedClaudeBinary))
+    return cachedClaudeBinary;
+  cachedClaudeBinary = undefined;
+  const names =
+    process.platform === "win32"
+      ? ["claude.exe", "claude.cmd", "claude"]
+      : ["claude"];
+  for (const directory of (process.env.PATH ?? "").split(path.delimiter)) {
+    if (!directory) continue;
+    for (const name of names) {
+      const candidate = path.join(directory, name);
+      if (executable(candidate)) {
+        cachedClaudeBinary = candidate;
+        return candidate;
+      }
+    }
+  }
+  return undefined;
+}
+
+// --- Streaming input ---------------------------------------------------------
+
+/** A single-consumer push queue adapted to the SDK's AsyncIterable input. */
+class ClaudeInput implements AsyncIterable<SDKUserMessage> {
+  private pending: SDKUserMessage[] = [];
+  private waiter:
+    ((result: IteratorResult<SDKUserMessage>) => void) | undefined;
+  private closed = false;
+
+  push(text: string) {
+    if (this.closed) return undefined;
+    const message: SDKUserMessage = {
+      type: "user",
+      message: { role: "user", content: text },
+      parent_tool_use_id: null,
+      // Stamped UUIDs make queued messages visible in interrupt receipts.
+      uuid: randomUUID(),
+    };
+    const waiter = this.waiter;
+    if (waiter) {
+      this.waiter = undefined;
+      waiter({ value: message, done: false });
+    } else {
+      this.pending.push(message);
+    }
+    return message;
+  }
+
+  clear() {
+    return this.pending.splice(0);
+  }
+
+  end() {
+    if (this.closed) return;
+    this.closed = true;
+    const waiter = this.waiter;
+    this.waiter = undefined;
+    waiter?.({ value: undefined, done: true });
+  }
+
+  async *[Symbol.asyncIterator]() {
+    while (true) {
+      const message = this.pending.shift();
+      if (message) {
+        yield message;
+        continue;
+      }
+      if (this.closed) return;
+      const next = await new Promise<IteratorResult<SDKUserMessage>>(
+        (resolve) => {
+          this.waiter = resolve;
+        },
+      );
+      if (next.done) return;
+      yield next.value;
+    }
+  }
+}
+
+// --- Model, effort, and transcript helpers ----------------------------------
+
+/**
+ * Claude's deprecated-but-supported maxThinkingTokens is the closest match to
+ * the shared numeric scale requested by this extension. Zero explicitly
+ * disables extended thinking in SDK 0.3.207; an omitted effort leaves the CLI
+ * default untouched.
+ */
+const THINKING_BUDGETS = {
+  off: 0,
+  minimal: 1_024,
+  low: 4_096,
+  medium: 10_000,
+  high: 16_000,
+  xhigh: 32_000,
+  max: 63_999,
+} satisfies Record<ReasoningEffort, number>;
+
+function boundedError(error: unknown) {
+  return (error instanceof Error ? error.message : String(error)).slice(
+    0,
+    4_096,
+  );
+}
+
+function singleLine(text: string) {
+  const flattened = text.replace(/\s+/g, " ").trim();
+  return flattened ? flattened.slice(0, PREVIEW_MAX_LENGTH) : undefined;
+}
+
+function safeJson(value: unknown) {
+  try {
+    const text = JSON.stringify(value);
+    if (!text || text === "{}") return undefined;
+    return singleLine(text);
+  } catch {
+    return undefined;
+  }
+}
+
+function outputPreview(value: unknown): string | undefined {
+  if (typeof value === "string") return singleLine(value);
+  if (Array.isArray(value)) {
+    const text = value
+      .flatMap((part) => {
+        if (!part || typeof part !== "object") return [];
+        const record = part as { type?: unknown; text?: unknown };
+        return record.type === "text" && typeof record.text === "string"
+          ? [record.text]
+          : [];
+      })
+      .join(" ");
+    return singleLine(text) ?? safeJson(value);
+  }
+  return safeJson(value);
+}
+
+function assistantParts(message: SDKAssistantMessage): TranscriptPart[] {
+  const parts: TranscriptPart[] = [];
+  for (const block of message.message.content) {
+    if (block.type === "text") {
+      parts.push({ type: "text", text: block.text });
+    } else if (block.type === "thinking") {
+      parts.push({ type: "thinking", text: block.thinking });
+    } else if (block.type === "redacted_thinking") {
+      parts.push({ type: "thinking", text: "", redacted: true });
+    } else if (block.type === "tool_use") {
+      parts.push({
+        type: "toolCall",
+        toolId: block.id,
+        name: block.name,
+        argsPreview: safeJson(block.input),
+      });
+    }
+  }
+  return parts;
+}
+
+/** Claude Code's project-directory escaping, verified against CLI 2.1.207. */
+function sessionFilePath(cwd: string, sessionId: string) {
+  const projectDirectory = cwd.replace(/[/.]/g, "-");
+  return path.join(
+    os.homedir(),
+    ".claude",
+    "projects",
+    projectDirectory,
+    `${sessionId}.jsonl`,
+  );
+}
+
+/**
+ * Context occupancy after one API request. An assistant message's `usage`
+ * describes only that request: the full prompt (fresh + cache-read +
+ * cache-written input) plus this response's output — exactly what now sits
+ * in the context window. The result message's `usage` instead sums these
+ * per-request counts across the whole run, so a multi-request turn
+ * re-counts cached context once per request and quickly exceeds the real
+ * window; it must never be treated as occupancy.
+ */
+export function contextOccupancyTokens(
+  usage:
+    | {
+        input_tokens?: number | null;
+        cache_read_input_tokens?: number | null;
+        cache_creation_input_tokens?: number | null;
+        output_tokens?: number | null;
+      }
+    | null
+    | undefined,
+) {
+  if (!usage || typeof usage.input_tokens !== "number") return undefined;
+  const count = (value: number | null | undefined) =>
+    typeof value === "number" && Number.isFinite(value) ? value : 0;
+  return (
+    count(usage.input_tokens) +
+    count(usage.cache_read_input_tokens) +
+    count(usage.cache_creation_input_tokens) +
+    count(usage.output_tokens)
+  );
+}
+
+function resultContextWindow(result: SDKResultMessage) {
+  return Object.values(result.modelUsage)[0]?.contextWindow;
+}
+
+function waitBounded(operation: Promise<unknown>, timeoutMs: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  return Promise.race([
+    operation.then(
+      () => undefined,
+      () => undefined,
+    ),
+    timeout,
+  ]).finally(() => {
+    if (timer) clearTimeout(timer);
+  });
+}
+
+// --- The session -------------------------------------------------------------
+
+interface NativeQueuedMessage extends QueuedMessage {
+  readonly uuid: string;
+  /** Raw response sequence after which this steer can be consumed. */
+  readonly afterResponse: number;
+}
+
+const makeClaudeSession = (
+  task: SpawnTask,
+): Effect.Effect<SubagentSession, SpawnError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const input = new ClaudeInput();
+    const abortController = new AbortController();
+    const events = yield* Queue.make<SubagentEvent, Cause.Done>();
+    const emit = (event: SubagentEvent) => {
+      Queue.offerUnsafe(events, event);
+    };
+
+    const state = {
+      closed: false,
+      activeRun: false,
+      interruptRequested: false,
+      runVersion: 0,
+      lastSettledVersion: 0,
+      responseSequence: 0,
+      queued: [] as NativeQueuedMessage[],
+      submittedUuids: new Set<string>(),
+      currentText: "",
+      liveText: "",
+      tools: new Map<string, string>(),
+      settleWaiters: new Set<() => void>(),
+      meta: {
+        backend: "claude",
+        modelLabel: task.model,
+        // Claude models used by this backend currently expose 200k context;
+        // result.modelUsage replaces this fallback when the CLI knows better.
+        contextWindow: CLAUDE_CONTEXT_WINDOW,
+      } satisfies SubagentMeta as SubagentMeta,
+    };
+
+    const trackSubmittedUuid = (uuid: string | undefined) => {
+      if (!uuid) return;
+      state.submittedUuids.add(uuid);
+      if (state.submittedUuids.size <= SUBMITTED_UUID_LIMIT) return;
+      const oldest = state.submittedUuids.values().next().value;
+      if (oldest !== undefined) state.submittedUuids.delete(oldest);
+    };
+
+    const thinkingBudget = task.reasoningEffort
+      ? THINKING_BUDGETS[task.reasoningEffort]
+      : undefined;
+    const claudeBinary = resolveClaudeBinary();
+    const nativeQuery = yield* Effect.try({
+      try: () =>
+        query({
+          prompt: input,
+          options: {
+            cwd: task.cwd,
+            // Headless children cannot answer approval prompts. The caller
+            // already chose to launch an autonomous subagent, so let it use
+            // its tools without interactive permission checks.
+            permissionMode: "bypassPermissions",
+            allowDangerouslySkipPermissions: true,
+            // Keep child orchestration inside this extension's global manager
+            // and concurrency cap rather than Claude Code's native subagents.
+            disallowedTools: ["Agent", "Task"],
+            // For cwds pi marked untrusted, restrict to user-level settings so
+            // an untrusted project's config cannot reconfigure the child.
+            ...(task.parent.projectTrusted
+              ? {}
+              : { settingSources: ["user" as const] }),
+            includePartialMessages: true,
+            abortController,
+            ...(claudeBinary
+              ? { pathToClaudeCodeExecutable: claudeBinary }
+              : {}),
+            ...(task.model ? { model: task.model } : {}),
+            ...(thinkingBudget !== undefined
+              ? { maxThinkingTokens: thinkingBudget }
+              : {}),
+          },
+        }),
+      catch: (error) => new SpawnError({ message: boundedError(error) }),
+    });
+
+    let resolvePumpDone: (() => void) | undefined;
+    const pumpDone = new Promise<void>((resolve) => {
+      resolvePumpDone = resolve;
+    });
+
+    const queuedView = (): ReadonlyArray<QueuedMessage> =>
+      state.queued.map(({ text, kind }) => ({ text, kind }));
+
+    const notifySettled = () => {
+      for (const waiter of state.settleWaiters) waiter();
+      state.settleWaiters.clear();
+    };
+
+    const partialText = () => state.liveText || state.currentText || undefined;
+
+    const settle = (outcome: RunOutcome) => {
+      if (!state.activeRun) return;
+      emit({ _tag: "RunSettled", outcome });
+      state.activeRun = false;
+      state.lastSettledVersion = state.runVersion;
+      state.interruptRequested = false;
+      state.liveText = "";
+      notifySettled();
+    };
+
+    const updateMeta = (patch: Partial<SubagentMeta>) => {
+      state.meta = { ...state.meta, ...patch };
+      emit({ _tag: "MetaChanged", meta: patch });
+    };
+
+    const beginQueuedRunIfNeeded = () => {
+      if (state.activeRun || state.queued.length === 0) return;
+      // A steer arriving too late for the prior turn becomes a fresh queued
+      // turn. The repeated init is the first reliable signal that it started.
+      state.activeRun = true;
+      state.runVersion++;
+      state.currentText = "";
+      state.liveText = "";
+      emit({ _tag: "RunStarted" });
+    };
+
+    const clearConsumedSteers = () => {
+      const remaining: NativeQueuedMessage[] = [];
+      for (const message of state.queued) {
+        if (message.afterResponse < state.responseSequence) {
+          state.submittedUuids.delete(message.uuid);
+        } else {
+          remaining.push(message);
+        }
+      }
+      if (remaining.length === state.queued.length) return;
+      state.queued = remaining;
+      emit({ _tag: "QueueChanged", queued: queuedView() });
+    };
+
+    const handleAssistant = (message: SDKAssistantMessage) => {
+      const parts = assistantParts(message);
+      if (parts.length > 0) emit({ _tag: "AssistantMessage", parts });
+
+      // Top-level messages only: subagent (sidechain) requests have their own
+      // context and must not overwrite this conversation's occupancy.
+      if (message.parent_tool_use_id == null) {
+        const tokens = contextOccupancyTokens(message.message.usage);
+        if (tokens !== undefined) emit({ _tag: "UsageChanged", tokens });
+      }
+
+      const text = message.message.content
+        .filter((block) => block.type === "text")
+        .map((block) => block.text)
+        .join("\n")
+        .trim();
+      if (text) state.currentText = text;
+      state.liveText = "";
+
+      if (message.message.model !== state.meta.modelLabel) {
+        updateMeta({ modelLabel: message.message.model });
+      }
+      for (const block of message.message.content) {
+        if (block.type !== "tool_use") continue;
+        state.tools.set(block.id, block.name);
+        emit({
+          _tag: "ToolStart",
+          toolId: block.id,
+          name: block.name,
+          argsPreview: safeJson(block.input),
+        });
+      }
+    };
+
+    const handleUser = (message: SDKUserMessage) => {
+      const content = message.message.content;
+      if (!Array.isArray(content)) return;
+      for (const block of content) {
+        if (block.type !== "tool_result") continue;
+        const name = state.tools.get(block.tool_use_id) ?? "Tool";
+        state.tools.delete(block.tool_use_id);
+        emit({
+          _tag: "ToolEnd",
+          toolId: block.tool_use_id,
+          name,
+          isError: block.is_error ?? false,
+          outputPreview: outputPreview(block.content),
+        });
+      }
+      // External prompts are emitted synchronously by submit(); ignoring text
+      // here prevents a future CLI echo from duplicating the transcript row.
+    };
+
+    const handleResult = (result: SDKResultMessage) => {
+      // result.usage is a whole-run aggregate, not occupancy (see
+      // contextOccupancyTokens); only the capacity is trustworthy here. The
+      // occupancy itself was already emitted by the last assistant message.
+      const contextWindow = resultContextWindow(result);
+      emit({
+        _tag: "UsageChanged",
+        contextWindow: contextWindow ?? state.meta.contextWindow,
+      });
+      if (
+        contextWindow !== undefined &&
+        contextWindow !== state.meta.contextWindow
+      ) {
+        updateMeta({ contextWindow });
+      }
+
+      if (state.interruptRequested) {
+        settle({ _tag: "Interrupted", partialText: partialText() });
+      } else if (result.subtype === "success") {
+        settle({
+          _tag: "Completed",
+          finalText: result.result.trim() || state.currentText,
+        });
+      } else {
+        const details =
+          result.errors.filter((error) => error.trim()).join("\n") ||
+          result.stop_reason ||
+          `Claude Code ended with ${result.subtype}`;
+        settle({
+          _tag: "Failed",
+          errorText: boundedError(details),
+          partialText: partialText(),
+        });
+      }
+    };
+
+    const handleMessage = (message: SDKMessage) => {
+      if (state.closed) return;
+      // A queued steer's turn normally announces itself with a repeated
+      // system/init, but any turn activity is an equally valid begin signal —
+      // without this, a missed init would stream events into a "done" run
+      // that could then never settle.
+      if (
+        message.type === "stream_event" ||
+        message.type === "assistant" ||
+        message.type === "result"
+      ) {
+        beginQueuedRunIfNeeded();
+      }
+      if (message.type === "system" && message.subtype === "init") {
+        beginQueuedRunIfNeeded();
+        updateMeta({
+          modelLabel: message.model,
+          nativeSessionId: message.session_id,
+          sessionFilePath: sessionFilePath(message.cwd, message.session_id),
+          contextWindow: CLAUDE_CONTEXT_WINDOW,
+        });
+      } else if (message.type === "stream_event") {
+        if (message.parent_tool_use_id !== null) return;
+        if (message.event.type === "message_start") {
+          state.responseSequence++;
+          clearConsumedSteers();
+        } else if (message.event.type === "content_block_delta") {
+          const delta = message.event.delta;
+          if (delta.type === "text_delta") {
+            state.liveText += delta.text;
+            emit({ _tag: "AssistantDelta", kind: "text", delta: delta.text });
+          } else if (delta.type === "thinking_delta") {
+            emit({
+              _tag: "AssistantDelta",
+              kind: "thinking",
+              delta: delta.thinking,
+            });
+          }
+        }
+      } else if (message.type === "assistant") {
+        handleAssistant(message);
+      } else if (message.type === "user") {
+        handleUser(message);
+      } else if (message.type === "result") {
+        handleResult(message);
+      }
+    };
+
+    const pump = async () => {
+      let failure: string | undefined;
+      try {
+        for await (const message of nativeQuery) handleMessage(message);
+      } catch (error) {
+        if (!state.closed && !abortController.signal.aborted) {
+          failure = boundedError(error);
+        }
+      } finally {
+        if (!state.closed) {
+          if (state.activeRun) {
+            settle(
+              state.interruptRequested
+                ? { _tag: "Interrupted", partialText: partialText() }
+                : {
+                    _tag: "Failed",
+                    errorText:
+                      failure ?? "Claude Code query ended unexpectedly",
+                    partialText: partialText(),
+                  },
+            );
+          } else if (failure) {
+            emit({ _tag: "BackendError", message: failure });
+          }
+          state.closed = true;
+          Queue.endUnsafe(events);
+        }
+        resolvePumpDone?.();
+      }
+    };
+
+    yield* Effect.addFinalizer(() =>
+      Effect.promise(async () => {
+        // Settle before marking closed: the pump's finally skips settlement
+        // once closed, and every run must end in a RunSettled even when the
+        // scope closes mid-run.
+        if (state.activeRun) {
+          settle({ _tag: "Interrupted", partialText: partialText() });
+        }
+        state.closed = true;
+        input.end();
+        abortController.abort();
+        nativeQuery.close();
+        await waitBounded(pumpDone, INTERRUPT_TIMEOUT_MS);
+        Queue.endUnsafe(events);
+      }),
+    );
+
+    void pump();
+
+    const submit = (text: string) => {
+      const wasActive = state.activeRun;
+      const message = input.push(text);
+      if (!message) return false;
+      trackSubmittedUuid(message.uuid);
+      if (!wasActive) {
+        state.activeRun = true;
+        state.runVersion++;
+        state.currentText = "";
+        state.liveText = "";
+      }
+      // Idle restarts flip status synchronously (like pi's startRun); a steer
+      // into an active run must NOT re-emit RunStarted — its own turn begins
+      // later via beginQueuedRunIfNeeded.
+      if (!wasActive) emit({ _tag: "RunStarted" });
+      emit({ _tag: "UserMessage", text });
+      if (wasActive) {
+        state.queued.push({
+          text,
+          kind: "steer",
+          uuid: message.uuid ?? "",
+          afterResponse: state.responseSequence,
+        });
+        emit({ _tag: "QueueChanged", queued: queuedView() });
+      }
+      return true;
+    };
+
+    const waitForVersion = (version: number) => {
+      if (state.lastSettledVersion >= version) return Promise.resolve();
+      return new Promise<void>((resolve) => {
+        const waiter = () => {
+          if (state.lastSettledVersion < version && !state.closed) return;
+          state.settleWaiters.delete(waiter);
+          resolve();
+        };
+        state.settleWaiters.add(waiter);
+      });
+    };
+
+    emit({ _tag: "MetaChanged", meta: state.meta });
+    submit(task.prompt);
+
+    return {
+      meta: Effect.sync(() => state.meta),
+      events: Stream.fromQueue(events),
+      send: (text) =>
+        Effect.suspend((): Effect.Effect<void, SendError> => {
+          if (state.closed) {
+            return new SendError({ message: "Subagent session is closed." });
+          }
+          return submit(text)
+            ? Effect.void
+            : new SendError({ message: "Subagent session is closed." });
+        }),
+      interrupt: Effect.promise(async () => {
+        if (state.closed || !state.activeRun) return;
+        const version = state.runVersion;
+        state.interruptRequested = true;
+        input.clear();
+        state.queued = [];
+        emit({ _tag: "QueueChanged", queued: [] });
+
+        const interruptAndSettle = (async () => {
+          try {
+            const receipt = await nativeQuery.interrupt();
+            const hasOwnQueuedMessage = receipt?.still_queued?.some((uuid) =>
+              state.submittedUuids.has(uuid),
+            );
+            state.submittedUuids.clear();
+            if (hasOwnQueuedMessage) {
+              // 0.3.207 exposes cancellation receipts but no public per-message
+              // cancel method. Closing is the only way to prevent a cancelled
+              // queued prompt from immediately starting another turn.
+              input.end();
+              nativeQuery.close();
+            }
+          } catch (error) {
+            if (!state.closed) {
+              emit({ _tag: "BackendError", message: boundedError(error) });
+            }
+          }
+          await waitForVersion(version);
+        })();
+
+        await waitBounded(interruptAndSettle, INTERRUPT_TIMEOUT_MS);
+        if (!state.closed && state.activeRun && state.runVersion === version) {
+          // Covers pre-init/pending races and SDK versions that acknowledge an
+          // interrupt without delivering a result. Force-close after settling
+          // so a late native result cannot resurrect or re-settle this run.
+          settle({ _tag: "Interrupted", partialText: partialText() });
+          state.closed = true;
+          input.end();
+          abortController.abort();
+          nativeQuery.close();
+          Queue.endUnsafe(events);
+        }
+      }),
+    } satisfies SubagentSession;
+  });
+
+// --- Backend -----------------------------------------------------------------
+
+export const claudeBackend: SubagentBackend = {
+  name: "claude",
+  // The SDK bundles a CLI; PATH resolution only selects a preferred external one.
+  available: Effect.succeed(true),
+  spawn: makeClaudeSession,
+};

--- a/users/profiles/pi/extensions/subagents/src/backends/pi.ts
+++ b/users/profiles/pi/extensions/subagents/src/backends/pi.ts
@@ -1,0 +1,613 @@
+/**
+ * pi backend — real implementation over the pi SDK.
+ *
+ * Each subagent is an in-process `AgentSession` (a port of v1
+ * subagents/manager.ts + shared/child-session.ts):
+ * - real session files visible in /resume, child resources loaded per-cwd
+ *   with trust gating, and the child tool denylist;
+ * - `session.subscribe()` events translated to normalized SubagentEvents;
+ * - send() steers a streaming run or starts a fresh prompt() when idle;
+ * - interrupt clears the queue and aborts; closing the session scope emits
+ *   the child session_shutdown hook and disposes the session.
+ */
+
+import type { AssistantMessage, Message, Model } from "@earendil-works/pi-ai";
+import type {
+  AgentSession,
+  AgentSessionEvent,
+  ModelRegistry,
+} from "@earendil-works/pi-coding-agent";
+import {
+  createAgentSession,
+  DefaultResourceLoader,
+  getAgentDir,
+  SessionManager,
+  SettingsManager,
+} from "@earendil-works/pi-coding-agent";
+import type { Cause, Scope } from "effect";
+import { Effect, Queue, Stream } from "effect";
+import type { SubagentBackend, SubagentSession } from "../backend.ts";
+import type {
+  SpawnTask,
+  SubagentEvent,
+  SubagentMeta,
+  TranscriptPart,
+} from "../domain.ts";
+import { SendError, SpawnError } from "../domain.ts";
+import { createToolCallTimeoutGuard } from "../tool-call-timeout.ts";
+
+const CHILD_SHUTDOWN_TIMEOUT_MS = 5_000;
+
+/** Tools that headless children must not receive. Everything else stays enabled. */
+const CHILD_EXCLUDED_TOOL_NAMES = [
+  "subagent_spawn",
+  "subagent_wait",
+  "subagent_cancel",
+  "subagent_check",
+  "subagent_list",
+  "workflow",
+  "ask_user",
+] as const;
+
+// --- Model + effort resolution -----------------------------------------------
+
+type ThinkingLevel = NonNullable<
+  NonNullable<Parameters<typeof createAgentSession>[0]>["thinkingLevel"]
+>;
+
+/**
+ * Resolve the generic model hint against the parent registry (v1 semantics):
+ * "provider/model-id" is exact; a bare id prefers the inherited provider,
+ * then must be unambiguous across providers. No hint inherits the parent
+ * model; with nothing to inherit, the SDK default applies.
+ */
+function resolvePiModel(
+  registry: ModelRegistry,
+  hint: string | undefined,
+  inherited: { provider: string; id: string } | undefined,
+): Model<any> | undefined {
+  if (!hint) {
+    if (!inherited) return undefined;
+    return registry.find(inherited.provider, inherited.id) ?? undefined;
+  }
+  const slash = hint.indexOf("/");
+  if (slash > 0) {
+    const provider = hint.slice(0, slash);
+    const id = hint.slice(slash + 1);
+    const found = registry.find(provider, id);
+    if (found) return found;
+    throw new Error(`Unknown model "${hint}".`);
+  }
+  if (inherited) {
+    const found = registry.find(inherited.provider, hint);
+    if (found) return found;
+  }
+  const matches = registry.getAll().filter((m) => m.id === hint);
+  if (matches.length === 1) return matches[0];
+  if (matches.length > 1) {
+    throw new Error(
+      `Model "${hint}" exists in multiple providers (${matches.map((m) => m.provider).join(", ")}). Use "provider/${hint}".`,
+    );
+  }
+  throw new Error(`Unknown model "${hint}".`);
+}
+
+// --- Child session helpers (ported from v1 shared/child-session.ts) -----------
+
+/** Load normal global/package resources and trust-gated project resources. */
+async function createChildResources(cwd: string, projectTrusted: boolean) {
+  const agentDir = getAgentDir();
+  const settingsManager = SettingsManager.create(cwd, agentDir, {
+    projectTrusted,
+  });
+  const loader = new DefaultResourceLoader({ cwd, agentDir, settingsManager });
+  await loader.reload();
+  return { loader, settingsManager };
+}
+
+function waitBounded(operation: Promise<unknown>, timeoutMs: number) {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<void>((resolve) => {
+    timer = setTimeout(resolve, timeoutMs);
+  });
+  return Promise.race([
+    operation.then(
+      () => undefined,
+      () => undefined,
+    ),
+    timeout,
+  ])
+    .catch(() => {})
+    .finally(() => {
+      if (timer) clearTimeout(timer);
+    });
+}
+
+/** Emit child session_shutdown (bounded), then dispose. Never throws. */
+async function shutdownAndDisposeChildSession(session: AgentSession) {
+  try {
+    if (session.extensionRunner.hasHandlers("session_shutdown")) {
+      await waitBounded(
+        session.extensionRunner.emit({
+          type: "session_shutdown",
+          reason: "quit",
+        }),
+        CHILD_SHUTDOWN_TIMEOUT_MS,
+      );
+    }
+  } catch {
+    // Extension runner inspection/emission is best-effort during teardown.
+  } finally {
+    try {
+      session.dispose();
+    } catch {
+      // Disposal is terminal and must remain idempotent for callers.
+    }
+  }
+}
+
+// --- Event translation ----------------------------------------------------------
+
+function messageRole(msg: unknown): Message["role"] | undefined {
+  const role = (msg as { role?: string } | undefined)?.role;
+  if (role === "user" || role === "assistant" || role === "toolResult")
+    return role;
+  return undefined;
+}
+
+export function indexAfterMessageBoundary(
+  messages: ReadonlyArray<unknown>,
+  boundary: unknown,
+ ) {
+  if (boundary === undefined) return 0;
+  const index = messages.indexOf(boundary);
+  return index < 0 ? 0 : index + 1;
+}
+
+function lastAssistantMessage(
+  session: Pick<AgentSession, "messages">,
+  startIndex = 0,
+ ): AssistantMessage | undefined {
+  const messages = session.messages;
+  const effectiveStart = startIndex > messages.length ? 0 : startIndex;
+  for (let i = messages.length - 1; i >= effectiveStart; i--) {
+    const msg = messages[i];
+    if (messageRole(msg) === "assistant") return msg as AssistantMessage;
+  }
+  return undefined;
+}
+
+/** Final assistant text output within the current run. */
+export function finalOutput(
+  session: Pick<AgentSession, "messages">,
+  startIndex = 0,
+ ): string {
+  const messages = session.messages;
+  // Pi replaces the message array during compaction. If that shortened the
+  // array past the saved run boundary, all remaining messages are post-boundary.
+  const effectiveStart = startIndex > messages.length ? 0 : startIndex;
+  for (let i = messages.length - 1; i >= effectiveStart; i--) {
+    const msg = messages[i];
+    if (messageRole(msg) !== "assistant") continue;
+    const text = (msg as AssistantMessage).content
+      .filter((part) => part.type === "text")
+      .map((part) => part.text)
+      .join("\n")
+      .trim();
+    if (text) return text;
+  }
+  return "";
+}
+
+function safeJson(value: unknown): string | undefined {
+  try {
+    const text = JSON.stringify(value);
+    return text === "{}" ? undefined : text.slice(0, 4_096);
+  } catch {
+    return undefined;
+  }
+}
+
+/** First non-empty line of a tool result-ish value (v1 liveToolPreview). */
+function toolPreview(value: unknown): string | undefined {
+  if (typeof value === "string") {
+    return value
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim();
+  }
+  if (!value || typeof value !== "object") return undefined;
+  const content = (value as { content?: unknown }).content;
+  if (!Array.isArray(content)) return undefined;
+  for (const part of content) {
+    if (!part || typeof part !== "object") continue;
+    const record = part as { type?: unknown; text?: unknown };
+    if (record.type !== "text" || typeof record.text !== "string") continue;
+    const firstLine = record.text.split("\n").find((line) => line.trim());
+    if (firstLine) return firstLine.trim();
+  }
+  return undefined;
+}
+
+function assistantParts(msg: AssistantMessage): TranscriptPart[] {
+  const parts: TranscriptPart[] = [];
+  for (const part of msg.content) {
+    if (part.type === "text") {
+      parts.push({ type: "text", text: part.text });
+    } else if (part.type === "thinking") {
+      parts.push({
+        type: "thinking",
+        text: part.redacted ? "" : part.thinking,
+        redacted: part.redacted,
+      });
+    } else if (part.type === "toolCall") {
+      parts.push({
+        type: "toolCall",
+        toolId: part.id,
+        name: part.name,
+        argsPreview: safeJson(part.arguments),
+      });
+    }
+  }
+  return parts;
+}
+
+function userText(msg: Message): string {
+  const content = (msg as { content: unknown }).content;
+  if (typeof content === "string") return content;
+  if (!Array.isArray(content)) return "";
+  return content
+    .filter(
+      (part): part is { type: "text"; text: string } =>
+        !!part &&
+        typeof part === "object" &&
+        (part as { type?: unknown }).type === "text",
+    )
+    .map((part) => part.text)
+    .join("\n");
+}
+
+// --- The session ------------------------------------------------------------------
+
+function boundedError(error: unknown) {
+  return (error instanceof Error ? error.message : String(error)).slice(
+    0,
+    4096,
+  );
+}
+
+const makePiSession = (
+  task: SpawnTask,
+): Effect.Effect<SubagentSession, SpawnError, Scope.Scope> =>
+  Effect.gen(function* () {
+    const registry = task.parent.modelRegistry;
+    if (!registry) {
+      return yield* new SpawnError({
+        message: "pi backend requires the parent session's model registry.",
+      });
+    }
+
+    const model = yield* Effect.try({
+      try: () =>
+        resolvePiModel(registry, task.model, task.parent.inheritedModel),
+      catch: (error) => new SpawnError({ message: boundedError(error) }),
+    });
+    // pi's thinking levels ARE the shared reasoning-effort scale.
+    const thinkingLevel = (task.reasoningEffort ??
+      task.parent.inheritedThinkingLevel) as ThinkingLevel | undefined;
+
+    const session = yield* Effect.tryPromise({
+      try: async () => {
+        const { loader, settingsManager } = await createChildResources(
+          task.cwd,
+          task.parent.projectTrusted,
+        );
+        const { session } = await createAgentSession({
+          cwd: task.cwd,
+          sessionManager: SessionManager.create(task.cwd),
+          settingsManager,
+          resourceLoader: loader,
+          model,
+          thinkingLevel,
+          excludeTools: [...CHILD_EXCLUDED_TOOL_NAMES],
+        });
+        // Start child extension session hooks/resources in headless mode.
+        // A rejection here would otherwise leak the freshly created session:
+        // the scope finalizer that owns cleanup is only registered later.
+        try {
+          await session.bindExtensions({ mode: "print" });
+        } catch (error) {
+          await shutdownAndDisposeChildSession(session);
+          throw error;
+        }
+        return session;
+      },
+      catch: (error) => new SpawnError({ message: boundedError(error) }),
+    });
+
+    const state = {
+      closed: false,
+      /** prompt() rejection for the active run; folded into RunSettled. */
+      runError: undefined as string | undefined,
+      runBoundaryMessage: undefined as unknown,
+      runStarted: false,
+      runSerial: 0,
+      /** One terminal event per run: lifecycle, prompt-rejection, and abort
+       * fallbacks can all race to settle; the first wins. */
+      settled: false,
+    };
+
+    const events = yield* Queue.make<SubagentEvent, Cause.Done>();
+    const emit = (event: SubagentEvent) => {
+      Queue.offerUnsafe(events, event);
+    };
+
+    const toolTimeout = createToolCallTimeoutGuard();
+    toolTimeout.apply(session);
+
+    const activeModel = (): Model<any> | undefined => {
+      const sessionModel = session.model;
+      const last = lastAssistantMessage(session);
+      if (!last) return sessionModel;
+      if (
+        sessionModel &&
+        (last.provider !== sessionModel.provider ||
+          last.model !== sessionModel.id)
+      ) {
+        // The session changed models after this assistant response.
+        return sessionModel;
+      }
+      return (
+        registry.find(last.provider, last.responseModel ?? last.model) ??
+        sessionModel
+      );
+    };
+
+    const currentMeta = (): SubagentMeta => {
+      const m = activeModel();
+      return {
+        backend: "pi",
+        modelLabel: m ? `${m.provider}/${m.id}` : undefined,
+        contextWindow: m?.contextWindow,
+        sessionFilePath: session.sessionFile,
+      };
+    };
+
+    const emitUsage = () => {
+      const usage = session.getContextUsage();
+      emit({
+        _tag: "UsageChanged",
+        tokens: usage?.tokens ?? undefined,
+        contextWindow: activeModel()?.contextWindow ?? usage?.contextWindow,
+      });
+    };
+
+    const settle = (serial = state.runSerial) => {
+      if (serial !== state.runSerial || state.settled) return;
+      state.settled = true;
+      state.runStarted = false;
+      const runStartIndex = indexAfterMessageBoundary(
+        session.messages,
+        state.runBoundaryMessage,
+      );
+      const last = lastAssistantMessage(session, runStartIndex);
+      const finalText = finalOutput(session, runStartIndex);
+      const partialText = finalText || undefined;
+      if (last?.stopReason === "aborted") {
+        emit({
+          _tag: "RunSettled",
+          outcome: { _tag: "Interrupted", partialText },
+        });
+        return;
+      }
+      const errorText =
+        state.runError ??
+        (last?.stopReason === "error"
+          ? (last.errorMessage ?? "Run failed")
+          : undefined);
+      if (errorText !== undefined) {
+        emit({
+          _tag: "RunSettled",
+          outcome: {
+            _tag: "Failed",
+            errorText: boundedError(errorText),
+            partialText,
+          },
+        });
+        return;
+      }
+      emit({
+        _tag: "RunSettled",
+        outcome: { _tag: "Completed", finalText },
+      });
+    };
+
+    const handleEvent = (event: AgentSessionEvent) => {
+      if (state.closed) return;
+      switch (event.type) {
+        case "agent_start":
+          // Extensions may register tools between runs; guard new ones too.
+          toolTimeout.apply(session);
+          state.runError = undefined;
+          state.settled = false;
+          if (!state.runStarted) {
+            // A queued follow-up or extension-triggered turn did not pass
+            // through startRun(), so establish its own transcript boundary.
+            state.runSerial++;
+            state.runBoundaryMessage = session.messages.at(-1);
+            state.runStarted = true;
+            emit({ _tag: "RunStarted" });
+          }
+          break;
+        case "message_update": {
+          const streamEvent = event.assistantMessageEvent;
+          if (streamEvent.type === "text_delta") {
+            emit({
+              _tag: "AssistantDelta",
+              kind: "text",
+              delta: streamEvent.delta,
+            });
+          } else if (streamEvent.type === "thinking_delta") {
+            emit({
+              _tag: "AssistantDelta",
+              kind: "thinking",
+              delta: streamEvent.delta,
+            });
+          }
+          break;
+        }
+        case "message_end": {
+          const role = messageRole(event.message);
+          if (role === "user") {
+            const text = userText(event.message as Message);
+            if (text.trim()) emit({ _tag: "UserMessage", text });
+          } else if (role === "assistant") {
+            emit({
+              _tag: "AssistantMessage",
+              parts: assistantParts(event.message as AssistantMessage),
+            });
+            emitUsage();
+            emit({ _tag: "MetaChanged", meta: currentMeta() });
+          }
+          // toolResult messages are covered by tool_execution_end.
+          break;
+        }
+        case "tool_execution_start":
+          emit({
+            _tag: "ToolStart",
+            toolId: event.toolCallId,
+            name: event.toolName,
+            argsPreview: safeJson(event.args),
+          });
+          break;
+        case "tool_execution_update":
+          emit({
+            _tag: "ToolUpdate",
+            toolId: event.toolCallId,
+            outputPreview: toolPreview(event.partialResult),
+          });
+          break;
+        case "tool_execution_end":
+          emit({
+            _tag: "ToolEnd",
+            toolId: event.toolCallId,
+            name: event.toolName,
+            isError: event.isError,
+            outputPreview: toolPreview(event.result),
+          });
+          break;
+        case "queue_update":
+          emit({
+            _tag: "QueueChanged",
+            queued: [
+              ...event.steering.map((text) => ({
+                text,
+                kind: "steer" as const,
+              })),
+              ...event.followUp.map((text) => ({
+                text,
+                kind: "follow-up" as const,
+              })),
+            ],
+          });
+          break;
+        case "agent_settled":
+          settle();
+          break;
+      }
+    };
+    const unsubscribe = session.subscribe(handleEvent);
+
+    yield* Effect.addFinalizer(() =>
+      Effect.promise(async () => {
+        state.closed = true;
+        unsubscribe();
+        try {
+          session.clearQueue();
+        } catch {
+          // Continue with abort/dispose.
+        }
+        await waitBounded(session.abort(), CHILD_SHUTDOWN_TIMEOUT_MS);
+        await shutdownAndDisposeChildSession(session);
+        Queue.endUnsafe(events);
+      }),
+    );
+
+    /** Start a fresh run (v1 manager.run): fire-and-forget, errors -> events. */
+    const startRun = (text: string) => {
+      const serial = ++state.runSerial;
+      state.runError = undefined;
+      state.runBoundaryMessage = session.messages.at(-1);
+      state.runStarted = true;
+      state.settled = false;
+      // Emit eagerly because prompt preflight failures may never produce an
+      // agent_start event. agent_start suppresses the duplicate.
+      emit({ _tag: "RunStarted" });
+      void session.prompt(text).catch((error) => {
+        if (serial !== state.runSerial) return;
+        state.runError = boundedError(error);
+        if (!session.isStreaming) settle(serial);
+      });
+    };
+
+    // Session naming is best-effort.
+    yield* Effect.try(() =>
+      session.sessionManager.appendSessionInfo(
+        `${task.origin === "btw" ? "btw" : "subagent"}: ${task.title}`,
+      ),
+    ).pipe(Effect.ignore);
+
+    emit({ _tag: "MetaChanged", meta: currentMeta() });
+    startRun(task.prompt);
+
+    return {
+      meta: Effect.sync(currentMeta),
+      events: Stream.fromQueue(events),
+      send: (text) =>
+        Effect.suspend((): Effect.Effect<void, SendError> => {
+          if (state.closed) {
+            return new SendError({ message: "Subagent session is closed." });
+          }
+          if (session.isStreaming) {
+            // Steer the active run via the SDK's queue; queue_update events
+            // render it, message_end(user) lands it in the transcript. A
+            // rejected steer is a real send failure, not a diagnostic.
+            return Effect.tryPromise({
+              try: () => session.steer(text),
+              catch: (error) => new SendError({ message: boundedError(error) }),
+            }).pipe(Effect.asVoid);
+          }
+          return Effect.sync(() => startRun(text));
+        }),
+      interrupt: Effect.promise(async () => {
+        if (state.closed) return;
+        try {
+          session.clearQueue();
+        } catch {
+          // Abort regardless.
+        }
+        await session.abort().catch(() => undefined);
+        // Only resolve once streaming has actually stopped: reporting the
+        // interrupt as complete while the run keeps working would let the
+        // manager settle a run that is still mutating the workspace. The
+        // manager bounds this effect at 5s and force-disposes on timeout.
+        while (!state.closed && session.isStreaming) {
+          await new Promise((resolve) => setTimeout(resolve, 50));
+        }
+        // No streaming run means no agent_settled will arrive; emit the
+        // terminal event (once) so the run cannot look running forever.
+        if (!state.closed && !state.settled) {
+          state.settled = true;
+          state.runStarted = false;
+          emit({ _tag: "RunSettled", outcome: { _tag: "Interrupted" } });
+        }
+      }),
+    } satisfies SubagentSession;
+  });
+
+export const piBackend: SubagentBackend = {
+  name: "pi",
+  // In-process SDK: always available.
+  available: Effect.succeed(true),
+  spawn: makePiSession,
+};

--- a/users/profiles/pi/extensions/subagents/src/backends/stub.ts
+++ b/users/profiles/pi/extensions/subagents/src/backends/stub.ts
@@ -1,0 +1,295 @@
+/**
+ * Scripted stub sessions shared by all three backend implementations while
+ * the real integrations are pending. A stub session:
+ *
+ * - streams a plausible turn (thinking deltas, one fake tool cycle, text
+ *   deltas, usage ramp, a final assistant message, RunSettled) over a few
+ *   seconds so streaming UI, wait, and the footer counters are observable;
+ * - supports send() while running (queued-steer rendering) and while idle
+ *   (fresh run);
+ * - supports interrupt (RunSettled Interrupted -> status "error", matching v1);
+ * - fails the run when the prompt starts with "FAIL:" (error-path testing);
+ * - appends every event to a JSONL "session file" in tmpdir so the
+ *   "full transcript in session file" pointers resolve.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import type { Cause, Scope } from "effect";
+import { Duration, Effect, Fiber, Queue, Ref, Stream } from "effect";
+import type { SubagentBackend, SubagentSession } from "../backend.ts";
+import type {
+  BackendName,
+  QueuedMessage,
+  SpawnTask,
+  SubagentEvent,
+  SubagentMeta,
+} from "../domain.ts";
+import { SendError } from "../domain.ts";
+
+export interface StubProfile {
+  readonly backend: BackendName;
+  readonly defaultModelLabel: string;
+  readonly contextWindow: number;
+  readonly toolName: string;
+  /** Delay between scripted events; varies per backend so streams differ. */
+  readonly cadenceMs: number;
+}
+
+const STUB_DIR = path.join(os.tmpdir(), "subagents-stub");
+let sessionCounter = 0;
+
+export function makeStubBackend(profile: StubProfile): SubagentBackend {
+  return {
+    name: profile.backend,
+    // Real impls probe binary-on-PATH / SDK import / credentials here.
+    available: Effect.succeed(true),
+    spawn: (task) => makeStubSession(profile, task),
+  };
+}
+
+function firstLine(text: string): string {
+  return (
+    text
+      .split("\n")
+      .find((line) => line.trim())
+      ?.trim() ?? ""
+  );
+}
+
+function chunked(text: string, size: number): string[] {
+  const chunks: string[] = [];
+  for (let i = 0; i < text.length; i += size)
+    chunks.push(text.slice(i, i + size));
+  return chunks;
+}
+
+const makeStubSession = (
+  profile: StubProfile,
+  task: SpawnTask,
+): Effect.Effect<SubagentSession, never, Scope.Scope> =>
+  Effect.gen(function* () {
+    const sessionId = `stub-${profile.backend}-${++sessionCounter}`;
+    const sessionFile = path.join(STUB_DIR, `${sessionId}.jsonl`);
+
+    const state = {
+      meta: {
+        backend: profile.backend,
+        modelLabel: task.model ?? profile.defaultModelLabel,
+        contextWindow: profile.contextWindow,
+        sessionFilePath: sessionFile,
+        nativeSessionId: sessionId,
+      } satisfies SubagentMeta as SubagentMeta,
+      pending: [] as string[],
+      turnCount: 0,
+      closed: false,
+      /** True between the driver dequeuing a prompt and registering its turn fiber. */
+      dispatching: false,
+    };
+
+    const events = yield* Queue.make<SubagentEvent, Cause.Done>();
+    const inbox = yield* Queue.make<string, Cause.Done>();
+    const activeTurn = yield* Ref.make<Fiber.Fiber<void> | undefined>(
+      undefined,
+    );
+
+    const emit = (event: SubagentEvent) =>
+      Effect.suspend(() => {
+        try {
+          fs.appendFileSync(sessionFile, `${JSON.stringify(event)}\n`);
+        } catch {
+          // The fake session file is best-effort.
+        }
+        if (event._tag === "MetaChanged") {
+          state.meta = { ...state.meta, ...event.meta };
+        }
+        return Queue.offer(events, event);
+      }).pipe(Effect.asVoid);
+
+    const pause = Effect.sleep(Duration.millis(profile.cadenceMs));
+
+    const runTurn = (userText: string, turn: number) =>
+      Effect.gen(function* () {
+        yield* emit({ _tag: "RunStarted" });
+        const failing = userText.trimStart().startsWith("FAIL:");
+
+        const thinking = "Looking at the task and planning an approach...";
+        for (const delta of chunked(thinking, 16)) {
+          yield* emit({ _tag: "AssistantDelta", kind: "thinking", delta });
+          yield* pause;
+        }
+
+        const toolId = `${sessionId}-tool-${turn}`;
+        const argsPreview = `{"command":"ls ${task.cwd}"}`;
+        yield* emit({
+          _tag: "AssistantMessage",
+          parts: [
+            { type: "thinking", text: thinking },
+            {
+              type: "text",
+              text: `I'll run ${profile.toolName} to look around first.`,
+            },
+            { type: "toolCall", toolId, name: profile.toolName, argsPreview },
+          ],
+        });
+        yield* emit({
+          _tag: "ToolStart",
+          toolId,
+          name: profile.toolName,
+          argsPreview,
+        });
+        yield* pause;
+        yield* emit({
+          _tag: "ToolUpdate",
+          toolId,
+          outputPreview: "src docs package.json",
+        });
+        yield* pause;
+        yield* emit({
+          _tag: "ToolEnd",
+          toolId,
+          name: profile.toolName,
+          isError: false,
+          outputPreview: "src docs package.json",
+        });
+        yield* emit({
+          _tag: "UsageChanged",
+          tokens: Math.min(profile.contextWindow, 2400 * (turn + 1)),
+          contextWindow: profile.contextWindow,
+        });
+
+        if (failing) {
+          yield* pause;
+          yield* emit({
+            _tag: "RunSettled",
+            outcome: {
+              _tag: "Failed",
+              errorText: `[stub:${profile.backend}] task failed as requested by FAIL: prefix`,
+            },
+          });
+          return;
+        }
+
+        const finalText =
+          `[stub:${profile.backend}] completed: ${firstLine(userText).slice(0, 200)}\n\n` +
+          `This is a stubbed ${profile.backend} subagent turn ${turn + 1}. ` +
+          `The real backend integration will replace this scripted output.`;
+        for (const delta of chunked(finalText, 24)) {
+          yield* emit({ _tag: "AssistantDelta", kind: "text", delta });
+          yield* pause;
+        }
+        yield* emit({
+          _tag: "AssistantMessage",
+          parts: [{ type: "text", text: finalText }],
+        });
+        yield* emit({
+          _tag: "UsageChanged",
+          tokens: Math.min(profile.contextWindow, 2400 * (turn + 1) + 900),
+          contextWindow: profile.contextWindow,
+        });
+        yield* emit({
+          _tag: "RunSettled",
+          outcome: { _tag: "Completed", finalText },
+        });
+      });
+
+    const queuedView = (): ReadonlyArray<QueuedMessage> =>
+      state.pending.map((text) => ({ text, kind: "steer" as const }));
+
+    // Driver: one turn at a time, in submission order. Turns run as child
+    // fibers so interrupt() stops the turn without killing the driver.
+    const driver = Effect.gen(function* () {
+      while (true) {
+        const text = yield* Queue.take(inbox);
+        state.dispatching = true;
+        state.pending.shift();
+        yield* emit({ _tag: "QueueChanged", queued: queuedView() });
+        yield* emit({ _tag: "UserMessage", text });
+        const turn = state.turnCount++;
+        const fiber = yield* Effect.forkChild(
+          runTurn(text, turn).pipe(
+            Effect.onInterrupt(() =>
+              emit({
+                _tag: "RunSettled",
+                outcome: { _tag: "Interrupted" },
+              }).pipe(Effect.ignore),
+            ),
+          ),
+        );
+        yield* Ref.set(activeTurn, fiber);
+        state.dispatching = false;
+        yield* Fiber.await(fiber);
+        yield* Ref.set(activeTurn, undefined);
+      }
+    });
+    yield* Effect.forkScoped(driver.pipe(Effect.ignore));
+
+    yield* Effect.addFinalizer(() =>
+      Effect.gen(function* () {
+        state.closed = true;
+        yield* Queue.end(inbox).pipe(Effect.ignore);
+        yield* Queue.end(events).pipe(Effect.ignore);
+      }),
+    );
+
+    const submit = (text: string) =>
+      Effect.gen(function* () {
+        if (state.closed) {
+          return yield* new SendError({
+            message: "Subagent session is closed.",
+          });
+        }
+        state.pending.push(text);
+        const busy = (yield* Ref.get(activeTurn)) !== undefined;
+        if (busy) {
+          // Show the queued steer line until the driver picks it up.
+          yield* emit({ _tag: "QueueChanged", queued: queuedView() });
+        }
+        yield* Queue.offer(inbox, text);
+      });
+
+    // Announce metadata, then kick off the initial run.
+    yield* Effect.try(() => fs.mkdirSync(STUB_DIR, { recursive: true })).pipe(
+      Effect.ignore, // The fake session file directory is best-effort.
+    );
+    yield* emit({ _tag: "MetaChanged", meta: state.meta });
+    // The session cannot be closed yet, so the initial submit cannot fail.
+    yield* submit(task.prompt).pipe(Effect.orDie);
+
+    return {
+      meta: Effect.sync(() => state.meta),
+      events: Stream.fromQueue(events),
+      send: submit,
+      interrupt: Effect.gen(function* () {
+        // Drop queued prompts so interrupting cannot immediately start
+        // another turn, then stop the active turn. A prompt may be mid-flight
+        // between the driver dequeuing it and registering its fiber, so wait
+        // that window out instead of silently missing the turn.
+        const cleared = yield* Queue.clear(inbox).pipe(
+          Effect.orElseSucceed(() => []),
+        );
+        state.pending = [];
+        yield* emit({ _tag: "QueueChanged", queued: [] });
+        while (true) {
+          const fiber = yield* Ref.get(activeTurn);
+          if (fiber) {
+            yield* Fiber.interrupt(fiber);
+            return;
+          }
+          if (!state.dispatching) {
+            // No turn ever started. If we cancelled queued prompts, the run
+            // still needs a terminal event or it would look running forever.
+            if (cleared.length > 0) {
+              yield* emit({
+                _tag: "RunSettled",
+                outcome: { _tag: "Interrupted" },
+              });
+            }
+            return;
+          }
+          yield* Effect.sleep(Duration.millis(5));
+        }
+      }),
+    } satisfies SubagentSession;
+  });

--- a/users/profiles/pi/extensions/subagents/src/by-the-way.ts
+++ b/users/profiles/pi/extensions/subagents/src/by-the-way.ts
@@ -1,0 +1,21 @@
+import type { SubagentOrigin } from "./domain.ts";
+
+export const BTW_TITLE_MAX_LENGTH = 60;
+
+/** Build a compact dashboard title from the first non-empty prompt line. */
+export function deriveBtwTitle(prompt: string) {
+  const firstLine = prompt
+    .split("\n")
+    .find((line) => line.trim())
+    ?.trim();
+  const title = firstLine?.replace(/\s+/g, " ") ?? "";
+  if (!title) return "by the way";
+  const codePoints = Array.from(title);
+  if (codePoints.length <= BTW_TITLE_MAX_LENGTH) return title;
+  return `${codePoints.slice(0, BTW_TITLE_MAX_LENGTH - 1).join("")}…`;
+}
+
+/** User asides remain visible in the dashboard but hidden from model tools. */
+export function isModelVisible(snap: { readonly origin: SubagentOrigin }) {
+  return snap.origin === "model";
+}

--- a/users/profiles/pi/extensions/subagents/src/domain.ts
+++ b/users/profiles/pi/extensions/subagents/src/domain.ts
@@ -1,0 +1,252 @@
+/**
+ * Domain model for subagents.
+ *
+ * Everything downstream of a backend (manager, tools, UI) speaks only these
+ * types. Backends translate their native pi-session or Claude Agent SDK
+ * streams into the normalized `SubagentEvent` union.
+ */
+
+import type { ModelRegistry } from "@earendil-works/pi-coding-agent";
+import { Data } from "effect";
+
+export const BACKEND_NAMES = ["pi", "claude"] as const;
+export type BackendName = (typeof BACKEND_NAMES)[number];
+
+/** Who initiated the session. User asides stay out of model-facing tooling. */
+export type SubagentOrigin = "model" | "btw";
+
+/**
+ * Shared reasoning-effort scale (pi's thinking levels). Pi uses it directly,
+ * while Claude translates it to thinking budgets. Omitted = backend default
+ * (pi inherits the parent level).
+ */
+export const REASONING_EFFORTS = [
+  "off",
+  "minimal",
+  "low",
+  "medium",
+  "high",
+  "xhigh",
+  "max",
+] as const;
+export type ReasoningEffort = (typeof REASONING_EFFORTS)[number];
+
+export type SubagentStatus = "running" | "done" | "error";
+
+/** Parent-session context resolved by the tool layer and passed opaquely. */
+export interface ParentContext {
+  readonly parentCwd: string;
+  readonly projectTrusted: boolean;
+  /** Parent pi model, for the pi backend's "inherit" default. */
+  readonly inheritedModel?: { readonly provider: string; readonly id: string };
+  readonly inheritedThinkingLevel?: string;
+  /** Parent model registry; required by the pi backend to resolve models. */
+  readonly modelRegistry?: ModelRegistry;
+}
+
+export interface SpawnTask {
+  /** Omitted for normal tool-driven spawns. */
+  readonly origin?: SubagentOrigin;
+  readonly prompt: string;
+  readonly title: string;
+  readonly cwd: string;
+  /**
+   * Generic model hint: pi accepts "provider/model-id" or a bare model id;
+   * Claude accepts its model aliases. Omitted = backend default / inherit.
+   */
+  readonly model?: string;
+  /** Shared effort scale; each backend maps it to its native equivalent. */
+  readonly reasoningEffort?: ReasoningEffort;
+  readonly parent: ParentContext;
+}
+
+export interface SubagentMeta {
+  readonly backend: BackendName;
+  /** Display label, e.g. "anthropic/claude-opus-4-5". */
+  readonly modelLabel?: string;
+  /** Context window capacity for utilization display, when known. */
+  readonly contextWindow?: number;
+  /** Pi session file or Claude projects JSONL path. */
+  readonly sessionFilePath?: string;
+  /** Claude session id. */
+  readonly nativeSessionId?: string;
+}
+
+// --- Transcript ------------------------------------------------------------
+
+export type TranscriptPart =
+  | { readonly type: "text"; readonly text: string }
+  | {
+      readonly type: "thinking";
+      readonly text: string;
+      readonly redacted?: boolean;
+    }
+  | {
+      readonly type: "toolCall";
+      readonly toolId: string;
+      readonly name: string;
+      readonly argsPreview?: string;
+    };
+
+export type TranscriptItem =
+  | { readonly kind: "user"; readonly text: string }
+  | {
+      readonly kind: "assistant";
+      readonly parts: ReadonlyArray<TranscriptPart>;
+    }
+  | {
+      readonly kind: "toolResult";
+      readonly toolId: string;
+      readonly name: string;
+      readonly isError: boolean;
+      readonly outputPreview?: string;
+    };
+
+export interface LiveToolState {
+  readonly toolId: string;
+  readonly name: string;
+  readonly argsPreview?: string;
+  readonly outputPreview?: string;
+  readonly done?: boolean;
+  readonly isError?: boolean;
+}
+
+export interface QueuedMessage {
+  readonly text: string;
+  readonly kind: "steer" | "follow-up";
+}
+
+// --- Events ------------------------------------------------------------------
+
+export type RunOutcome =
+  | { readonly _tag: "Completed"; readonly finalText: string }
+  | {
+      readonly _tag: "Failed";
+      readonly errorText: string;
+      readonly partialText?: string;
+    }
+  | { readonly _tag: "Interrupted"; readonly partialText?: string };
+
+/**
+ * Normalized activity stream. Previews (`argsPreview`, `outputPreview`) are
+ * pre-flattened single-line strings because the UI only ever renders one
+ * sanitized line, which keeps three different native tool-result shapes out
+ * of the interface.
+ */
+export type SubagentEvent =
+  // lifecycle (a session can run multiple turns via send())
+  | { readonly _tag: "RunStarted" }
+  | { readonly _tag: "RunSettled"; readonly outcome: RunOutcome }
+  // transcript building blocks
+  | { readonly _tag: "UserMessage"; readonly text: string }
+  | {
+      readonly _tag: "AssistantDelta";
+      readonly kind: "text" | "thinking";
+      readonly delta: string;
+    }
+  | {
+      readonly _tag: "AssistantMessage";
+      readonly parts: ReadonlyArray<TranscriptPart>;
+    }
+  | {
+      readonly _tag: "ToolStart";
+      readonly toolId: string;
+      readonly name: string;
+      readonly argsPreview?: string;
+    }
+  | {
+      readonly _tag: "ToolUpdate";
+      readonly toolId: string;
+      readonly outputPreview?: string;
+    }
+  | {
+      readonly _tag: "ToolEnd";
+      readonly toolId: string;
+      readonly name: string;
+      readonly isError: boolean;
+      readonly outputPreview?: string;
+    }
+  // bookkeeping
+  | {
+      readonly _tag: "QueueChanged";
+      readonly queued: ReadonlyArray<QueuedMessage>;
+    }
+  | {
+      readonly _tag: "UsageChanged";
+      readonly tokens?: number;
+      readonly contextWindow?: number;
+    }
+  | { readonly _tag: "MetaChanged"; readonly meta: Partial<SubagentMeta> }
+  /** Non-fatal diagnostics. Fatal failures arrive as a RunSettled outcome. */
+  | { readonly _tag: "BackendError"; readonly message: string };
+
+// --- Snapshot ---------------------------------------------------------------
+
+/**
+ * The manager folds `SubagentEvent`s into one snapshot per subagent. This is
+ * everything the tools, footer status, and both TUI views read.
+ */
+export interface SubagentSnapshot {
+  readonly id: string;
+  readonly origin: SubagentOrigin;
+  readonly backend: BackendName;
+  readonly title: string;
+  readonly prompt: string;
+  readonly cwd: string;
+  readonly status: SubagentStatus;
+  readonly createdAt: number;
+  readonly settledAt?: number;
+  /** Monotonic per-session settlement generation; avoids timestamp collisions. */
+  readonly settlement: number;
+  readonly errorText?: string;
+  readonly meta: SubagentMeta;
+  readonly usage: { readonly tokens?: number; readonly contextWindow?: number };
+  readonly transcript: ReadonlyArray<TranscriptItem>;
+  /** Streaming assistant buffers, cleared when the finalized message lands. */
+  readonly liveAssistant?: { readonly text: string; readonly thinking: string };
+  readonly liveTools: ReadonlyArray<LiveToolState>;
+  readonly queued: ReadonlyArray<QueuedMessage>;
+  /** Final text of the most recent completed run (v1 `finalOutput`). */
+  readonly finalText: string;
+  /** Count of finalized assistant messages (for subagent_check). */
+  readonly turns: number;
+}
+
+/** Final text, or the live streaming buffer while a run is active (v1 `latestOutput`). */
+export function latestText(snap: SubagentSnapshot) {
+  const live = snap.liveAssistant?.text.trim();
+  if (live) return live;
+  return snap.finalText;
+}
+
+export function formatElapsed(snap: SubagentSnapshot) {
+  const end = snap.settledAt ?? Date.now();
+  const totalSeconds = Math.max(0, Math.round((end - snap.createdAt) / 1000));
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return minutes > 0
+    ? `${minutes}m${seconds.toString().padStart(2, "0")}s`
+    : `${seconds}s`;
+}
+
+// --- Errors -------------------------------------------------------------------
+
+export class SpawnError extends Data.TaggedError("SpawnError")<{
+  readonly message: string;
+}> {}
+
+export class BackendUnavailableError extends Data.TaggedError(
+  "BackendUnavailableError",
+)<{
+  readonly message: string;
+}> {}
+
+export class ConcurrencyLimitError extends Data.TaggedError(
+  "ConcurrencyLimitError",
+)<{
+  readonly message: string;
+}> {}
+
+export class SendError extends Data.TaggedError("SendError")<{
+  readonly message: string;
+}> {}

--- a/users/profiles/pi/extensions/subagents/src/format.ts
+++ b/users/profiles/pi/extensions/subagents/src/format.ts
@@ -1,0 +1,74 @@
+/**
+ * Formatting helpers (self-contained copies of the v1 shared helpers:
+ * context-utilization + activity-status).
+ */
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+
+export interface ContextUtilization {
+  /** Current conversation context occupancy; undefined while unknown. */
+  tokens?: number | null;
+  /** Capacity of the model currently serving the conversation. */
+  contextWindow?: number | null;
+}
+
+function usableTokens(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value >= 0
+    ? value
+    : undefined;
+}
+
+function usableCapacity(value: number | null | undefined) {
+  return typeof value === "number" && Number.isFinite(value) && value > 0
+    ? value
+    : undefined;
+}
+
+export function contextPercent(usage: ContextUtilization) {
+  const tokens = usableTokens(usage.tokens);
+  const capacity = usableCapacity(usage.contextWindow);
+  if (tokens === undefined || capacity === undefined) return undefined;
+  return Math.round(Math.min(100, Math.max(0, (tokens / capacity) * 100)));
+}
+
+export function formatCompactTokens(count: number) {
+  if (count < 1000) return Math.round(count).toString();
+  if (count < 10000) return `${(count / 1000).toFixed(1)}k`;
+  if (count < 1000000) return `${Math.round(count / 1000)}k`;
+  return `${(count / 1000000).toFixed(1)}M`;
+}
+
+/**
+ * Render `%/capacity`. If occupancy is unknown, retain the useful capacity
+ * as `?%/capacity`; with no valid capacity, omit the statistic entirely.
+ */
+export function formatContextUtilization(usage: ContextUtilization) {
+  const capacity = usableCapacity(usage.contextWindow);
+  if (capacity === undefined) return "";
+  const percent = contextPercent(usage);
+  return `${percent === undefined ? "?" : percent}%/${formatCompactTokens(capacity)}`;
+}
+
+interface ActivityCounts {
+  running: number;
+  done: number;
+  failed: number;
+}
+
+const SQUARE = "■";
+
+export function formatActivityStatus(theme: Theme, counts: ActivityCounts) {
+  const parts: string[] = [];
+  if (counts.running > 0) {
+    parts.push(theme.fg("warning", `${SQUARE} ${counts.running} running`));
+  }
+  if (counts.done > 0) {
+    parts.push(theme.fg("success", `${SQUARE} ${counts.done} done`));
+  }
+  if (counts.failed > 0) {
+    parts.push(theme.fg("error", `${SQUARE} ${counts.failed} failed`));
+  }
+  parts.push(theme.fg("accent", "/subagents") + theme.fg("dim", " to view"));
+
+  return `${theme.fg("muted", "subagents:")} ${parts.join(theme.fg("dim", " · "))}`;
+}

--- a/users/profiles/pi/extensions/subagents/src/manager.ts
+++ b/users/profiles/pi/extensions/subagents/src/manager.ts
@@ -1,0 +1,772 @@
+/**
+ * SubagentManager — owns the registry of running/finished subagents.
+ *
+ * Each subagent is a scoped `SubagentSession` from a `SubagentBackend` plus a
+ * pump fiber that folds its normalized event stream into a mutable
+ * `SubagentSnapshot`. Closing a subagent's scope kills the underlying
+ * session/process and stops the pump.
+ *
+ * The manager also exposes a synchronous `SubagentReadModel` so the
+ * imperative TUI components (which render synchronously) can read snapshots
+ * and issue fire-and-forget commands without touching the Effect runtime.
+ */
+
+import {
+  Context,
+  Effect,
+  Exit,
+  Fiber,
+  Layer,
+  Result,
+  Scope,
+  Stream,
+} from "effect";
+import type { SubagentBackend, SubagentSession } from "./backend.ts";
+import { BackendRegistry } from "./backend.ts";
+import type {
+  BackendName,
+  LiveToolState,
+  RunOutcome,
+  SpawnTask,
+  SubagentEvent,
+  SubagentOrigin,
+  SubagentMeta,
+  SubagentSnapshot,
+  SubagentStatus,
+  TranscriptItem,
+} from "./domain.ts";
+import {
+  BackendUnavailableError,
+  ConcurrencyLimitError,
+  SendError,
+  SpawnError,
+} from "./domain.ts";
+
+export const MAX_RUNNING = 4;
+export const MAX_TRACKED = 64;
+const STOP_TIMEOUT_MS = 5_000;
+const ERROR_TEXT_MAX_LENGTH = 4_096;
+const TRANSCRIPT_TEXT_MAX_LENGTH = 64 * 1_024;
+const LIVE_ASSISTANT_MAX_LENGTH = 128 * 1_024;
+const FINAL_TEXT_MAX_LENGTH = 1_024 * 1_024;
+const MAX_TRANSCRIPT_ITEMS = 512;
+
+function bounded(text: string) {
+  return text.slice(0, ERROR_TEXT_MAX_LENGTH);
+}
+
+function boundedTranscriptText(text: string) {
+  return text.slice(0, TRANSCRIPT_TEXT_MAX_LENGTH);
+}
+
+function appendTranscript(snapshot: MutableSnapshot, item: TranscriptItem) {
+  snapshot.transcript.push(item);
+  if (snapshot.transcript.length > MAX_TRANSCRIPT_ITEMS) {
+    snapshot.transcript.splice(
+      0,
+      snapshot.transcript.length - MAX_TRANSCRIPT_ITEMS,
+    );
+  }
+}
+
+// --- Internal state -----------------------------------------------------------
+
+/** Mutable snapshot; exposed to readers via the readonly SubagentSnapshot type. */
+interface MutableSnapshot {
+  id: string;
+  origin: SubagentOrigin;
+  backend: BackendName;
+  title: string;
+  prompt: string;
+  cwd: string;
+  status: SubagentStatus;
+  createdAt: number;
+  settledAt?: number;
+  settlement: number;
+  errorText?: string;
+  meta: SubagentMeta;
+  usage: { tokens?: number; contextWindow?: number };
+  transcript: TranscriptItem[];
+  liveAssistant?: { text: string; thinking: string };
+  liveTools: LiveToolState[];
+  queued: SubagentSnapshot["queued"];
+  finalText: string;
+  turns: number;
+}
+
+interface Entry {
+  snapshot: MutableSnapshot;
+  session: SubagentSession;
+  scope: Scope.Closeable;
+  pump?: Fiber.Fiber<void>;
+  liveToolMap: Map<string, LiveToolState>;
+  /** Idle restart dispatched but RunStarted not folded yet; counts as running
+   * so concurrent restarts cannot race past the cap. */
+  restarting?: boolean;
+}
+
+// --- Read model ----------------------------------------------------------------
+
+/** Synchronous bridge for the TUI. Snapshots are live objects; do not mutate. */
+export interface SubagentReadModel {
+  list(): ReadonlyArray<SubagentSnapshot>;
+  get(id: string): SubagentSnapshot | undefined;
+  size(): number;
+  /** Any-change notification (footer status, dashboard). */
+  subscribe(listener: () => void): () => void;
+  /** Per-subagent notification (takeover view). */
+  subscribeTo(id: string, listener: () => void): () => void;
+  /** Fire-and-forget: steer/continue a subagent and report send failures. */
+  requestSend(
+    id: string,
+    text: string,
+    onError?: (message: string) => void,
+  ): void;
+  /** Fire-and-forget: abort a running subagent (dashboard `x`, takeover). */
+  requestAbort(id: string): void;
+  /**
+   * Register the settle hook. `consumed` is true when an active
+   * subagent_wait/cancel is collecting the result (so it must not also be
+   * delivered as a follow-up message).
+   */
+  setOnSettled(
+    hook: ((snap: SubagentSnapshot, consumed: boolean) => void) | undefined,
+  ): void;
+}
+
+// --- Service --------------------------------------------------------------------
+
+export interface CancelResult {
+  readonly id: string;
+  readonly title: string;
+  readonly status: SubagentStatus;
+  readonly cancelled: boolean;
+}
+
+export interface SubagentManagerShape {
+  spawn(
+    backend: BackendName,
+    task: SpawnTask,
+  ): Effect.Effect<
+    SubagentSnapshot,
+    SpawnError | ConcurrencyLimitError | BackendUnavailableError
+  >;
+  /**
+   * Wait until all listed subagents are settled. Unknown ids are treated as
+   * settled (the tool layer validates ids first). While waiting, settles for
+   * these ids are marked "consumed". Interruption (tool abort) releases the
+   * interest and leaves the subagents running.
+   */
+  waitFor(
+    ids: ReadonlyArray<string>,
+    onPending?: (pending: string[]) => void,
+  ): Effect.Effect<void>;
+  /** Cancel running subagents; resolves when they have settled. */
+  cancel(
+    ids: ReadonlyArray<string>,
+  ): Effect.Effect<ReadonlyArray<CancelResult>>;
+  send(id: string, text: string): Effect.Effect<void, SendError>;
+  get(id: string): Effect.Effect<SubagentSnapshot | undefined>;
+  readonly list: Effect.Effect<ReadonlyArray<SubagentSnapshot>>;
+  readonly disposeAll: Effect.Effect<void>;
+  readonly view: SubagentReadModel;
+}
+
+export class SubagentManager extends Context.Service<
+  SubagentManager,
+  SubagentManagerShape
+>()("subagents/SubagentManager") {}
+
+/**
+ * Monotonic change notification that cannot lose a wakeup between a caller's
+ * state check and waiter registration. Exported for the regression test.
+ */
+export function makeChangeSignal() {
+  let version = 0;
+  let waiters: Array<() => void> = [];
+
+  return {
+    version: () => version,
+    notify: () => {
+      version++;
+      const current = waiters;
+      waiters = [];
+      for (const waiter of current) waiter();
+    },
+    wait: (observedVersion: number) =>
+      Effect.callback<void>((resume) => {
+        if (version !== observedVersion) {
+          resume(Effect.void);
+          return;
+        }
+        const waiter = () => resume(Effect.void);
+        waiters.push(waiter);
+        return Effect.sync(() => {
+          const index = waiters.indexOf(waiter);
+          if (index >= 0) waiters.splice(index, 1);
+        });
+      }),
+  };
+}
+
+// --- Implementation --------------------------------------------------------------
+
+const makeManager = Effect.gen(function* () {
+  const registry = yield* BackendRegistry;
+  // Detached forker for sync contexts (read-model commands, pruning) that
+  // preserves the manager's services instead of using the global runtime.
+  const runDetached = Effect.runForkWith(yield* Effect.context());
+
+  const entries = new Map<string, Entry>();
+  const waitInterest = new Map<string, number>();
+  const listeners = new Set<() => void>();
+  const changes = makeChangeSignal();
+  const idListeners = new Map<string, Set<() => void>>();
+  const cleanups = new Set<Fiber.Fiber<unknown>>();
+  let modelCounter = 0;
+  let btwCounter = 0;
+  let reserved = 0;
+  let disposed = false;
+  let onSettled:
+    ((snap: SubagentSnapshot, consumed: boolean) => void) | undefined;
+
+  const notify = (id?: string) => {
+    changes.notify();
+    for (const listener of [...listeners]) {
+      try {
+        listener();
+      } catch {
+        // A failed status/render listener must not corrupt lifecycle state.
+      }
+    }
+    if (id) {
+      for (const listener of idListeners.get(id) ?? []) {
+        try {
+          listener();
+        } catch {
+          // Same.
+        }
+      }
+    }
+  };
+
+
+  const runningCount = () =>
+    [...entries.values()].filter(
+      (e) => e.snapshot.status === "running" || e.restarting === true,
+    ).length;
+
+  const addInterest = (ids: ReadonlyArray<string>) => {
+    for (const id of ids) waitInterest.set(id, (waitInterest.get(id) ?? 0) + 1);
+  };
+  const releaseInterest = (ids: ReadonlyArray<string>) => {
+    for (const id of ids) {
+      const count = (waitInterest.get(id) ?? 1) - 1;
+      if (count <= 0) waitInterest.delete(id);
+      else waitInterest.set(id, count);
+    }
+  };
+
+  const closeEntryScope = (entry: Entry) =>
+    Scope.close(entry.scope, Exit.void).pipe(Effect.ignore);
+
+  const pruneSettled = () => {
+    if (entries.size <= MAX_TRACKED) return;
+    const candidates = [...entries.values()]
+      .filter(
+        (e) =>
+          e.snapshot.status !== "running" && !waitInterest.has(e.snapshot.id),
+      )
+      .sort(
+        (a, b) =>
+          (a.snapshot.settledAt ?? a.snapshot.createdAt) -
+          (b.snapshot.settledAt ?? b.snapshot.createdAt),
+      );
+    for (const entry of candidates) {
+      if (entries.size <= MAX_TRACKED) break;
+      entries.delete(entry.snapshot.id);
+      const fiber = runDetached(closeEntryScope(entry));
+      cleanups.add(fiber);
+      fiber.addObserver(() => cleanups.delete(fiber));
+    }
+  };
+
+  const settle = (entry: Entry, outcome: RunOutcome) => {
+    const s = entry.snapshot;
+    entry.restarting = false;
+    if (s.status !== "running") return;
+    s.settledAt = Date.now();
+    s.settlement++;
+    switch (outcome._tag) {
+      case "Completed":
+        s.status = "done";
+        s.errorText = undefined;
+        s.finalText = outcome.finalText.slice(0, FINAL_TEXT_MAX_LENGTH);
+        break;
+      case "Failed":
+        s.status = "error";
+        s.errorText = bounded(outcome.errorText);
+        // Never let a failed run report the previous run's successful output.
+        s.finalText = (outcome.partialText ?? "").slice(
+          0,
+          FINAL_TEXT_MAX_LENGTH,
+        );
+        break;
+      case "Interrupted":
+        s.status = "error";
+        s.errorText = "Run was aborted";
+        s.finalText = (outcome.partialText ?? "").slice(
+          0,
+          FINAL_TEXT_MAX_LENGTH,
+        );
+        break;
+    }
+    s.liveAssistant = undefined;
+    entry.liveToolMap.clear();
+    s.liveTools = [];
+    s.queued = [];
+    const consumed = (waitInterest.get(s.id) ?? 0) > 0;
+    notify(s.id);
+    try {
+      // During teardown, don't queue results into a shutting-down session.
+      if (!disposed) onSettled?.(s, consumed);
+    } catch {
+      // The parent session may be unavailable; settlement stays final.
+    }
+    pruneSettled();
+  };
+
+  const foldEvent = (entry: Entry, event: SubagentEvent) => {
+    const s = entry.snapshot;
+    switch (event._tag) {
+      case "RunStarted":
+        entry.restarting = false;
+        s.status = "running";
+        s.settledAt = undefined;
+        s.errorText = undefined;
+        break;
+      case "RunSettled":
+        settle(entry, event.outcome);
+        return; // settle() already notified
+      case "UserMessage":
+        appendTranscript(s, {
+          kind: "user",
+          text: boundedTranscriptText(event.text),
+        });
+        break;
+      case "AssistantDelta": {
+        const live = s.liveAssistant ?? { text: "", thinking: "" };
+        s.liveAssistant =
+          event.kind === "text"
+            ? {
+                ...live,
+                text: (live.text + event.delta).slice(
+                  -LIVE_ASSISTANT_MAX_LENGTH,
+                ),
+              }
+            : {
+                ...live,
+                thinking: (live.thinking + event.delta).slice(
+                  -LIVE_ASSISTANT_MAX_LENGTH,
+                ),
+              };
+        break;
+      }
+      case "AssistantMessage":
+        appendTranscript(s, {
+          kind: "assistant",
+          parts: event.parts.map((part) =>
+            part.type === "toolCall"
+              ? {
+                  ...part,
+                  argsPreview: part.argsPreview
+                    ? boundedTranscriptText(part.argsPreview)
+                    : undefined,
+                }
+              : { ...part, text: boundedTranscriptText(part.text) },
+          ),
+        });
+        s.liveAssistant = undefined;
+        s.turns++;
+        break;
+      case "ToolStart":
+        entry.liveToolMap.set(event.toolId, {
+          toolId: event.toolId,
+          name: event.name,
+          argsPreview: event.argsPreview
+            ? boundedTranscriptText(event.argsPreview)
+            : undefined,
+        });
+        s.liveTools = [...entry.liveToolMap.values()];
+        break;
+      case "ToolUpdate": {
+        const current = entry.liveToolMap.get(event.toolId);
+        if (current) {
+          entry.liveToolMap.set(event.toolId, {
+            ...current,
+            outputPreview: event.outputPreview
+              ? boundedTranscriptText(event.outputPreview)
+              : current.outputPreview,
+          });
+          s.liveTools = [...entry.liveToolMap.values()];
+        }
+        break;
+      }
+      case "ToolEnd":
+        entry.liveToolMap.delete(event.toolId);
+        s.liveTools = [...entry.liveToolMap.values()];
+        appendTranscript(s, {
+          kind: "toolResult",
+          toolId: event.toolId,
+          name: event.name,
+          isError: event.isError,
+          outputPreview: event.outputPreview
+            ? boundedTranscriptText(event.outputPreview)
+            : undefined,
+        });
+        break;
+      case "QueueChanged":
+        s.queued = event.queued;
+        break;
+      case "UsageChanged":
+        s.usage = {
+          tokens: event.tokens ?? s.usage.tokens,
+          contextWindow: event.contextWindow ?? s.usage.contextWindow,
+        };
+        break;
+      case "MetaChanged":
+        s.meta = { ...s.meta, ...event.meta };
+        break;
+      case "BackendError":
+        s.errorText = bounded(event.message);
+        break;
+    }
+    notify(s.id);
+  };
+
+  const spawn = (backendName: BackendName, task: SpawnTask) =>
+    Effect.gen(function* () {
+      // Reserve synchronously (before the first yield inside doSpawn) so
+      // parallel tool calls cannot race past the global cap.
+      yield* Effect.suspend(
+        (): Effect.Effect<void, SpawnError | ConcurrencyLimitError> => {
+          if (disposed) {
+            return new SpawnError({
+              message: "Subagent manager is shutting down.",
+            });
+          }
+          if (runningCount() + reserved >= MAX_RUNNING) {
+            return new ConcurrencyLimitError({
+              message: `Max ${MAX_RUNNING} subagents can run concurrently. Wait for one to finish before spawning another.`,
+            });
+          }
+          reserved++;
+          return Effect.void;
+        },
+      );
+
+      const doSpawn = Effect.gen(function* () {
+        const backend: SubagentBackend | undefined = registry.get(backendName);
+        if (!backend) {
+          return yield* new BackendUnavailableError({
+            message: `Unknown backend "${backendName}".`,
+          });
+        }
+        const available = yield* backend.available;
+        if (!available) {
+          return yield* new BackendUnavailableError({
+            message: `Backend "${backendName}" is not available on this machine (binary/SDK/credentials missing).`,
+          });
+        }
+
+        const scope = yield* Scope.make();
+        const session = yield* Scope.provide(backend.spawn(task), scope).pipe(
+          Effect.onError(() => Scope.close(scope, Exit.void)),
+        );
+        if (disposed) {
+          yield* Scope.close(scope, Exit.void);
+          return yield* new SpawnError({
+            message: "Subagent manager shut down while spawning.",
+          });
+        }
+
+        const origin = task.origin ?? "model";
+        const id =
+          origin === "btw" ? `btw-${++btwCounter}` : `sa-${++modelCounter}`;
+        const meta = yield* session.meta;
+        const entry: Entry = {
+          snapshot: {
+            id,
+            origin,
+            backend: backendName,
+            title: task.title,
+            prompt: task.prompt,
+            cwd: task.cwd,
+            status: "running",
+            createdAt: Date.now(),
+            meta,
+            usage: { contextWindow: meta.contextWindow },
+            transcript: [],
+            liveTools: [],
+            queued: [],
+            finalText: "",
+            turns: 0,
+            settlement: 0,
+          },
+          session,
+          scope,
+          liveToolMap: new Map(),
+        };
+        entries.set(id, entry);
+
+        // Pump: fold the event stream into the snapshot. Tied to the entry
+        // scope, so closing the scope stops it. If the stream ends while the
+        // subagent still looks running, the backend died out from under us.
+        const pump = Stream.runForEach(session.events, (event) =>
+          Effect.sync(() => foldEvent(entry, event)),
+        ).pipe(
+          Effect.ensuring(
+            Effect.sync(() => {
+              if (entry.snapshot.status === "running") {
+                settle(entry, {
+                  _tag: "Failed",
+                  errorText: "Backend event stream ended unexpectedly",
+                });
+              }
+            }),
+          ),
+        );
+        entry.pump = yield* Scope.provide(Effect.forkScoped(pump), scope);
+
+        notify(id);
+        return entry.snapshot as SubagentSnapshot;
+      });
+
+      return yield* doSpawn.pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            reserved--;
+            notify();
+          }),
+        ),
+      );
+    });
+
+  const waitFor = (
+    ids: ReadonlyArray<string>,
+    onPending?: (pending: string[]) => void,
+  ) =>
+    Effect.suspend(() => {
+      const unique = [...new Set(ids)];
+      addInterest(unique);
+      const loop = Effect.gen(function* () {
+        while (true) {
+          const version = changes.version();
+          const pending = unique.filter(
+            (id) => entries.get(id)?.snapshot.status === "running",
+          );
+          if (pending.length === 0) return;
+          onPending?.(pending);
+          yield* changes.wait(version);
+        }
+      });
+      return loop.pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            releaseInterest(unique);
+            pruneSettled();
+          }),
+        ),
+      );
+    });
+
+  /** Interrupt one running entry, force-closing its scope after 5s. */
+  const abortEntry = (entry: Entry) =>
+    Effect.gen(function* () {
+      if (entry.snapshot.status !== "running") return;
+      const graceful = yield* entry.session.interrupt.pipe(
+        Effect.timeout(STOP_TIMEOUT_MS),
+        Effect.result,
+      );
+      if (Result.isFailure(graceful)) {
+        // Settle before closing the scope so the pump's stream-ended
+        // fallback ("Backend event stream ended unexpectedly") cannot win
+        // the race and report the wrong terminal reason.
+        yield* Effect.sync(() => {
+          settle(entry, { _tag: "Interrupted" });
+          entry.snapshot.errorText =
+            "Abort deadline exceeded; session was force-disposed";
+          notify(entry.snapshot.id);
+        });
+        // Bound the close like disposeAll does: a stuck backend finalizer
+        // must not hang cancel after the run is already settled.
+        yield* closeEntryScope(entry).pipe(
+          Effect.timeout(STOP_TIMEOUT_MS),
+          Effect.ignore,
+        );
+      }
+    });
+
+  const cancel = (ids: ReadonlyArray<string>) =>
+    Effect.suspend(() => {
+      const unique = [...new Set(ids)];
+      const running = unique
+        .map((id) => entries.get(id))
+        .filter(
+          (entry): entry is Entry => entry?.snapshot.status === "running",
+        );
+      const runningIds = running.map((entry) => entry.snapshot.id);
+      // Mark consumed before interrupting so cancellation does not also
+      // enqueue duplicate automatic result messages into the parent.
+      addInterest(runningIds);
+      const work = Effect.gen(function* () {
+        yield* Effect.forEach(running, abortEntry, {
+          concurrency: "unbounded",
+        });
+        while (true) {
+          const version = changes.version();
+          if (!running.some((entry) => entry.snapshot.status === "running"))
+            break;
+          yield* changes.wait(version);
+        }
+      });
+      return work.pipe(
+        Effect.ensuring(
+          Effect.sync(() => {
+            releaseInterest(runningIds);
+            pruneSettled();
+          }),
+        ),
+        Effect.map((): ReadonlyArray<CancelResult> =>
+          unique.map((id) => {
+            const snapshot = entries.get(id)?.snapshot;
+            return {
+              id,
+              title: snapshot?.title ?? "?",
+              status: snapshot?.status ?? "error",
+              cancelled: runningIds.includes(id),
+            };
+          }),
+        ),
+      );
+    });
+
+  const send = (id: string, text: string) =>
+    Effect.suspend((): Effect.Effect<void, SendError> => {
+      const entry = entries.get(id);
+      if (!entry || disposed) {
+        return new SendError({
+          message: `Subagent "${id}" is no longer tracked.`,
+        });
+      }
+      // Restarting a settled subagent occupies a running slot again, so it
+      // must respect the same cap as spawn. Steering an already-running one
+      // does not consume additional capacity.
+      if (entry.snapshot.status !== "running") {
+        if (runningCount() + reserved >= MAX_RUNNING) {
+          return new SendError({
+            message: `Max ${MAX_RUNNING} subagents can run concurrently; restarting "${id}" would exceed that.`,
+          });
+        }
+        // Occupy the slot synchronously: the RunStarted that flips status
+        // arrives via the async pump, and two concurrent restarts must not
+        // both pass the check in that window. Cleared by RunStarted/settle,
+        // or here when the backend rejects the send.
+        entry.restarting = true;
+        return entry.session.send(text).pipe(
+          Effect.onError(() =>
+            Effect.sync(() => {
+              entry.restarting = false;
+            }),
+          ),
+        );
+      }
+      return entry.session.send(text);
+    });
+
+  const disposeAll = Effect.gen(function* () {
+    disposed = true;
+    const all = [...entries.values()];
+    entries.clear();
+    yield* Effect.forEach(
+      all,
+      (entry) =>
+        closeEntryScope(entry).pipe(
+          Effect.timeout(STOP_TIMEOUT_MS),
+          Effect.ignore,
+        ),
+      { concurrency: "unbounded" },
+    );
+    // Pruning cleanups are detached; bound them like everything else so a
+    // stuck backend finalizer cannot block runtime shutdown indefinitely.
+    yield* Effect.forEach(
+      [...cleanups],
+      (fiber) =>
+        Fiber.await(fiber).pipe(Effect.timeout(STOP_TIMEOUT_MS), Effect.ignore),
+      { concurrency: "unbounded" },
+    ).pipe(Effect.ignore);
+    yield* Effect.sync(() => notify());
+  });
+
+  const view: SubagentReadModel = {
+    list: () => [...entries.values()].map((entry) => entry.snapshot),
+    get: (id) => entries.get(id)?.snapshot,
+    size: () => entries.size,
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => listeners.delete(listener);
+    },
+    subscribeTo: (id, listener) => {
+      let set = idListeners.get(id);
+      if (!set) {
+        set = new Set();
+        idListeners.set(id, set);
+      }
+      set.add(listener);
+      return () => {
+        set.delete(listener);
+        if (set.size === 0) idListeners.delete(id);
+      };
+    },
+    requestSend: (id, text, onError) => {
+      runDetached(
+        send(id, text).pipe(
+          Effect.catch((error) =>
+            Effect.sync(() => onError?.(error.message)),
+          ),
+        ),
+      );
+    },
+    requestAbort: (id) => {
+      const entry = entries.get(id);
+      if (!entry) return;
+      // UI-initiated aborts are not "consumed": the failed result still
+      // flows back to the parent as a follow-up message, matching v1.
+      runDetached(abortEntry(entry).pipe(Effect.ignore));
+    },
+    setOnSettled: (hook) => {
+      onSettled = hook;
+    },
+  };
+
+  // Safety net: disposing the ManagedRuntime tears everything down even if
+  // the extension forgot to call disposeAll explicitly.
+  yield* Effect.addFinalizer(() => disposeAll);
+
+  return SubagentManager.of({
+    spawn,
+    waitFor,
+    cancel,
+    send,
+    get: (id) => Effect.sync(() => entries.get(id)?.snapshot),
+    list: Effect.sync(() => [...entries.values()].map((e) => e.snapshot)),
+    disposeAll,
+    view,
+  });
+});
+
+export const SubagentManagerLive: Layer.Layer<
+  SubagentManager,
+  never,
+  BackendRegistry
+> = Layer.effect(SubagentManager, makeManager);

--- a/users/profiles/pi/extensions/subagents/src/prompt.ts
+++ b/users/profiles/pi/extensions/subagents/src/prompt.ts
@@ -1,0 +1,92 @@
+/** All model-facing strings for the subagents tools. */
+
+/** Describes subagent_spawn, including harnesses and the fixed concurrency cap. */
+export const SUBAGENT_SPAWN_TOOL_DESCRIPTION =
+  "Spawn a background subagent: a fully autonomous, headless agent with its own context window and the selected harness's normal host permissions. You choose the harness it runs on: pi (in-process pi session, inherits this environment's tools and config) or claude (Claude Code). Fire-and-forget: this returns immediately with an id. The subagent's final output is queued back to you as a message when it settles, or collect it explicitly with subagent_wait. Children cannot orchestrate more agents/workflows or ask the user, and cannot see this conversation, so the prompt must be self-contained. Max 4 subagents can be running at once across both harnesses.";
+
+/** Adds background subagent delegation to the parent model's available-tools prompt. */
+export const SUBAGENT_SPAWN_PROMPT_SNIPPET =
+  "Spawn a background subagent on Pi or Claude Code for a self-contained task";
+
+/** Guides the parent model to delegate standalone tasks and avoid unnecessary blocking waits. */
+export const SUBAGENT_SPAWN_PROMPT_GUIDELINES = [
+  "Use subagent_spawn to delegate self-contained tasks that can run in the background; give it a complete, standalone prompt.",
+  "Pick the subagent harness deliberately: use pi for OpenAI and other configured models, or Claude Code when the task benefits from Claude.",
+  "After subagent_spawn, keep working; results arrive automatically. Only call subagent_wait when you cannot proceed without the result.",
+];
+
+/** Model-facing schema descriptions for subagent_spawn task and execution options. */
+export const SUBAGENT_SPAWN_PARAMETER_DESCRIPTIONS = {
+  prompt:
+    "Task prompt for the subagent. Must be self-contained: include all needed context, file paths, and what to report back.",
+  name: "Short human-readable name for this subagent, shown in listings and the UI",
+  harness:
+    'Harness to run the subagent on: "pi" (in-process pi session; inherits this environment) or "claude" (Claude Code).',
+  workingDir:
+    "Working directory for the autonomous child (default: current working directory).",
+  model:
+    'Model hint, interpreted by the chosen harness (pi: "provider/model-id" or model id; claude: model alias like "sonnet"/"opus"). Omit for the harness default (pi inherits the current model).',
+  reasoningEffort:
+    "Reasoning effort on a shared scale; pi uses it as its thinking level and Claude maps it to a thinking budget. Omit for the harness default (pi inherits the current level).",
+};
+
+/** Builds the subagent_spawn result that tells the parent model how to continue or inspect the child. */
+export function buildSubagentSpawnResult(options: {
+  id: string;
+  title: string;
+  harness: string;
+  modelLabel: string;
+  cwd: string;
+}) {
+  return (
+    `Spawned subagent ${options.id} "${options.title}" (${options.harness}: ${options.modelLabel}, ${options.cwd}).\n` +
+    `It runs in the background. Its result will be delivered to you when it finishes, ` +
+    `or use subagent_wait(ids: ["${options.id}"]) to block for it, subagent_cancel to stop it, subagent_check to peek, subagent_list to see all.`
+  );
+}
+
+/** Describes explicit blocking collection of one or more subagent results. */
+export const SUBAGENT_WAIT_TOOL_DESCRIPTION =
+  "Block until all listed subagents have settled, then return their final outputs. Prefer letting results arrive automatically; use this only when you need a result before continuing.";
+
+/** Model-facing schema description for the subagent ids to await. */
+export const SUBAGENT_WAIT_PARAMETER_DESCRIPTIONS = {
+  ids: 'Subagent ids to wait for, e.g. ["sa-1", "sa-2"]',
+};
+
+/** Describes aborting running subagents while retaining their partial transcripts. */
+export const SUBAGENT_CANCEL_TOOL_DESCRIPTION =
+  "Cancel one or more running subagents. This aborts their active work but preserves their partial session transcripts on disk.";
+
+/** Model-facing schema description for the subagent ids to cancel. */
+export const SUBAGENT_CANCEL_PARAMETER_DESCRIPTIONS = {
+  ids: 'Subagent ids to cancel, e.g. ["sa-1", "sa-2"]',
+};
+
+/** Describes nonblocking inspection of a subagent without consuming its result. */
+export const SUBAGENT_CHECK_TOOL_DESCRIPTION =
+  "Peek at a subagent's status and recent activity without blocking. Does not consume its result.";
+
+/** Model-facing schema description for the subagent id to inspect. */
+export const SUBAGENT_CHECK_PARAMETER_DESCRIPTIONS = {
+  id: "Subagent id",
+};
+
+/** Describes listing all tracked running and settled subagents. */
+export const SUBAGENT_LIST_TOOL_DESCRIPTION =
+  "List all subagents (running and finished) with their harness and status.";
+
+/** Builds the child completion/failure wrapper injected into the parent model's context. */
+export function buildSubagentResultMessage(options: {
+  id: string;
+  title: string;
+  status: "running" | "done" | "error";
+  errorText?: string;
+  output: string;
+}) {
+  const verb = options.status === "error" ? "failed" : "finished";
+  let text = `Subagent ${options.id} "${options.title}" ${verb}.`;
+  if (options.errorText) text += `\nError: ${options.errorText}`;
+  text += `\n\n${options.output}`;
+  return text;
+}

--- a/users/profiles/pi/extensions/subagents/src/result-delivery.ts
+++ b/users/profiles/pi/extensions/subagents/src/result-delivery.ts
@@ -1,0 +1,20 @@
+export function createDeferredResultDelivery<T extends { id: string }>() {
+  const pending = new Map<string, T>();
+
+  return {
+    defer(result: T) {
+      pending.set(result.id, result);
+    },
+    consume(ids: Iterable<string>) {
+      for (const id of ids) pending.delete(id);
+    },
+    drain() {
+      const results = [...pending.values()];
+      pending.clear();
+      return results;
+    },
+    clear() {
+      pending.clear();
+    },
+  };
+}

--- a/users/profiles/pi/extensions/subagents/src/runtime.ts
+++ b/users/profiles/pi/extensions/subagents/src/runtime.ts
@@ -1,0 +1,52 @@
+/**
+ * Layer composition and the async entry-point boundary.
+ *
+ * Everything inside the extension is Effect generators; this module is where
+ * tool handlers (plain async functions) run those effects against one shared
+ * ManagedRuntime.
+ */
+
+import { Cause, Exit, Layer, ManagedRuntime, type Effect } from "effect";
+import { BackendRegistry, type SubagentBackend } from "./backend.ts";
+import { claudeBackend } from "./backends/claude.ts";
+import { piBackend } from "./backends/pi.ts";
+import type { BackendName } from "./domain.ts";
+
+const BackendRegistryLive = Layer.sync(BackendRegistry, () => {
+  const backends: SubagentBackend[] = [piBackend, claudeBackend];
+  return new Map<BackendName, SubagentBackend>(
+    backends.map((backend) => [backend.name, backend]),
+  );
+});
+
+import { SubagentManagerLive } from "./manager.ts";
+
+const AppLayer = SubagentManagerLive.pipe(Layer.provide(BackendRegistryLive));
+
+export function createSubagentRuntime() {
+  return ManagedRuntime.make(AppLayer);
+}
+
+export type SubagentRuntime = ReturnType<typeof createSubagentRuntime>;
+
+/**
+ * Run an effect from an async tool handler. Typed failures and defects are
+ * converted to thrown Errors (what pi's tool contract expects); interruption
+ * (tool AbortSignal) throws `interruptMessage`.
+ */
+export async function runTool<A, E>(
+  runtime: SubagentRuntime,
+  effect: Effect.Effect<A, E>,
+  options: { signal?: AbortSignal; interruptMessage?: string } = {},
+) {
+  const exit = await runtime.runPromiseExit(
+    effect,
+    options.signal ? { signal: options.signal } : undefined,
+  );
+  if (Exit.isSuccess(exit)) return exit.value;
+  if (Cause.hasInterruptsOnly(exit.cause)) {
+    throw new Error(options.interruptMessage ?? "Operation was aborted.");
+  }
+  const [first] = Cause.prettyErrors(exit.cause);
+  throw new Error(first?.message ?? Cause.pretty(exit.cause));
+}

--- a/users/profiles/pi/extensions/subagents/src/tool-call-timeout.ts
+++ b/users/profiles/pi/extensions/subagents/src/tool-call-timeout.ts
@@ -1,0 +1,104 @@
+import type { ToolDefinition } from "@earendil-works/pi-coding-agent";
+
+export const CHILD_TOOL_CALL_TIMEOUT_MS = 3 * 60 * 1_000;
+
+interface ToolRegistry {
+  getAllTools(): Array<{ name: string }>;
+  getToolDefinition(name: string): ToolDefinition | undefined;
+}
+
+function formatTimeout(timeoutMs: number) {
+  if (timeoutMs % 60_000 === 0) {
+    const minutes = timeoutMs / 60_000;
+    return `${minutes} minute${minutes === 1 ? "" : "s"}`;
+  }
+  if (timeoutMs % 1_000 === 0) {
+    const seconds = timeoutMs / 1_000;
+    return `${seconds} second${seconds === 1 ? "" : "s"}`;
+  }
+  return `${timeoutMs} ms`;
+}
+
+export class ToolCallTimeoutError extends Error {
+  constructor(toolName: string, timeoutMs: number) {
+    super(
+      `Tool call "${toolName}" timed out after ${formatTimeout(timeoutMs)}.`,
+    );
+    this.name = "ToolCallTimeoutError";
+  }
+}
+
+export async function runWithToolCallTimeout<T>(
+  toolName: string,
+  timeoutMs: number,
+  signal: AbortSignal | undefined,
+  execute: (signal: AbortSignal) => Promise<T>,
+) {
+  const timeoutController = new AbortController();
+  const executionSignal = signal
+    ? AbortSignal.any([signal, timeoutController.signal])
+    : timeoutController.signal;
+  const timeoutError = new ToolCallTimeoutError(toolName, timeoutMs);
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const timeout = new Promise<never>((_resolve, reject) => {
+    timer = setTimeout(() => {
+      reject(timeoutError);
+      timeoutController.abort(timeoutError);
+    }, timeoutMs);
+  });
+
+  let removeAbortListener: (() => void) | undefined;
+  const aborted = new Promise<never>((_resolve, reject) => {
+    if (!signal) return;
+    const onAbort = () => {
+      reject(
+        signal.reason instanceof Error
+          ? signal.reason
+          : new Error(`Tool call "${toolName}" was aborted.`),
+      );
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener("abort", onAbort, { once: true });
+    removeAbortListener = () => signal.removeEventListener("abort", onAbort);
+  });
+
+  try {
+    return await Promise.race([execute(executionSignal), timeout, aborted]);
+  } finally {
+    if (timer) clearTimeout(timer);
+    removeAbortListener?.();
+  }
+}
+
+/**
+ * Wrap every currently registered child tool with an independent execution
+ * timeout. Calling apply() again is safe and picks up tools registered later.
+ */
+export function createToolCallTimeoutGuard(
+  timeoutMs = CHILD_TOOL_CALL_TIMEOUT_MS,
+) {
+  const wrapped = new WeakSet<ToolDefinition>();
+
+  const wrap = (definition: ToolDefinition) => {
+    if (wrapped.has(definition)) return;
+    wrapped.add(definition);
+
+    const execute = definition.execute;
+    definition.execute = async (toolCallId, params, signal, onUpdate, ctx) =>
+      runWithToolCallTimeout(definition.name, timeoutMs, signal, (signal) =>
+        execute.call(definition, toolCallId, params, signal, onUpdate, ctx),
+      );
+  };
+
+  return {
+    apply(session: ToolRegistry) {
+      for (const { name } of session.getAllTools()) {
+        const definition = session.getToolDefinition(name);
+        if (definition) wrap(definition);
+      }
+    },
+  };
+}

--- a/users/profiles/pi/extensions/subagents/src/ui/takeover.ts
+++ b/users/profiles/pi/extensions/subagents/src/ui/takeover.ts
@@ -1,0 +1,599 @@
+/**
+ * Takeover UI for subagents (ported from v1, rendering from the synchronous
+ * SubagentReadModel instead of live pi sessions):
+ * - SubagentDashboard: full popup (overlay) listing all subagents.
+ * - TakeoverView: full interactive view of one subagent with an input line
+ *   to steer/continue it.
+ */
+
+import type {
+  ExtensionCommandContext,
+  KeybindingsManager,
+  Theme,
+} from "@earendil-works/pi-coding-agent";
+import type { Component, Focusable, TUI } from "@earendil-works/pi-tui";
+import { Input, truncateToWidth, visibleWidth } from "@earendil-works/pi-tui";
+import { formatElapsed, type SubagentSnapshot } from "../domain.ts";
+import { formatContextUtilization } from "../format.ts";
+import type { SubagentReadModel } from "../manager.ts";
+import { buildTranscriptLines } from "./transcript.ts";
+
+function configuredKeys(
+  keybindings: KeybindingsManager,
+  binding: Parameters<KeybindingsManager["getKeys"]>[0],
+) {
+  return keybindings.getKeys(binding).join("/") || "unbound";
+}
+
+function statusGlyph(snap: SubagentSnapshot, theme: Theme): string {
+  switch (snap.status) {
+    case "running":
+      return theme.fg("warning", "■");
+    case "done":
+      return theme.fg("success", "■");
+    case "error":
+      return theme.fg("error", "■");
+  }
+}
+
+function statusWord(snap: SubagentSnapshot, theme: Theme): string {
+  switch (snap.status) {
+    case "running":
+      return theme.fg("warning", "running");
+    case "done":
+      return theme.fg("success", "done");
+    case "error":
+      return theme.fg("error", "failed");
+  }
+}
+
+// --- Entry points --------------------------------------------------------------
+
+export interface TakeoverOptions {
+  readonly badge?: string;
+}
+
+export async function openSubagentTakeover(
+  ctx: ExtensionCommandContext,
+  view: SubagentReadModel,
+  id: string,
+  options?: TakeoverOptions,
+) {
+  if (!view.get(id)) return;
+  await ctx.ui.custom<null>(
+    (tui, theme, keybindings, done) =>
+      new TakeoverView(tui, theme, keybindings, id, view, done, options),
+    {
+      overlay: true,
+      overlayOptions: { anchor: "center", width: "100%", maxHeight: "100%" },
+    },
+  );
+}
+
+export async function openSubagentPicker(
+  ctx: ExtensionCommandContext,
+  view: SubagentReadModel,
+) {
+  const selection: DashboardSelection = { index: 0 };
+
+  while (true) {
+    if (view.size() === 0) {
+      ctx.ui.notify("No subagents", "info");
+      return;
+    }
+
+    const picked = await ctx.ui.custom<string | null>(
+      (tui, theme, keybindings, done) =>
+        new SubagentDashboard(tui, theme, keybindings, view, selection, done),
+      {
+        overlay: true,
+        overlayOptions: { anchor: "center", width: "100%", maxHeight: "100%" },
+      },
+    );
+
+    if (!picked) return;
+    if (!view.get(picked)) continue;
+
+    await openSubagentTakeover(ctx, view, picked);
+    // After leaving the takeover view, fall back to the dashboard.
+  }
+}
+
+// --- Dashboard (fullscreen overlay) ----------------------------------------------
+
+export interface DashboardSelection {
+  id?: string;
+  index: number;
+}
+
+export function reconcileDashboardSelection(
+  selection: DashboardSelection,
+  subs: ReadonlyArray<Pick<SubagentSnapshot, "id">>,
+) {
+  const stableIndex = selection.id
+    ? subs.findIndex((snap) => snap.id === selection.id)
+    : -1;
+  selection.index =
+    stableIndex >= 0
+      ? stableIndex
+      : Math.min(Math.max(0, selection.index), Math.max(0, subs.length - 1));
+  selection.id = subs[selection.index]?.id;
+}
+
+class SubagentDashboard implements Component {
+  private tui: TUI;
+  private theme: Theme;
+  private keybindings: KeybindingsManager;
+  private view: SubagentReadModel;
+  private selection: DashboardSelection;
+  private done: (value: string | null) => void;
+
+  private closed = false;
+  private ticker: ReturnType<typeof setInterval>;
+  private unsubChange: () => void;
+
+  constructor(
+    tui: TUI,
+    theme: Theme,
+    keybindings: KeybindingsManager,
+    view: SubagentReadModel,
+    selection: DashboardSelection,
+    done: (value: string | null) => void,
+  ) {
+    this.tui = tui;
+    this.theme = theme;
+    this.keybindings = keybindings;
+    this.view = view;
+    this.selection = selection;
+    this.done = done;
+    // Elapsed times, token counts, and statuses tick along at 1Hz.
+    this.ticker = setInterval(() => this.tui.requestRender(), 1000);
+    this.unsubChange = view.subscribe(() => this.tui.requestRender());
+  }
+
+  private subs(): ReadonlyArray<SubagentSnapshot> {
+    return this.view.list();
+  }
+
+  private cleanup() {
+    if (this.closed) return false;
+    this.closed = true;
+    clearInterval(this.ticker);
+    this.unsubChange();
+    return true;
+  }
+
+  private close(result: string | null) {
+    if (this.cleanup()) this.done(result);
+  }
+
+  dispose(): void {
+    this.cleanup();
+  }
+
+  handleInput(data: string): void {
+    const subs = this.subs();
+    reconcileDashboardSelection(this.selection, subs);
+
+    if (this.keybindings.matches(data, "tui.select.cancel")) {
+      this.close(null);
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.select.confirm")) {
+      const snap = subs[this.selection.index];
+      if (snap) this.close(snap.id);
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.select.up") || data === "k") {
+      if (subs.length > 0) {
+        this.selection.index =
+          (this.selection.index - 1 + subs.length) % subs.length;
+        this.selection.id = subs[this.selection.index]?.id;
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.select.down") || data === "j") {
+      if (subs.length > 0) {
+        this.selection.index = (this.selection.index + 1) % subs.length;
+        this.selection.id = subs[this.selection.index]?.id;
+        this.tui.requestRender();
+      }
+      return;
+    }
+    if (data === "x") {
+      const snap = subs[this.selection.index];
+      if (snap && snap.status === "running") this.view.requestAbort(snap.id);
+      return;
+    }
+  }
+
+  private pad(text: string, width: number): string {
+    const truncated = truncateToWidth(text, width);
+    return truncated + " ".repeat(Math.max(0, width - visibleWidth(truncated)));
+  }
+
+  private borderSegment(width: number, title: string): string {
+    const theme = this.theme;
+    const label = title
+      ? ` ${truncateToWidth(title, Math.max(0, width - 3))} `
+      : "";
+    const labelWidth = visibleWidth(label);
+    return (
+      theme.fg("border", "─") +
+      (label ? theme.fg("text", label) : "") +
+      theme.fg("border", "─".repeat(Math.max(0, width - 1 - labelWidth)))
+    );
+  }
+
+  render(width: number): string[] {
+    const theme = this.theme;
+    const subs = this.subs();
+    reconcileDashboardSelection(this.selection, subs);
+
+    const rows = this.tui.terminal.rows || 30;
+    // Render exactly terminal rows - 1 so the overlay covers the header,
+    // chat, editor, and extra footer lines while leaving pi's final footer
+    // row visible.
+    const bodyHeight = Math.max(6, rows - 5);
+    const innerWidth = width - 2;
+
+    const lines: string[] = [];
+
+    // Header: title left, count right
+    const headerLeft = theme.fg("accent", theme.bold("Subagents"));
+    const headerRight = theme.fg(
+      "muted",
+      `${subs.length} agent${subs.length === 1 ? "" : "s"}`,
+    );
+    const headerPad = Math.max(
+      1,
+      width - visibleWidth(headerLeft) - visibleWidth(headerRight) - 4,
+    );
+    lines.push(
+      truncateToWidth(
+        `  ${headerLeft}${" ".repeat(headerPad)}${headerRight}  `,
+        width,
+      ),
+    );
+
+    // Top border with panel title
+    const settled = subs.filter((s) => s.status !== "running").length;
+    lines.push(
+      theme.fg("border", "╭") +
+        this.borderSegment(innerWidth, `agents · ${settled}/${subs.length}`) +
+        theme.fg("border", "╮"),
+    );
+
+    // Rows
+    const divider = theme.fg("border", "│");
+    const rowLines = this.renderRows(subs, innerWidth, bodyHeight);
+    for (let i = 0; i < bodyHeight; i++) {
+      lines.push(divider + this.pad(rowLines[i] ?? "", innerWidth) + divider);
+    }
+
+    // Bottom border
+    lines.push(
+      theme.fg("border", "╰") +
+        theme.fg("border", "─".repeat(innerWidth)) +
+        theme.fg("border", "╯"),
+    );
+
+    // Hints
+    lines.push(
+      truncateToWidth(
+        theme.fg(
+          "dim",
+          `  ${configuredKeys(this.keybindings, "tui.select.up")}/${configuredKeys(this.keybindings, "tui.select.down")}/jk select · ${configuredKeys(this.keybindings, "tui.select.confirm")} take over · x abort · ${configuredKeys(this.keybindings, "tui.select.cancel")} close`,
+        ),
+        width,
+      ),
+    );
+
+    return lines;
+  }
+
+  private renderRows(
+    subs: ReadonlyArray<SubagentSnapshot>,
+    width: number,
+    height: number,
+  ): string[] {
+    const theme = this.theme;
+    const out: string[] = [];
+
+    // Scroll window around selection
+    let start = 0;
+    if (subs.length > height) {
+      start = Math.min(
+        Math.max(0, this.selection.index - Math.floor(height / 2)),
+        subs.length - height,
+      );
+    }
+    const visible = subs.slice(start, start + height);
+
+    for (let i = 0; i < visible.length; i++) {
+      const snap = visible[i];
+      const index = start + i;
+      const isSelected = index === this.selection.index;
+
+      // Left: marker, status square, title, dim id
+      const marker = isSelected ? theme.fg("accent", "❯") : " ";
+      const title = isSelected
+        ? theme.fg("accent", snap.title)
+        : theme.fg("text", snap.title);
+      const left = ` ${marker} ${statusGlyph(snap, theme)} ${title} ${theme.fg("dim", snap.id)}`;
+
+      // Right: backend · model · context utilization · elapsed · status
+      const utilization = formatContextUtilization(snap.usage);
+      const dot = theme.fg("dim", " · ");
+      const rightParts = [
+        theme.fg("muted", snap.backend),
+        theme.fg("muted", snap.meta.modelLabel ?? "?"),
+        ...(utilization ? [theme.fg("muted", utilization)] : []),
+        theme.fg("muted", formatElapsed(snap)),
+        statusWord(snap, theme),
+      ];
+      const right = `${rightParts.join(dot)} `;
+
+      const rightWidth = visibleWidth(right);
+      const leftMax = Math.max(0, width - rightWidth - 2);
+      const leftTruncated = truncateToWidth(left, leftMax);
+      const gap = Math.max(2, width - visibleWidth(leftTruncated) - rightWidth);
+      out.push(truncateToWidth(leftTruncated + " ".repeat(gap) + right, width));
+    }
+
+    if (start > 0) {
+      out[0] = truncateToWidth(
+        `${theme.fg("dim", `... ${start} more ·`)} ${out[0]}`,
+        width,
+      );
+    }
+    if (start + height < subs.length) {
+      out[out.length - 1] = truncateToWidth(
+        `${theme.fg("dim", `... ${subs.length - start - height} more ·`)} ${out[out.length - 1]}`,
+        width,
+      );
+    }
+    return out;
+  }
+
+  invalidate(): void {}
+}
+
+// --- Takeover view ------------------------------------------------------------
+
+const TRANSCRIPT_SCROLL_STEP = 6;
+
+class TakeoverView implements Component, Focusable {
+  private tui: TUI;
+  private theme: Theme;
+  private keybindings: KeybindingsManager;
+  private id: string;
+  private view: SubagentReadModel;
+  private done: (value: null) => void;
+  private options?: TakeoverOptions;
+
+  private input = new Input();
+  /** Scroll offset in lines from the bottom of the transcript. 0 = pinned to bottom. */
+  private scrollOffset = 0;
+  private unsubscribe: () => void;
+  private renderTimer?: ReturnType<typeof setTimeout>;
+  private ticker: ReturnType<typeof setInterval>;
+  private closed = false;
+  private sendError?: string;
+
+  private _focused = false;
+  get focused(): boolean {
+    return this._focused;
+  }
+  set focused(value: boolean) {
+    this._focused = value;
+    this.input.focused = value;
+  }
+
+  constructor(
+    tui: TUI,
+    theme: Theme,
+    keybindings: KeybindingsManager,
+    id: string,
+    view: SubagentReadModel,
+    done: (value: null) => void,
+    options?: TakeoverOptions,
+  ) {
+    this.tui = tui;
+    this.theme = theme;
+    this.keybindings = keybindings;
+    this.id = id;
+    this.view = view;
+    this.done = done;
+    this.options = options;
+    this.unsubscribe = view.subscribeTo(id, () => this.scheduleRender());
+    // Elapsed time in the header ticks along at 1Hz.
+    this.ticker = setInterval(() => this.tui.requestRender(), 1000);
+    this.input.onSubmit = (value: string) => {
+      const text = value.trim();
+      if (!text) return;
+      this.sendError = undefined;
+      this.input.setValue("");
+      this.view.requestSend(this.id, text, (message) => {
+        if (this.closed) return;
+        // Do not overwrite anything the user typed while the send was pending.
+        if (!this.input.getValue()) this.input.setValue(text);
+        this.sendError = message;
+        this.tui.requestRender();
+      });
+      this.scrollOffset = 0;
+      this.tui.requestRender();
+    };
+  }
+
+  private snap(): SubagentSnapshot | undefined {
+    return this.view.get(this.id);
+  }
+
+  private scheduleRender() {
+    if (this.renderTimer) return;
+    // Streaming can emit an event per token. Limit terminal repaints so this
+    // view cannot starve input handling or make the child look frozen.
+    this.renderTimer = setTimeout(() => {
+      this.renderTimer = undefined;
+      if (!this.closed) this.tui.requestRender();
+    }, 50);
+  }
+
+  private cleanup() {
+    if (this.closed) return false;
+    this.closed = true;
+    this.unsubscribe();
+    clearInterval(this.ticker);
+    if (this.renderTimer) clearTimeout(this.renderTimer);
+    this.renderTimer = undefined;
+    return true;
+  }
+
+  private close() {
+    if (this.cleanup()) this.done(null);
+  }
+
+  dispose(): void {
+    this.cleanup();
+  }
+
+  handleInput(data: string): void {
+    if (this.keybindings.matches(data, "app.clear")) {
+      const snap = this.snap();
+      if (snap?.status === "running") this.view.requestAbort(this.id);
+      return;
+    }
+    if (
+      this.keybindings.matches(data, "app.interrupt") ||
+      this.keybindings.matches(data, "tui.select.cancel")
+    ) {
+      this.close();
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.editor.cursorUp")) {
+      this.scrollOffset += TRANSCRIPT_SCROLL_STEP;
+      this.tui.requestRender();
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.editor.cursorDown")) {
+      this.scrollOffset = Math.max(
+        0,
+        this.scrollOffset - TRANSCRIPT_SCROLL_STEP,
+      );
+      this.tui.requestRender();
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.editor.pageUp")) {
+      this.scrollOffset += this.viewportHeight();
+      this.tui.requestRender();
+      return;
+    }
+    if (this.keybindings.matches(data, "tui.editor.pageDown")) {
+      this.scrollOffset = Math.max(
+        0,
+        this.scrollOffset - this.viewportHeight(),
+      );
+      this.tui.requestRender();
+      return;
+    }
+    this.input.handleInput(data);
+    this.tui.requestRender();
+  }
+
+  private viewportHeight(): number {
+    const rows = this.tui.terminal.rows || 30;
+    // The complete view renders viewport + 7 chrome rows. Using rows - 8
+    // makes the overlay exactly terminal rows - 1.
+    return Math.max(6, rows - 8);
+  }
+
+  render(width: number): string[] {
+    const theme = this.theme;
+    const border = theme.fg("borderAccent", "─".repeat(Math.max(1, width)));
+    const lines: string[] = [];
+    const snap = this.snap();
+
+    if (!snap) {
+      lines.push(border);
+      lines.push(theme.fg("dim", `${this.id} is no longer tracked`));
+      lines.push(border);
+      return lines;
+    }
+
+    lines.push(border);
+    const utilization = formatContextUtilization(snap.usage);
+    const header =
+      `${statusGlyph(snap, theme)} ` +
+      theme.fg("accent", theme.bold(`${snap.id} · ${snap.title}`)) +
+      theme.fg("muted", ` · ${snap.status} · ${formatElapsed(snap)}`) +
+      (this.options?.badge
+        ? theme.fg("muted", ` · ${this.options.badge}`)
+        : "") +
+      theme.fg("dim", ` · ${snap.backend}: ${snap.meta.modelLabel ?? "?"}`) +
+      (utilization ? theme.fg("dim", ` · ${utilization}`) : "");
+    lines.push(truncateToWidth(header, width));
+    lines.push(border);
+
+    // Fixed-height transcript viewport. Error and scroll status consume rows
+    // inside the viewport so streaming/scrolling never changes overlay height.
+    const transcript = buildTranscriptLines(snap, width, theme);
+    const viewport = this.viewportHeight();
+    const errorRows = (snap.errorText ? 1 : 0) + (this.sendError ? 1 : 0);
+    const scrollRows = this.scrollOffset > 0 ? 1 : 0;
+    const transcriptCapacity = Math.max(1, viewport - errorRows - scrollRows);
+    const maxOffset = Math.max(0, transcript.length - transcriptCapacity);
+    if (this.scrollOffset > maxOffset) this.scrollOffset = maxOffset;
+
+    const body: string[] = [];
+    if (snap.errorText) {
+      body.push(
+        truncateToWidth(theme.fg("error", `error: ${snap.errorText}`), width),
+      );
+    }
+    if (this.sendError) {
+      body.push(
+        truncateToWidth(theme.fg("error", `send failed: ${this.sendError}`), width),
+      );
+    }
+
+    const capacity = Math.max(
+      1,
+      viewport - body.length - (this.scrollOffset > 0 ? 1 : 0),
+    );
+    const end = transcript.length - this.scrollOffset;
+    const visible = transcript.slice(Math.max(0, end - capacity), end);
+    if (visible.length === 0) body.push(theme.fg("dim", "(no output yet)"));
+    else body.push(...visible);
+
+    if (this.scrollOffset > 0) {
+      body.push(
+        truncateToWidth(
+          theme.fg("dim", `... ${this.scrollOffset} lines below · ↓/pgdn`),
+          width,
+        ),
+      );
+    }
+    while (body.length < viewport) body.push("");
+    lines.push(...body.slice(0, viewport));
+
+    lines.push(border);
+    lines.push(...this.input.render(width));
+    lines.push(
+      truncateToWidth(
+        theme.fg(
+          "dim",
+          `${configuredKeys(this.keybindings, "tui.input.submit")} send · ${configuredKeys(this.keybindings, "app.interrupt")} back · ${configuredKeys(this.keybindings, "app.clear")} abort run · ${configuredKeys(this.keybindings, "tui.editor.cursorUp")}/${configuredKeys(this.keybindings, "tui.editor.cursorDown")} scroll · ${configuredKeys(this.keybindings, "tui.editor.pageUp")}/${configuredKeys(this.keybindings, "tui.editor.pageDown")} page`,
+        ),
+        width,
+      ),
+    );
+    lines.push(border);
+    return lines;
+  }
+
+  invalidate(): void {
+    this.input.invalidate();
+  }
+}

--- a/users/profiles/pi/extensions/subagents/src/ui/transcript.ts
+++ b/users/profiles/pi/extensions/subagents/src/ui/transcript.ts
@@ -1,0 +1,182 @@
+/**
+ * Transcript rendering for the takeover view: turns a SubagentSnapshot's
+ * normalized transcript + live state into plain wrapped lines. Ported from
+ * v1, with the session-poking replaced by snapshot reads.
+ */
+
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import {
+  truncateToWidth,
+  visibleWidth,
+  wrapTextWithAnsi,
+} from "@earendil-works/pi-tui";
+import type { SubagentSnapshot, TranscriptItem } from "../domain.ts";
+
+const ANSI_PATTERN =
+  // eslint-disable-next-line no-control-regex
+  /[\u001B\u009B][[\]()#;?]*(?:(?:(?:[a-zA-Z\d]*(?:;[a-zA-Z\d]*)*)?\u0007)|(?:(?:\d{1,4}(?:;\d{0,4})*)?[\dA-PR-TZcf-nq-uy=><~]))/g;
+
+/**
+ * Strip raw ANSI codes, expand tabs, and drop control chars. Terminal-expanded
+ * tabs (and stray escapes) make lines wider than the width we declare to the
+ * TUI, which desyncs the renderer and smears the overlay.
+ */
+export function sanitizeText(text: string): string {
+  return text
+    .replace(ANSI_PATTERN, "")
+    .replaceAll("\t", "  ")
+    .replace(/[\u0000-\u0008\u000b-\u001f\u007f]/g, "");
+}
+
+function renderUserText(
+  theme: Theme,
+  text: string,
+  width: number,
+  out: string[],
+) {
+  const clean = sanitizeText(text).trim();
+  if (!clean) return;
+  const wrapped = wrapTextWithAnsi(clean, Math.max(10, width - 2));
+  for (let i = 0; i < wrapped.length; i++) {
+    const prefix = i === 0 ? theme.fg("accent", "> ") : "  ";
+    out.push(
+      truncateToWidth(prefix + theme.fg("userMessageText", wrapped[i]), width),
+    );
+  }
+}
+
+function renderThinking(
+  theme: Theme,
+  text: string,
+  width: number,
+  out: string[],
+) {
+  const reasoning = sanitizeText(text).trim();
+  if (!reasoning) return;
+  const prefix = theme.fg("dim", "~ ");
+  const wrapped = wrapTextWithAnsi(reasoning, Math.max(10, width - 2));
+  for (let i = 0; i < wrapped.length; i++) {
+    out.push(
+      truncateToWidth(
+        (i === 0 ? prefix : "  ") + theme.fg("muted", theme.italic(wrapped[i])),
+        width,
+      ),
+    );
+  }
+}
+
+function renderAssistantItem(
+  theme: Theme,
+  item: Extract<TranscriptItem, { kind: "assistant" }>,
+  width: number,
+  out: string[],
+) {
+  for (const part of item.parts) {
+    if (part.type === "text") {
+      const text = sanitizeText(part.text).trim();
+      if (!text) continue;
+      out.push(...wrapTextWithAnsi(text, width));
+    } else if (part.type === "thinking") {
+      renderThinking(
+        theme,
+        part.redacted ? "[redacted reasoning]" : part.text,
+        width,
+        out,
+      );
+    } else if (part.type === "toolCall") {
+      const preview = part.argsPreview ? sanitizeText(part.argsPreview) : "";
+      const line =
+        theme.fg("muted", "→ ") +
+        theme.fg("toolTitle", part.name) +
+        (preview && preview !== "{}" ? theme.fg("dim", ` ${preview}`) : "");
+      out.push(truncateToWidth(line, width));
+    }
+  }
+}
+
+function renderToolResultItem(
+  theme: Theme,
+  item: Extract<TranscriptItem, { kind: "toolResult" }>,
+  width: number,
+  out: string[],
+) {
+  const firstLine =
+    sanitizeText(item.outputPreview ?? "")
+      .split("\n")
+      .find((line) => line.trim()) ?? "";
+  const label = item.isError
+    ? theme.fg("error", "  error: ")
+    : theme.fg("dim", "  output: ");
+  out.push(
+    truncateToWidth(label + theme.fg("dim", firstLine || "(no output)"), width),
+  );
+}
+
+/** Render a subagent's conversation as plain lines, wrapped to `width`. */
+export function buildTranscriptLines(
+  snap: SubagentSnapshot,
+  width: number,
+  theme: Theme,
+): string[] {
+  const out: string[] = [];
+
+  for (const item of snap.transcript) {
+    const before = out.length;
+    if (item.kind === "user") {
+      renderUserText(theme, item.text, width, out);
+    } else if (item.kind === "assistant") {
+      renderAssistantItem(theme, item, width, out);
+    } else {
+      renderToolResultItem(theme, item, width, out);
+    }
+    if (out.length > before) out.push("");
+  }
+  while (out.length > 0 && out[out.length - 1] === "") out.pop();
+
+  // Live streaming assistant buffers (cleared when the finalized message lands).
+  if (snap.liveAssistant) {
+    const { thinking, text } = snap.liveAssistant;
+    const before = out.length;
+    if (out.length > 0) out.push("");
+    if (thinking.trim()) renderThinking(theme, thinking, width, out);
+    if (text.trim())
+      out.push(...wrapTextWithAnsi(sanitizeText(text).trim(), width));
+    if (out.length === before + 1) out.pop();
+  }
+
+  // Live tool executions (present until the ToolEnd lands in the transcript).
+  for (const tool of snap.liveTools) {
+    if (out.length > 0) out.push("");
+    const marker = tool.done
+      ? tool.isError
+        ? theme.fg("error", "error")
+        : theme.fg("success", "done")
+      : theme.fg("warning", "running");
+    let line = `${theme.fg("toolTitle", tool.name)} · ${marker}`;
+    const preview = tool.outputPreview && sanitizeText(tool.outputPreview);
+    if (preview) line += theme.fg("dim", ` · ${preview}`);
+    out.push(truncateToWidth(line, width));
+  }
+
+  // Queued steering/follow-up messages: show them immediately so Enter
+  // visibly acknowledges the user's input instead of appearing to do nothing.
+  for (const message of snap.queued) {
+    if (out.length > 0) out.push("");
+    const prefix = theme.fg("warning", `> [queued ${message.kind}] `);
+    const wrapped = wrapTextWithAnsi(
+      sanitizeText(message.text),
+      Math.max(10, width - visibleWidth(prefix)),
+    );
+    for (let i = 0; i < wrapped.length; i++) {
+      out.push(
+        truncateToWidth(
+          (i === 0 ? prefix : " ".repeat(visibleWidth(prefix))) +
+            theme.fg("muted", wrapped[i]),
+          width,
+        ),
+      );
+    }
+  }
+
+  return out;
+}

--- a/users/profiles/pi/extensions/subagents/takeover.test.ts
+++ b/users/profiles/pi/extensions/subagents/takeover.test.ts
@@ -1,0 +1,29 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import {
+  reconcileDashboardSelection,
+  type DashboardSelection,
+} from "./src/ui/takeover.ts";
+
+test("dashboard selection follows its subagent id and falls back by row", () => {
+  const selection: DashboardSelection = { id: "sa-7", index: 6 };
+
+  reconcileDashboardSelection(selection, [
+    { id: "sa-new" },
+    ...Array.from({ length: 8 }, (_, index) => ({ id: `sa-${index + 1}` })),
+  ]);
+  assert.deepEqual(selection, { id: "sa-7", index: 7 });
+
+  reconcileDashboardSelection(selection, [
+    ...Array.from({ length: 6 }, (_, index) => ({ id: `sa-${index + 1}` })),
+    { id: "sa-8" },
+    { id: "sa-9" },
+  ]);
+  assert.deepEqual(selection, { id: "sa-9", index: 7 });
+
+  reconcileDashboardSelection(selection, [{ id: "sa-1" }, { id: "sa-2" }]);
+  assert.deepEqual(selection, { id: "sa-2", index: 1 });
+
+  reconcileDashboardSelection(selection, []);
+  assert.deepEqual(selection, { id: undefined, index: 0 });
+});

--- a/users/profiles/pi/extensions/subagents/tsconfig.json
+++ b/users/profiles/pi/extensions/subagents/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "allowImportingTsExtensions": true,
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2022",
+    "types": ["node"],
+    "verbatimModuleSyntax": true
+  },
+  "include": ["index.ts", "src/**/*.ts", "*.test.ts"]
+}


### PR DESCRIPTION
## Summary

- add a Pi subagents extension with Pi and Claude backends
- add lifecycle, concurrency, result-delivery, and takeover UI handling
- package the extension for Home Manager with focused runtime contents

## Validation

- `npm run check`
- `npm test` (22 tests)
- `statix check users/profiles/pi/default.nix`
- focused Home Manager activation package build for `nicolina`