### PR TITLE
fix(k3s): wait for Tailscale before startup

### DIFF
--- a/profiles/k3s.nix
+++ b/profiles/k3s.nix
@@ -112,6 +112,16 @@
       };
     };
 
+  systemd.services.k3s = {
+    wants = [ "tailscaled.service" ];
+    after = [ "tailscaled.service" ];
+    preStart = lib.mkBefore ''
+      until ${pkgs.iproute2}/bin/ip -o -4 addr show scope global dev tailscale0 >/dev/null 2>&1; do
+        sleep 1
+      done
+    '';
+  };
+
   services.k3s = {
     enable = true;
     package = pkgs.k3s_1_36;

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -50,7 +50,7 @@ let
   themeName = "catppuccin-frappe";
   settings = {
     defaultProvider = "openai-codex";
-    defaultModel = "gpt-5.6-sol";
+    defaultModel = "gpt-5.6-luna";
     defaultThinkingLevel = "high";
     enableInstallTelemetry = false;
     enableSkillCommands = true;


### PR DESCRIPTION
## Summary
- start k3s after tailscaled is available
- wait for tailscale0 IPv4 before resolving the external node IP
- update Pi's default model to gpt-5.6-luna

## Validation
- statix check profiles/k3s.nix
- nixos-rebuild dry-build --flake .#nicolina --no-link