### PR TITLE
feat(pi): add trakkt MCP server and pi-mcp-adapter extension

### DIFF
--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -27,6 +27,7 @@ let
       "npm:@juicesharp/rpiv-ask-user-question@2.3.1"
       "npm:@plannotator/pi-extension@0.25.1"
       "npm:pi-hashline-edit@0.8.3"
+      "npm:pi-mcp-adapter@2.19.0"
       "npm:pi-web-access@0.17.1"
       # Keep remote-pi installed, but do not load any of its resources by default.
       # It can be enabled later through `pi config`.
@@ -81,7 +82,13 @@ let
   };
 
   mcp = {
-    mcpServers = { };
+    mcpServers = {
+      trakkt = {
+        url = "https://trakkt.exsules.dev/mcp";
+        auth = "oauth";
+        oauth.scope = "mcp";
+      };
+    };
   };
 
   models = {


### PR DESCRIPTION
Adds the `pi-mcp-adapter` extension to the pi profile and registers the `trakkt` MCP server (`https://trakkt.exsules.dev/mcp`) with OAuth authentication, scope `mcp`.