### PR TITLE
fix(pi): disable remote-pi resources by default

### DIFF
--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -30,7 +30,15 @@ let
       "npm:pi-claude-bridge@0.6.3"
       "npm:pi-hashline-edit@0.8.3"
       "npm:pi-web-access@0.14.0"
-      "npm:remote-pi@0.5.5"
+      # Keep remote-pi installed, but do not load any of its resources by default.
+      # It can be enabled later through `pi config`.
+      {
+        source = "npm:remote-pi@0.5.5";
+        extensions = [ ];
+        skills = [ ];
+        prompts = [ ];
+        themes = [ ];
+      }
     ];
 
   extraSkillDirs = [ ];


### PR DESCRIPTION
## Summary

- keep `remote-pi` installed
- disable its extensions, skills, prompts, and themes by default
- allow manual re-enabling through `pi config`

## Validation

- `nix-instantiate --parse users/profiles/pi/default.nix`
- `statix check users/profiles/pi/default.nix`