### PR TITLE
feat(ai): expose llama-swap as Tailscale service

### DIFF
--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -4,6 +4,10 @@
   lib,
   ...
 }:
+let
+  port = 9292;
+  service = "svc:ai";
+in
 {
   services.llama-swap = {
     enable = true;
@@ -48,7 +52,7 @@
         };
       };
     });
-    port = 9292;
+    inherit port;
     listenAddress = "0.0.0.0";
     openFirewall = true;
     settings =
@@ -234,7 +238,7 @@
   };
 
   systemd.services.tailscale-serve-llama-swap = {
-    description = "Expose llama-swap over Tailscale HTTPS";
+    description = "Expose llama-swap as a Tailscale Service";
     after = [
       "tailscaled.service"
       "tailscale-auth.service"
@@ -248,8 +252,8 @@
     serviceConfig = {
       Type = "oneshot";
       RemainAfterExit = true;
-      ExecStart = "${lib.getExe config.services.tailscale.package} serve --bg --https=443 http://127.0.0.1:9292";
-      ExecStop = "${lib.getExe config.services.tailscale.package} serve --https=443 off";
+      ExecStart = "${lib.getExe config.services.tailscale.package} serve --service=${service} --https=443 --yes http://127.0.0.1:${toString port}";
+      ExecStop = "${lib.getExe config.services.tailscale.package} serve --service=${service} --https=443 off";
     };
   };
 

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -93,11 +93,11 @@ let
     mcpServers = { };
   };
 
-  # llama-swap exposes Qwen models through an OpenAI-compatible Tailscale endpoint.
+  # llama-swap exposes Qwen models through a stable OpenAI-compatible Tailscale Service.
   models = {
     providers = {
-      "margot" = {
-        baseUrl = "https://margot.tailef5cf.ts.net/v1";
+      "local-ai" = {
+        baseUrl = "https://ai.tailef5cf.ts.net/v1";
         api = "openai-responses";
         apiKey = "llama-swap";
         compat = {


### PR DESCRIPTION
## Summary

- expose llama-swap through the named Tailscale service `svc:ai`
- point Pi's `local-ai` provider at the stable `ai.tailef5cf.ts.net` endpoint

## Validation

- evaluated the generated llama-swap Tailscale `ExecStart`
- evaluated Pi's generated models configuration
- `statix check` on both modified Nix files
- `deadnix -f` on both modified Nix files