### PR TITLE
feat(pi): animate working timer in terminal title

### DIFF
--- a/users/profiles/pi/extension-tests/footer-timer.test.ts
+++ b/users/profiles/pi/extension-tests/footer-timer.test.ts
@@ -193,10 +193,10 @@ test("JJ footer keeps an empty merge revision instead of mixing multiple parents
   }
 });
 
-test("working timer spans repeated agent starts, settles once, and never owns the title", () => {
+test("working timer spans repeated agent starts and animates the title", () => {
   let now = 1_000;
   let intervalCallback: (() => void) | undefined;
-  let titleWrites = 0;
+  let titleWrites: string[] = [];
   let clears = 0;
   const handlers = new Map<string, (event: unknown, ctx: any) => void>();
   const messages: Array<string | undefined> = [];
@@ -204,6 +204,9 @@ test("working timer spans repeated agent starts, settles once, and never owns th
   const pi = {
     on(name: string, handler: (event: unknown, ctx: any) => void) {
       handlers.set(name, handler);
+    },
+    getSessionName() {
+      return "test";
     },
   };
   const ctx = {
@@ -215,8 +218,8 @@ test("working timer spans repeated agent starts, settles once, and never owns th
       setWidget(key: string, widget: unknown) {
         widgets.set(key, widget);
       },
-      setTitle() {
-        titleWrites++;
+      setTitle(title: string) {
+        titleWrites.push(title);
       },
     },
   };
@@ -231,29 +234,33 @@ test("working timer spans repeated agent starts, settles once, and never owns th
       intervalCallback = undefined;
     }) as typeof globalThis.clearInterval,
   })(pi as never);
-
+  
   handlers.get("agent_start")?.({}, ctx);
   now = 5_000;
   handlers.get("agent_start")?.({}, ctx);
   intervalCallback?.();
   now = 7_000;
   handlers.get("agent_settled")?.({}, ctx);
-
-  assert.equal(titleWrites, 0);
+  
+  assert.equal(titleWrites[0]?.startsWith("⠋ π - test - "), true);
+  assert.equal(titleWrites[1]?.startsWith("⠙ π - test - "), true);
+  assert.equal(titleWrites[2]?.startsWith("π - test - "), true);
   assert.equal(messages.includes("Working... (4s)"), true);
   assert.equal(messages.at(-1), undefined);
-  assert.equal(clears, 1);
+  assert.equal(clears, 2);
   const widgetFactory = widgets.get("working-timer-summary") as (
     tui: unknown,
     theme: { fg: (_role: string, text: string) => string },
   ) => { render(width: number): string[] };
   const component = widgetFactory({}, { fg: (_role, text) => text });
   assert.deepEqual(component.render(80), ["Worked for 6s"]);
-
+  
   now = 8_000;
   handlers.get("agent_start")?.({}, ctx);
   handlers.get("session_shutdown")?.({}, ctx);
-  assert.equal(clears, 2);
+  assert.equal(titleWrites[3]?.startsWith("⠋ π - test - "), true);
+  assert.equal(titleWrites[4]?.startsWith("π - test - "), true);
+  assert.equal(clears, 4);
   assert.equal(widgets.get("working-timer-summary"), undefined);
 });
 

--- a/users/profiles/pi/extensions/working-timer/index.ts
+++ b/users/profiles/pi/extensions/working-timer/index.ts
@@ -1,14 +1,17 @@
 /**
  * Working timer extension for Pi.
  *
- * Adds elapsed time to the TUI working message without taking ownership of the
- * terminal title, which may be managed by remote-pi or another integration.
+ * Adds elapsed time to the TUI working message and animates a spinner in the
+ * terminal title while the agent is working.
  */
 
+import { basename } from "node:path";
 import type { ExtensionAPI, ExtensionContext, Theme } from "@earendil-works/pi-coding-agent";
 import { truncateToWidth, type Component, type TUI } from "@earendil-works/pi-tui";
 
 const SUMMARY_WIDGET_KEY = "working-timer-summary";
+const TITLE_FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+const TITLE_INTERVAL_MS = 80;
 
 export interface WorkingTimerDependencies {
   now?: () => number;
@@ -28,12 +31,20 @@ export function formatElapsed(elapsedMs: number): string {
   return `${seconds}s`;
 }
 
+function getBaseTitle(pi: Pick<ExtensionAPI, "getSessionName">): string {
+  const cwd = basename(process.cwd());
+  const session = pi.getSessionName();
+  return session ? `π - ${session} - ${cwd}` : `π - ${cwd}`;
+}
+
 export function createWorkingTimerExtension(dependencies: WorkingTimerDependencies = {}) {
   const now = dependencies.now ?? Date.now;
   const startTimer = dependencies.setInterval ?? globalThis.setInterval;
   const stopTimer = dependencies.clearInterval ?? globalThis.clearInterval;
   let startedAt: number | null = null;
   let messageTimer: ReturnType<typeof setInterval> | null = null;
+  let titleTimer: ReturnType<typeof setInterval> | null = null;
+  let titleFrame = 0;
 
   const clearTimer = (): void => {
     if (messageTimer !== null) {
@@ -42,9 +53,23 @@ export function createWorkingTimerExtension(dependencies: WorkingTimerDependenci
     }
   };
 
+  const clearTitleTimer = (): void => {
+    if (titleTimer !== null) {
+      stopTimer(titleTimer);
+      titleTimer = null;
+    }
+  };
+
   const setMessage = (ctx: ExtensionContext): void => {
     if (ctx.mode !== "tui" || startedAt === null) return;
     ctx.ui.setWorkingMessage(`Working... (${formatElapsed(now() - startedAt)})`);
+  };
+
+  const setTitle = (pi: ExtensionAPI, ctx: ExtensionContext): void => {
+    if (ctx.mode !== "tui" || startedAt === null) return;
+    const frame = TITLE_FRAMES[titleFrame % TITLE_FRAMES.length] ?? TITLE_FRAMES[0];
+    ctx.ui.setTitle(`${frame} ${getBaseTitle(pi)}`);
+    titleFrame++;
   };
 
   const setWorkedSummary = (ctx: ExtensionContext, elapsedMs: number): void => {
@@ -57,7 +82,7 @@ export function createWorkingTimerExtension(dependencies: WorkingTimerDependenci
     }));
   };
 
-  const start = (ctx: ExtensionContext): void => {
+  const start = (pi: ExtensionAPI, ctx: ExtensionContext): void => {
     if (ctx.mode !== "tui") return;
     if (startedAt !== null) {
       setMessage(ctx);
@@ -66,25 +91,31 @@ export function createWorkingTimerExtension(dependencies: WorkingTimerDependenci
 
     ctx.ui.setWidget(SUMMARY_WIDGET_KEY, undefined);
     startedAt = now();
+    titleFrame = 0;
     setMessage(ctx);
+    setTitle(pi, ctx);
     messageTimer = startTimer(() => setMessage(ctx), 1000);
+    titleTimer = startTimer(() => setTitle(pi, ctx), TITLE_INTERVAL_MS);
   };
 
-  const stop = (ctx: ExtensionContext, showSummary: boolean, clearSummary = false): void => {
+  const stop = (pi: ExtensionAPI, ctx: ExtensionContext, showSummary: boolean, clearSummary = false): void => {
     const elapsedMs = startedAt === null ? null : now() - startedAt;
     clearTimer();
+    clearTitleTimer();
+    titleFrame = 0;
     startedAt = null;
     if (ctx.mode !== "tui") return;
 
     ctx.ui.setWorkingMessage();
+    ctx.ui.setTitle(getBaseTitle(pi));
     if (clearSummary) ctx.ui.setWidget(SUMMARY_WIDGET_KEY, undefined);
     else if (showSummary && elapsedMs !== null) setWorkedSummary(ctx, elapsedMs);
   };
 
   return function workingTimerExtension(pi: ExtensionAPI): void {
-    pi.on("agent_start", (_event, ctx) => start(ctx));
-    pi.on("agent_settled", (_event, ctx) => stop(ctx, true));
-    pi.on("session_shutdown", (_event, ctx) => stop(ctx, false, true));
+    pi.on("agent_start", (_event, ctx) => start(pi, ctx));
+    pi.on("agent_settled", (_event, ctx) => stop(pi, ctx, true));
+    pi.on("session_shutdown", (_event, ctx) => stop(pi, ctx, false, true));
   };
 }
 


### PR DESCRIPTION
## Summary

- animate a spinner in the terminal title while the agent is working
- restore the session title when work settles or the session shuts down
- extend the working timer tests to cover title updates

## Tests

- `nix build --no-write-lock-file path:.#checks.x86_64-linux.pi-extensions`