### PR TITLE
fix(pi): block private-commit push bypass

### DIFF
--- a/users/profiles/pi/AGENTS.md
+++ b/users/profiles/pi/AGENTS.md
@@ -14,6 +14,8 @@ Use tools only when needed. If the user asks only for an explanation, example, o
 
 All repositories on this machine use **JJ (Jujutsu)** with a Git backend. Prefer `jj` over `git` for version-control operations: status, diff, log, commits, bookmarks/branches, fetch, push, and history inspection. Use `git` only when a tool specifically requires Git or for explicit Git interop.
 
+Never pass `--allow-private` to `jj git push`. Private commits are intentionally protected; if a push is rejected, stop and report it instead of bypassing the protection.
+
 ## Shell command output
 
 The user's interactive shell is **Nushell**. When presenting commands for the user to copy and run:

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -10,6 +10,20 @@
 let
   system = pkgs.stdenv.hostPlatform.system;
   piNode = import ./node-package.nix { inherit pkgs inputs; };
+  piJujutsu = pkgs.writeShellApplication {
+    name = "jj";
+    text = ''
+      for argument in "$@"; do
+        case "$argument" in
+          --allow-private | --allow-private=*)
+            echo "jj: --allow-private is disabled in Pi" >&2
+            exit 2
+            ;;
+        esac
+      done
+      exec ${lib.getExe pkgs.jujutsu} "$@"
+    '';
+  };
 
   thirdPartyPackages =
     # Work around npm omitting remote-pi's optional native keyring dependency.
@@ -295,7 +309,16 @@ let
     paths = [ piNode ];
     nativeBuildInputs = [ pkgs.makeWrapper ];
     postBuild = ''
+      ${lib.getExe piJujutsu} --version >/dev/null
+      set +e
+      rejection="$(${lib.getExe piJujutsu} git push --allow-private 2>&1)"
+      rejectionStatus=$?
+      set -e
+      test "$rejectionStatus" -eq 2
+      test "$rejection" = "jj: --allow-private is disabled in Pi"
+
       wrapProgram $out/bin/pi \
+        --prefix PATH : ${lib.makeBinPath [ piJujutsu ]} \
         --run 'export TMPDIR="$HOME/.pi/tmp"; ${pkgs.coreutils}/bin/install -d -m 0700 "$TMPDIR"'
     '';
   };


### PR DESCRIPTION
## Summary

- reject `--allow-private` before Pi invokes the real `jj` binary
- instruct Pi agents to report private-commit rejection instead of bypassing it
- verify normal JJ passthrough and guarded rejection while building the wrapper

## Testing

- `nix-instantiate --parse users/profiles/pi/default.nix`
- `statix check users/profiles/pi/default.nix`
- targeted `pi-wrapped` Nix build