### PR TITLE
fix(ai): stabilize Qwen MTP and DeepSeek LoRA loading

### DIFF
--- a/patches/llama-cpp-amd-mmvf-odd-cols.patch
+++ b/patches/llama-cpp-amd-mmvf-odd-cols.patch
@@ -1,0 +1,24 @@
+diff --git a/ggml/src/ggml-cuda/ggml-cuda.cu b/ggml/src/ggml-cuda/ggml-cuda.cu
+index 44c2ac6aa..e114469d3 100644
+--- a/ggml/src/ggml-cuda/ggml-cuda.cu
++++ b/ggml/src/ggml-cuda/ggml-cuda.cu
+@@ -1884,7 +1884,8 @@ static bool ggml_cuda_mul_mat_id_needs_sync(const ggml_tensor * dst, const int c
+             if (dst->ne[2] <= get_mmvq_mmid_max_batch(src0->type, cc)) {
+                 return false;
+             }
+-        } else if (GGML_CUDA_CC_IS_AMD(cc)) {
++        } else if (GGML_CUDA_CC_IS_AMD(cc) &&
++                   ggml_cuda_should_use_mmvf(src0->type, cc, src0->ne, src0->nb, src1->ne[2])) {
+             return false;
+         }
+     }
+@@ -1923,7 +1924,8 @@ static void ggml_cuda_mul_mat_id(ggml_backend_cuda_context & ctx, ggml_tensor *
+                     return;
+                 }
+             } else {
+-                if (GGML_CUDA_CC_IS_AMD(cc)) {
++                if (GGML_CUDA_CC_IS_AMD(cc) &&
++                    ggml_cuda_should_use_mmvf(src0->type, cc, src0->ne, src0->nb, ne12)) {
+                     ggml_cuda_mul_mat_vec_f(ctx, src0, src1, ids, dst);
+                     return;
+                 }

--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -88,6 +88,7 @@ in
               };
               npmRoot = "tools/ui";
               npmDepsHash = "sha256-2Q7XhaLAArmviOLdQsNbYTfdyDE5pW9lR26cRHEVl9k=";
+              patches = (oa.patches or [ ]) ++ [ ../patches/llama-cpp-amd-mmvf-odd-cols.patch ];
 
               cmakeFlags = (oa.cmakeFlags or [ ]) ++ [
                 "-DGGML_NATIVE=ON"
@@ -114,7 +115,9 @@ in
         # quantized V cache causes on gfx1151).
         mkModel =
           {
-            hf,
+            hf ? null,
+            modelUrl ? null,
+            modelPath ? null,
             kv,
             ctx ? 262144,
             batchSize ? 4096,
@@ -136,7 +139,15 @@ in
               [
                 llama-server
                 "--host ::1"
+              ]
+              ++ lib.optionals (hf != null) [
                 "--hf-repo ${hf}"
+              ]
+              ++ lib.optionals (modelUrl != null) [
+                "--model ${modelPath}"
+                "--model-url ${modelUrl}"
+              ]
+              ++ [
                 "--port \${PORT}"
               ]
               ++ lib.optionals (lora != null) [
@@ -144,6 +155,7 @@ in
               ]
               ++ lib.optionals (mmproj != null) [
                 "--mmproj ${mmproj}"
+                "--image-min-tokens 1024"
               ]
               ++ [
                 "--ctx-size ${toString ctx}"
@@ -169,10 +181,13 @@ in
               ++ lib.optionals (chatTemplateFile != null) [
                 "--chat-template-file ${chatTemplateFile}"
               ]
-              ++ lib.optionals mtp [
-                "--spec-type draft-mtp"
-                "--spec-draft-n-max 2"
-              ]
+              ++ lib.optionals mtp (
+                lib.optional (modelPath != null) "--spec-draft-model ${modelPath}"
+                ++ [
+                  "--spec-type draft-mtp"
+                  "--spec-draft-n-max 2"
+                ]
+              )
               ++ lib.optionals thinking [
                 "--chat-template-kwargs '{\"preserve_thinking\":true}'"
               ]
@@ -212,11 +227,6 @@ in
             kv = "f16";
             ctx = 131072;
             sampling = deepseekSampling;
-            # Avoid the ROCm fused path that crashes while applying the rank-1 LoRA.
-            flashAttention = false;
-            # FA off needs smaller compute buffers on this GPU.
-            batchSize = 1024;
-            ubatchSize = 512;
             # The embedded template supports enable_thinking but enables no mode by default.
             thinking = false;
           };
@@ -237,13 +247,15 @@ in
             mtp = true;
           };
           "qwen3.8-27b:rvn-ara-q8" = mkModel {
-            hf = "0bserverx/Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF:RVN-Q8_0-multilingual";
+            modelUrl = "https://huggingface.co/0bserverx/Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF/resolve/main/RVN-Q8_0-multilingual-mtp.gguf";
+            modelPath = "/var/cache/llama-swap/RVN-Q8_0-multilingual-mtp.gguf";
             name = "Qwen3.8 27B RVN ARA Q8";
             description = "RVN ARA Qwen3.8 27B with image input support.";
             mmproj = qwenMmproj;
             vision = true;
             tools = true;
             kv = "q8_0";
+            mtp = true;
             sampling = [
               "--temp 1.0"
               "--top-p 0.95"
@@ -252,13 +264,15 @@ in
             ];
           };
           "qwen3.8-27b:rvn-ara-q6" = mkModel {
-            hf = "0bserverx/Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF:RVN-Q6_K-multilingual";
+            modelUrl = "https://huggingface.co/0bserverx/Qwen3.8-27B-Heretic-Abliterated-Uncensored-GGUF/resolve/main/RVN-Q6_K-multilingual-mtp.gguf";
+            modelPath = "/var/cache/llama-swap/RVN-Q6_K-multilingual-mtp.gguf";
             name = "Qwen3.8 27B RVN ARA Q6";
             description = "RVN ARA Qwen3.8 27B with image input support.";
             mmproj = qwenMmproj;
             vision = true;
             tools = true;
             kv = "f16";
+            mtp = true;
             sampling = [
               "--temp 1.0"
               "--top-p 0.95"
@@ -277,7 +291,7 @@ in
         groups = { };
 
         performance = {
-          disabled = true;
+          disabled = false;
           every = "15s";
         };
       };


### PR DESCRIPTION
## Summary

- download RVN embedded-MTP GGUFs to stable paths and use them explicitly as speculative drafts
- patch llama.cpp AMD dispatch so rank-1 DeepSeek LoRA tensors avoid the even-width-only MMVF kernel
- tune multimodal token usage and enable llama-swap performance metrics

## Validation

- `nix-instantiate --parse profiles/ai.nix`
- `statix check profiles/ai.nix`
- `nix build --no-link --no-write-lock-file path:.#nixosConfigurations.margot.config.system.build.toplevel`