### PR TITLE
feat: expand AI models and restic backups

### DIFF
--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -184,6 +184,17 @@ in
             ];
             mtp = true;
           };
+          "qwen3.8-27b:blackfrost-q8" = mkModel {
+            hf = "Blackfrost-AI/Qwen3.8-27B-ABLITERATED-GGUF:Q8_0";
+            kv = "q8_0";
+            sampling = [
+              "--temp 1.0"
+              "--top-p 0.95"
+              "--top-k 20"
+              "--min-p 0.0"
+            ];
+            mtp = true;
+          };
           "muse-glimmer-30b:q8" = mkModel {
             hf = "unsloth/Muse-Glimmer-30B-GGUF:UD-Q8_K_XL";
             kv = "q8_0";

--- a/profiles/restic-backup.nix
+++ b/profiles/restic-backup.nix
@@ -15,13 +15,13 @@
     backups = {
       remote = {
         paths = [
+          "/home/${adminUser.name}/.factorio"
           "/home/${adminUser.name}/Documents"
+          "/home/${adminUser.name}/Faugus/battlenet/drive_c/Program Files (x86)/World of Warcraft/_retail_/Interface"
+          "/home/${adminUser.name}/Faugus/battlenet/drive_c/Program Files (x86)/World of Warcraft/_retail_/WTF"
           "/home/${adminUser.name}/Photos"
           "/home/${adminUser.name}/Pictures"
           "/home/${adminUser.name}/code"
-          "/home/${adminUser.name}/.factorio"
-          "/home/${adminUser.name}/.var/app/com.usebottles.bottles/data/bottles/bottles/Games/drive_c/Program Files (x86)/World of Warcraft/_retail_/Interface"
-          "/home/${adminUser.name}/.var/app/com.usebottles.bottles/data/bottles/bottles/Games/drive_c/Program Files (x86)/World of Warcraft/_retail_/WTF"
         ];
         environmentFile = "/run/agenix/restic-env";
         passwordFile = "/run/agenix/restic-pw";
@@ -30,9 +30,20 @@
         timerConfig.OnCalendar = "00/2:00";
         timerConfig.RandomizedDelaySec = "30m";
         extraBackupArgs = [
+          "--exclude=\".devenv\""
           "--exclude=\".direnv\""
+          "--exclude=\".mypy_cache\""
+          "--exclude=\".pnpm-store\""
+          "--exclude=\".pytest_cache\""
+          "--exclude=\".ruff_cache\""
           "--exclude=\".terraform\""
+          "--exclude=\".tox\""
+          "--exclude=\".venv\""
+          "--exclude=\"__pycache__\""
+          "--exclude=\"go/pkg/mod\""
           "--exclude=\"node_modules/*\""
+          "--exclude=\"result\""
+          "--exclude=\"target\""
         ];
       };
     };

--- a/profiles/state.nix
+++ b/profiles/state.nix
@@ -49,6 +49,7 @@
         ".cache/nix"
         ".cache/nix-index"
         ".cache/nvim"
+        ".cache/restic"
         ".cache/spotify"
         ".cache/umu"
         ".cache/zellij"

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -211,6 +211,52 @@ let
               };
             };
           }
+          {
+            id = "qwen3.8-27b:q8";
+            name = "Qwen3.8 27B Q8";
+            reasoning = true;
+            input = [ "text" ];
+            contextWindow = 262144;
+            maxTokens = 32768;
+            cost = {
+              input = 0;
+              output = 0;
+              cacheRead = 0;
+              cacheWrite = 0;
+            };
+            compat = {
+              thinkingFormat = "chat-template";
+              chatTemplateKwargs = {
+                enable_thinking = {
+                  "$var" = "thinking.enabled";
+                };
+                preserve_thinking = true;
+              };
+            };
+          }
+          {
+            id = "qwen3.8-27b:blackfrost-q8";
+            name = "Qwen3.8 27B Blackfrost Q8";
+            reasoning = true;
+            input = [ "text" ];
+            contextWindow = 262144;
+            maxTokens = 32768;
+            cost = {
+              input = 0;
+              output = 0;
+              cacheRead = 0;
+              cacheWrite = 0;
+            };
+            compat = {
+              thinkingFormat = "chat-template";
+              chatTemplateKwargs = {
+                enable_thinking = {
+                  "$var" = "thinking.enabled";
+                };
+                preserve_thinking = true;
+              };
+            };
+          }
         ];
       };
     };


### PR DESCRIPTION
## Summary
- add Qwen 3.8 27B Q8 model variants
- include Factorio and WoW data in restic backups
- exclude common development caches and build artifacts

## Validation
- statix check .
- nix flake check --impure