### PR TITLE
fix(ai): handle llama-swap UI directory rename

### DIFF
--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -41,7 +41,7 @@ in
         ui = pkgs.buildNpmPackage {
           pname = "llama-swap-ui";
           inherit version src;
-          sourceRoot = "${src.name}/ui-svelte";
+          sourceRoot = "${src.name}/${if lib.versionAtLeast version "251" then "ui" else "ui-svelte"}";
           npmDepsHash = "sha256-6MPXQtmaz97D9PUU2Nn5DH/2HZNP/rnAWVSck/FiCyk=";
           postPatch = ''
             substituteInPlace vite.config.ts \

--- a/scripts/update-ai.sh
+++ b/scripts/update-ai.sh
@@ -154,7 +154,8 @@ NIX
 let pkgs = import <nixpkgs> {};
     src = ${llama_swap_src_expr//@HASH@/$src_hash};
 in pkgs.fetchNpmDeps {
-  src = "\${src}/ui-svelte";
+  inherit src;
+  sourceRoot = "\${src.name}/ui";
   hash = "$FAKE_HASH";
 }
 NIX

--- a/users/profiles/pi/default.nix
+++ b/users/profiles/pi/default.nix
@@ -288,7 +288,7 @@ let
     '';
   };
   webSearch = {
-    provider = "exa";
+    provider = "auto";
     exaApiKey = "!${lib.getExe exaApiKeyCommand}";
     allowBrowserCookies = false;
     workflow = "none";


### PR DESCRIPTION
## Summary
- fix the llama-swap updater for the v251 `ui` directory rename
- keep the Nix build compatible with v250 and v251+
- use the automatic web-search provider configuration

## Validation
- `bash -n scripts/update-ai.sh`
- `nix-instantiate --parse profiles/ai.nix`