### PR TITLE
fix(pi): report only working-copy changes in footer

### DIFF
--- a/users/profiles/pi/extension-tests/footer-timer.test.ts
+++ b/users/profiles/pi/extension-tests/footer-timer.test.ts
@@ -153,7 +153,7 @@ test("extension statuses are sorted, sanitized, and width-bounded", () => {
   assert.equal(visibleWidth(renderExtensionStatuses(statuses, 10, "...") ?? ""), 10);
 });
 
-test("JJ footer snapshots filesystem edits and diffs the displayed revision", async () => {
+test("JJ footer snapshots filesystem edits but reports only working-copy changes", async () => {
   const cwd = await mkdtemp(join(tmpdir(), "footer-jj-test-"));
   try {
     await runJj(cwd, ["git", "init"]);
@@ -167,7 +167,8 @@ test("JJ footer snapshots filesystem edits and diffs the displayed revision", as
     await runJj(cwd, ["new", "-m", "child"]);
     const parent = await readJjInfo(cwd);
     assert.equal(parent?.revset, "@-");
-    assert.equal(parent?.added, 1);
+    assert.equal(parent?.added, 0);
+    assert.equal(parent?.deleted, 0);
   } finally {
     await rm(cwd, { recursive: true, force: true });
   }

--- a/users/profiles/pi/extensions/footer/index.ts
+++ b/users/profiles/pi/extensions/footer/index.ts
@@ -176,8 +176,9 @@ export async function readJjInfo(cwd: string): Promise<VcsInfo | null> {
   ]);
   const hasConflict = conflictText.trim().length > 0;
 
-  // Get diff stat
-  const diff = parseDiffStat(await runJj(["diff", "-r", revset, "--stat"]));
+  // Diff stats always describe the working copy. The displayed revision may be
+  // @- when @ is empty, but diffing @- would show the parent's committed patch.
+  const diff = parseDiffStat(await runJj(["diff", "-r", "@", "--stat"]));
 
   const bookmarks = bookmarkLine.trim().split(/\s+/).filter(Boolean);
   const branch = bookmarks.length > 0 ? bookmarks[0] : changeId.slice(0, 8);


### PR DESCRIPTION
## Summary
- keep JJ revision identity selection independent from diff statistics
- calculate footer change counts from the working-copy commit
- update the regression test for an empty working copy above a changed parent

## Testing
- `nix build --no-write-lock-file --no-link 'path:.#checks.x86_64-linux.pi-extensions'`
