### PR TITLE
feat(ai): add DeepSeek V4 Flash Abliterated Q2 model

### DIFF
--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -163,6 +163,14 @@ in
             # The GGUF chat template enables thinking by default; avoid passing the
             thinking = false;
           };
+          "deepseek-v4-flash-0731-abliterated:q2" = mkModel {
+            hf = "huihui-ai/Huihui-DeepSeek-V4-Flash-0731-abliterated-GGUF";
+            kv = "f16";
+            ctx = 131072;
+            sampling = deepseekSampling;
+            # The embedded template supports enable_thinking but enables no mode by default.
+            thinking = false;
+          };
         };
 
         healthCheckTimeout = 7200;

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -118,40 +118,68 @@ let
           supportsLongCacheRetention = false;
         };
         models = [
-            {
-              id = "deepseek-v4-flash-0731:iq3";
-              name = "DeepSeek V4 Flash 0731 IQ3";
-              reasoning = true;
-              thinkingLevelMap = {
-                minimal = null;
-                low = null;
-                medium = null;
-                high = "high";
-                xhigh = null;
-                max = "max";
-              };
-              input = [ "text" ];
-              contextWindow = 131072;
-              maxTokens = 32768;
-              cost = {
-                input = 0;
-                output = 0;
-                cacheRead = 0;
-                cacheWrite = 0;
-              };
-              compat = {
-                thinkingFormat = "chat-template";
-                chatTemplateKwargs = {
-                  enable_thinking = {
-                    "$var" = "thinking.enabled";
-                  };
-                  reasoning_effort = {
-                    "$var" = "thinking.effort";
-                  };
+          {
+            id = "deepseek-v4-flash-0731:iq3";
+            name = "DeepSeek V4 Flash 0731 IQ3";
+            reasoning = true;
+            thinkingLevelMap = {
+              minimal = null;
+              low = null;
+              medium = null;
+              high = "high";
+              xhigh = null;
+              max = "max";
+            };
+            input = [ "text" ];
+            contextWindow = 131072;
+            maxTokens = 32768;
+            cost = {
+              input = 0;
+              output = 0;
+              cacheRead = 0;
+              cacheWrite = 0;
+            };
+            compat = {
+              thinkingFormat = "chat-template";
+              chatTemplateKwargs = {
+                enable_thinking = {
+                  "$var" = "thinking.enabled";
+                };
+                reasoning_effort = {
+                  "$var" = "thinking.effort";
                 };
               };
-            }
-          ];
+            };
+          }
+          {
+            id = "deepseek-v4-flash-0731-abliterated:q2";
+            name = "DeepSeek V4 Flash 0731 Abliterated Q2";
+            reasoning = true;
+            thinkingLevelMap = {
+              minimal = null;
+              low = null;
+              medium = null;
+              high = "high";
+              xhigh = null;
+              max = "max";
+            };
+            input = [ "text" ];
+            contextWindow = 131072;
+            maxTokens = 32768;
+            cost = {
+              input = 0;
+              output = 0;
+              cacheRead = 0;
+              cacheWrite = 0;
+            };
+            compat = {
+              thinkingFormat = "chat-template";
+              chatTemplateKwargs.enable_thinking = {
+                "$var" = "thinking.enabled";
+              };
+            };
+          }
+        ];
       };
     };
   };


### PR DESCRIPTION
## Summary

- add the DeepSeek V4 Flash 0731 Abliterated Q2 model to llama-swap
- expose the model to pi with chat-template reasoning controls

## Testing

- `statix check profiles/ai.nix`
- `statix check users/profiles/pi/default.nix`