### PR TITLE
feat(server): enable fwupd firmware updates

### DIFF
--- a/hosts/x86_64-linux/margot.nix
+++ b/hosts/x86_64-linux/margot.nix
@@ -34,8 +34,6 @@
 
   users.users.${adminUser.name}.shell = lib.mkForce pkgs.bashInteractive;
 
-  services.fwupd.enable = true;
-
   boot.initrd.availableKernelModules = [
     "igc"
     "nvme"

--- a/profiles/server.nix
+++ b/profiles/server.nix
@@ -29,6 +29,7 @@ in
   networking.firewall.allowedTCPPorts = [ 22 ];
 
   services.smartd.enable = true;
+  services.fwupd.enable = true;
 
   programs.fish.enable = true;
   security.sudo.wheelNeedsPassword = false;


### PR DESCRIPTION
Enable fwupd in the shared `profiles/server.nix` so all physical hosts (rebecca, elsa, sophia, anja, margot) can update device firmware via LVFS.

Also drops margot's now-redundant inline enable.

Verified on anja: SSD firmware is LVFS-covered and updatable; APU BIOS is not on LVFS (expected). ESP warning is cosmetic on legacy-BIOS hosts.