### PR TITLE
feat(hosts): enable autoUpgrade on anja

### DIFF
--- a/hosts/x86_64-linux/anja.nix
+++ b/hosts/x86_64-linux/anja.nix
@@ -187,10 +187,6 @@
     args.ssh = true;
     args.accept-routes = false;
     args.accept-dns = false;
-    # NOTE: exit-node advertising always includes ::/0 (tailscale has no
-    # v4-only flag), but this router intentionally forwards no IPv6 — v6
-    # from exit-node clients is blackholed and they fall back to v4 via
-    # happy eyeballs; v6-only destinations won't work through this exit.
     args.advertise-exit-node = true;
     args.auth-key = "file:/var/run/agenix/ts";
   };
@@ -198,7 +194,7 @@
   users.users.${adminUser.name}.shell = lib.mkForce pkgs.bashInteractive;
 
   system.autoUpgrade = {
-    enable = false;
+    enable = true;
     flake = "github:blazed/cake";
     allowReboot = true;
     dates = "05:00";


### PR DESCRIPTION
Enable `system.autoUpgrade` on the anja host; also drops the stale tailscale exit-node note.