### PR TITLE
fix(home-manager): disable nix-index timer

### DIFF
--- a/users/profiles/default.nix
+++ b/users/profiles/default.nix
@@ -79,19 +79,5 @@ in
 
   programs.skim.enable = true;
 
-  systemd.user.services.nix-index = {
-    Unit.Description = "Nix-index indexes all files in nixpkgs";
-    Service.ExecStart = "${pkgs.nix-index}/bin/nix-index";
-  };
-
-  systemd.user.timers.nix-index = {
-    Unit.Description = "Nix-index indexes all files in nixpkgs";
-    Timer = {
-      OnCalendar = "*-*-* 4:00:00";
-      Unit = "nix-index.service";
-    };
-    Install.WantedBy = [ "timers.target" ];
-  };
-
   home.stateVersion = "25.05";
 }


### PR DESCRIPTION
## Summary
- disable the nix-index user service and daily timer
- prevent temporary file listings from filling /tmp

## Validation
- statix check users/profiles/default.nix
- confirmed nix-index.timer is not-found and nix-index.service is inactive