### PR TITLE
fix(desktop): persist Vesktop state

### DIFF
--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -72,6 +72,7 @@
         ".config/pipewire"
         ".config/pulse"
         ".config/spotify"
+        ".config/vesktop"
         ".config/warcraftlogs"
         ".factorio"
         ".gemini"


### PR DESCRIPTION
## Summary

- Persist Vesktop state under `~/.config/vesktop` on ephemeral-root hosts.

## Validation

- `statix check profiles/state.nix`
- `nix-instantiate --parse profiles/state.nix`