### PR TITLE
feat(pi): render custom tools compactly

### DIFF
--- a/users/profiles/git.nix
+++ b/users/profiles/git.nix
@@ -44,6 +44,7 @@ in
 
     ignores = [
       ".nvimlog" # TODO(blazed): find out why this is needed?
+      ".pi/quiet-tools"
       ".pi/remote-pi/"
       ".pi/workflows/"
     ];

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -24,13 +24,13 @@ let
     ]
     ++ [
       "git:github.com/blazed/pi-openai-compaction@b087ebf12329a4da7bdd9376d3f7b28603cae2c1"
+      "git:github.com/DietrichGebert/ponytail@16f29800fd2681bdf24f3eb4ccffe38be3baec6b"
       "npm:@juicesharp/rpiv-ask-user-question@2.3.1"
-      "npm:@plannotator/pi-extension@0.25.1"
-      "npm:pi-hashline-edit@0.8.3"
+      "npm:@vanillagreen/pi-tool-renderer@1.7.1"
+      "npm:pi-blackhole@0.4.3"
       "npm:pi-mcp-adapter@2.19.0"
+      "npm:pi-quiet-tools@0.2.0"
       "npm:pi-web-access@0.17.1"
-      # Keep remote-pi installed, but do not load any of its resources by default.
-      # It can be enabled later through `pi config`.
       {
         source = "npm:remote-pi@0.5.5";
         extensions = [ ];

--- a/users/profiles/pi/extensions/jj-context/index.ts
+++ b/users/profiles/pi/extensions/jj-context/index.ts
@@ -6,6 +6,7 @@
  */
 
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 const JJ_TIMEOUT_MS = 5_000;
@@ -290,6 +291,39 @@ export default function jjContextExtension(pi: ExtensionAPI) {
       "Do not use jj_context for explicit mutations. Its default fresh read may perform JJ's normal working-copy snapshot.",
     ],
     parameters: jjContextParams,
+    renderShell: "self",
+    renderCall(args, theme) {
+      const mode = args.mode ?? "summary";
+      const revset = args.revset ? ` ${theme.fg("dim", args.revset)}` : "";
+      return new Text(
+        theme.fg("toolTitle", theme.bold("JJ Context")) + ` ${theme.fg("accent", mode)}` + revset,
+        0,
+        0,
+      );
+    },
+    renderResult(result, options, theme, context) {
+      const details = result.details as {
+        current?: CurrentRevision;
+        changes?: { changed?: { total?: number } };
+        log?: unknown[];
+        operation?: { recent?: unknown[] };
+      } | undefined;
+      const mode = (context.args.mode ?? "summary") as JjMode;
+      const count = mode === "log"
+        ? `${details?.log?.length ?? 0} revision(s)`
+        : mode === "recovery"
+          ? `${details?.operation?.recent?.length ?? 0} operation(s)`
+          : `${details?.changes?.changed?.total ?? 0} changed file(s)`;
+      const current = details?.current
+        ? ` · ${details.current.changeId} ${details.current.description}`
+        : "";
+      const raw = result.content.find((item) => item.type === "text")?.text;
+      const summary = context.isError ? raw?.split(/\r?\n/, 1)[0] ?? count : `${count}${current}`;
+      const color = context.isError ? "error" : "success";
+      let text = theme.fg(color, `${context.isError ? "x" : "✓"} ${summary}`);
+      if (options.expanded && raw && raw !== summary) text += `\n${raw}`;
+      return new Text(text, 0, 0);
+    },
 
     async execute(_toolCallId, params: JjContextParams, signal, _onUpdate, ctx) {
       const mode = (params.mode ?? "summary") as JjMode;

--- a/users/profiles/pi/extensions/jj-todo/index.ts
+++ b/users/profiles/pi/extensions/jj-todo/index.ts
@@ -8,6 +8,7 @@
 import { randomUUID } from "node:crypto";
 import { StringEnum } from "@earendil-works/pi-ai";
 import type { ExtensionAPI, ExtensionContext } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
 import { Type } from "typebox";
 
 const JJ_TIMEOUT_MS = 8_000;
@@ -616,6 +617,41 @@ export default function jjTodoExtension(pi: ExtensionAPI) {
       "Use jj_todo read actions before verbose jj shell commands; use bash with jj for graph edits and unusual mutations.",
     ],
     parameters: jjTodoParams,
+    renderShell: "self",
+    renderCall(args, theme) {
+      const target = args.rev ?? args.parent;
+      const detail = [args.action, args.flag, target].filter(Boolean).join(" ");
+      return new Text(
+        theme.fg("toolTitle", theme.bold("JJ TODO")) + ` ${theme.fg("accent", detail)}`,
+        0,
+        0,
+      );
+    },
+    renderResult(result, options, theme, context) {
+      const details = result.details as {
+        action?: JjTodoAction;
+        ok?: boolean;
+        issues?: unknown[];
+        tasks?: unknown[];
+        ready?: unknown[];
+        task?: { firstLine?: string };
+        previewTask?: { firstLine?: string };
+      } | undefined;
+      const action = details?.action ?? context.args.action;
+      const subject = details?.task?.firstLine ?? details?.previewTask?.firstLine;
+      const fallback = subject
+        ?? (action === "check"
+          ? details?.ok ? "workflow healthy" : `${details?.issues?.length ?? 0} workflow issue(s)`
+          : action === "next"
+            ? `${details?.ready?.length ?? 0} task(s) ready`
+            : `${details?.tasks?.length ?? 0} task(s)`);
+      const raw = result.content.find((item) => item.type === "text")?.text;
+      const summary = context.isError ? raw?.split(/\r?\n/, 1)[0] ?? fallback : fallback;
+      const color = context.isError ? "error" : "success";
+      let text = theme.fg(color, `${context.isError ? "x" : "✓"} ${summary}`);
+      if (options.expanded && raw && raw !== summary) text += `\n${raw}`;
+      return new Text(text, 0, 0);
+    },
 
     async execute(_toolCallId, params: JjTodoParams, signal, _onUpdate, ctx) {
       const action = params.action;

--- a/users/profiles/pi/extensions/subagents/index.ts
+++ b/users/profiles/pi/extensions/subagents/index.ts
@@ -74,6 +74,7 @@ import {
   runTool,
   type SubagentRuntime,
 } from "./src/runtime.ts";
+import { compactCall, compactResult } from "./src/tool-renderer.ts";
 import { openSubagentPicker, openSubagentTakeover } from "./src/ui/takeover.ts";
 import { resolveClaudePermissionPolicy } from "./src/backends/claude-permissions.ts";
 import { addUsage, createUsageLedger } from "./src/usage.ts";
@@ -393,6 +394,15 @@ export default function (pi: ExtensionAPI) {
         }),
       ),
     }),
+    renderShell: "self",
+    renderCall(args, theme) {
+      return compactCall(theme, "Subagent Spawn", `${args.harness}: ${args.name}`);
+    },
+    renderResult(result, options, theme, context) {
+      const details = result.details as { id?: string; title?: string } | undefined;
+      const summary = `${details?.id ?? "subagent"} · ${details?.title ?? "spawned"}`;
+      return compactResult(result, { ...options, isError: context.isError }, theme, summary);
+    },
     async execute(_toolCallId, params, signal, _onUpdate, ctx) {
       const manager = await getManager();
       const harness = params.harness;
@@ -463,6 +473,18 @@ export default function (pi: ExtensionAPI) {
         description: SUBAGENT_WAIT_PARAMETER_DESCRIPTIONS.ids,
       }),
     }),
+    renderShell: "self",
+    renderCall(args, theme) {
+      return compactCall(theme, "Subagent Wait", args.ids.join(", "));
+    },
+    renderResult(result, options, theme, context) {
+      const details = result.details as { pending?: string[]; results?: unknown[] } | undefined;
+      const count = details?.pending?.length ?? details?.results?.length ?? 0;
+      const summary = options.isPartial
+        ? `Waiting for ${count} subagent(s)…`
+        : `${count} subagent(s) settled`;
+      return compactResult(result, { ...options, isError: context.isError }, theme, summary);
+    },
     async execute(_toolCallId, params, signal, onUpdate) {
       const manager = await getManager();
       const ids = [...new Set(params.ids)];
@@ -565,6 +587,20 @@ export default function (pi: ExtensionAPI) {
         description: SUBAGENT_CANCEL_PARAMETER_DESCRIPTIONS.ids,
       }),
     }),
+    renderShell: "self",
+    renderCall(args, theme) {
+      return compactCall(theme, "Subagent Cancel", args.ids.join(", "));
+    },
+    renderResult(result, options, theme, context) {
+      const details = result.details as { results?: unknown[] } | undefined;
+      const count = details?.results?.length ?? 0;
+      return compactResult(
+        result,
+        { ...options, isError: context.isError },
+        theme,
+        `${count} subagent(s) handled`,
+      );
+    },
     async execute(_toolCallId, params, signal) {
       const manager = await getManager();
       const ids = [...new Set(params.ids)];
@@ -618,6 +654,15 @@ export default function (pi: ExtensionAPI) {
         description: SUBAGENT_CHECK_PARAMETER_DESCRIPTIONS.id,
       }),
     }),
+    renderShell: "self",
+    renderCall(args, theme) {
+      return compactCall(theme, "Subagent Check", args.id);
+    },
+    renderResult(result, options, theme, context) {
+      const details = result.details as { id?: string; status?: string; turns?: number } | undefined;
+      const summary = `${details?.id ?? "subagent"} · ${details?.status ?? "unknown"} · ${details?.turns ?? 0} turn(s)`;
+      return compactResult(result, { ...options, isError: context.isError }, theme, summary);
+    },
     async execute(_toolCallId, params) {
       const manager = await getManager();
       const snap = manager.view.get(params.id);
@@ -655,6 +700,20 @@ export default function (pi: ExtensionAPI) {
     label: "List Subagents",
     description: SUBAGENT_LIST_TOOL_DESCRIPTION,
     parameters: Type.Object({}),
+    renderShell: "self",
+    renderCall(_args, theme) {
+      return compactCall(theme, "Subagent List");
+    },
+    renderResult(result, options, theme, context) {
+      const details = result.details as { subagents?: unknown[] } | undefined;
+      const count = details?.subagents?.length ?? 0;
+      return compactResult(
+        result,
+        { ...options, isError: context.isError },
+        theme,
+        `${count} subagent(s)`,
+      );
+    },
     async execute() {
       const manager = await getManager();
       const subs = manager.view.list().filter(isModelVisible);

--- a/users/profiles/pi/extensions/subagents/src/tool-renderer.ts
+++ b/users/profiles/pi/extensions/subagents/src/tool-renderer.ts
@@ -1,0 +1,35 @@
+import type { Theme, ToolRenderResultOptions } from "@earendil-works/pi-coding-agent";
+import { Text } from "@earendil-works/pi-tui";
+
+interface ToolResult {
+  readonly content: readonly { readonly type: string; readonly text?: string }[];
+}
+
+type RenderOptions = ToolRenderResultOptions & { readonly isError?: boolean };
+
+export function compactCall(
+  theme: Theme,
+  label: string,
+  detail = "",
+): Text {
+  const suffix = detail ? ` ${theme.fg("accent", detail)}` : "";
+  return new Text(theme.fg("toolTitle", theme.bold(label)) + suffix, 0, 0);
+}
+
+export function compactResult(
+  result: ToolResult,
+  options: RenderOptions,
+  theme: Theme,
+  summary: string,
+): Text {
+  if (options.isPartial) {
+    return new Text(theme.fg("warning", summary), 0, 0);
+  }
+
+  const raw = result.content.find((item) => item.type === "text")?.text;
+  const color = options.isError ? "error" : "success";
+  const message = options.isError ? raw?.split(/\r?\n/, 1)[0] ?? summary : summary;
+  let text = theme.fg(color, `${options.isError ? "x" : "✓"} ${message}`);
+  if (options.expanded && raw && raw !== message) text += `\n${raw}`;
+  return new Text(text, 0, 0);
+}

--- a/users/profiles/pi/extensions/subagents/tool-renderer.test.ts
+++ b/users/profiles/pi/extensions/subagents/tool-renderer.test.ts
@@ -1,0 +1,18 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { Theme } from "@earendil-works/pi-coding-agent";
+import { compactResult } from "./src/tool-renderer.ts";
+
+const theme = {
+  fg: (_color: string, text: string) => text,
+} as Theme;
+
+const result = { content: [{ type: "text", text: "full output" }] };
+
+test("compact results reveal raw output only when expanded", () => {
+  const collapsed = compactResult(result, { expanded: false, isPartial: false }, theme, "done");
+  const expanded = compactResult(result, { expanded: true, isPartial: false }, theme, "done");
+
+  assert.doesNotMatch(collapsed.render(80).join("\n"), /full output/);
+  assert.match(expanded.render(80).join("\n"), /full output/);
+});


### PR DESCRIPTION
## Summary

- update the third-party Pi package set and ignore quiet-tools output
- add compact rendering for `jj_context`, `jj_todo`, and subagent tools
- preserve full tool output in expanded mode and cover it with a smoke test

## Validation

- `nix build --no-write-lock-file --no-link path:.#checks.x86_64-linux.pi-extensions`
- `statix check users/profiles/pi/default.nix`
