### PR TITLE
fix(ai): keep camera resident and unload idle models

### DIFF
--- a/patches/llama-swap-v250-shell.patch
+++ b/patches/llama-swap-v250-shell.patch
@@ -4,3 +4,47 @@ diff --git a/cmd/vllm-wrapper/main_test.go b/cmd/vllm-wrapper/main_test.go
 @@ -111 +111 @@ func TestStartDaemonArgv(t *testing.T) {
 -		"#!/bin/bash\nprintf '%s\n' \"$@\" > \""+argvFile+"\"\nexit 0\n",
 +		"#!/bin/sh\nprintf '%s\n' \"$@\" > \""+argvFile+"\"\nexit 0\n",
+diff --git a/internal/process/process_command.go b/internal/process/process_command.go
+--- a/internal/process/process_command.go
++++ b/internal/process/process_command.go
+@@ -797,6 +797,11 @@ func (p *ProcessCommand) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+ 		swaputil.SendResponse(w, r, http.StatusServiceUnavailable, fmt.Sprintf("[%s] process is not ready", p.id))
+ 		return
+ 	}
++	// Monitoring must not keep an otherwise idle model alive.
++	if r.URL.Path == "/metrics" {
++		(*fn)(w, r)
++		return
++	}
+ 	if p.config.Compat.IgnoreWebsockets && swaputil.IsWebSocketUpgrade(r) {
+ 		(*fn)(w, r)
+ 		return
+diff --git a/internal/process/process_command_test.go b/internal/process/process_command_test.go
+--- a/internal/process/process_command_test.go
++++ b/internal/process/process_command_test.go
+@@ -712,6 +712,25 @@ func TestProcessCommand_TTL_IgnoresWebsocket(t *testing.T) {
+ 	}
+ }
+ 
++func TestProcessCommand_MetricsDoesNotResetTTL(t *testing.T) {
++	p := &ProcessCommand{}
++	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
++		w.WriteHeader(http.StatusOK)
++	})
++	p.handler.Store(&handler)
++	p.lastUse.Store(42)
++
++	rr := httptest.NewRecorder()
++	p.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
++
++	if rr.Code != http.StatusOK {
++		t.Fatalf("expected 200, got %d", rr.Code)
++	}
++	if got := p.lastUse.Load(); got != 42 {
++		t.Fatalf("metrics request reset last use to %d", got)
++	}
++}
++
+ // TestProcessCommand_TTL_ZeroDisables verifies that UnloadAfter=0 does not
+ // spawn a TTL goroutine — the process stays ready until explicitly stopped.
+ func TestProcessCommand_TTL_ZeroDisables(t *testing.T) {

--- a/profiles/ai.nix
+++ b/profiles/ai.nix
@@ -81,6 +81,10 @@ in
           url = "https://huggingface.co/ggml-org/Qwen3.8-27B-GGUF/resolve/main/mmproj-Qwen3.8-27B-Q8_0.gguf";
           hash = "sha256-LpaKavl8412JcYkLJXubftq/IK2RRQUB+lMWKhnuM+s=";
         };
+        qwenChatTemplate = pkgs.fetchurl {
+          url = "https://huggingface.co/froggeric/Qwen-Fixed-Chat-Templates/resolve/main/chat_template.jinja";
+          hash = "sha256-xHyCsFRHUtRU9OQnIo2dnYw99kyeRGy9Aik2L2eUgAk=";
+        };
         deepseekHereticLora = pkgs.fetchurl {
           url = "https://huggingface.co/MoriNoNushi/DeepSeek-V4-Flash-0731-heretic-abliterated-v2-GGUF-lora/resolve/main/ds4-flash-heretic-f4-t265-lora.gguf";
           hash = "sha256-NkI/bWN/zO5tDACkpPJcJV+1OCVFt2ASM0qW4hzU3lI=";
@@ -146,11 +150,12 @@ in
             flashAttention ? true,
             thinking ? true,
             chatTemplateFile ? null,
+            reasoningFormat ? null,
             lora ? null,
             mmproj ? null,
             imageMinTokens ? null,
             imageMaxTokens ? null,
-            ttl ? null,
+            ttl ? -1,
             vision ? false,
             tools ? false,
             name ? null,
@@ -208,6 +213,9 @@ in
               ++ lib.optionals (chatTemplateFile != null) [
                 "--chat-template-file ${chatTemplateFile}"
               ]
+              ++ lib.optionals (reasoningFormat != null) [
+                "--reasoning-format ${reasoningFormat}"
+              ]
               ++ lib.optionals mtp (
                 lib.optional (modelPath != null) "--spec-draft-model ${modelPath}"
                 ++ [
@@ -263,7 +271,10 @@ in
             name = "Qwen3.8 27B Q8";
             imageMinTokens = 1024;
             description = "Stock Qwen3.8 27B with image input support.";
+
             mmproj = qwenMmproj;
+            chatTemplateFile = qwenChatTemplate;
+            reasoningFormat = "deepseek";
             vision = true;
             tools = true;
             kv = "q8_0";
@@ -282,6 +293,8 @@ in
             imageMinTokens = 1024;
             description = "RVN ARA Qwen3.8 27B with image input support.";
             mmproj = qwenMmproj;
+            chatTemplateFile = qwenChatTemplate;
+            reasoningFormat = "deepseek";
             vision = true;
             tools = true;
             kv = "q8_0";
@@ -300,6 +313,8 @@ in
             imageMinTokens = 1024;
             description = "RVN ARA Qwen3.8 27B with image input support.";
             mmproj = qwenMmproj;
+            chatTemplateFile = qwenChatTemplate;
+            reasoningFormat = "deepseek";
             vision = true;
             tools = true;
             kv = "f16";
@@ -344,7 +359,7 @@ in
         };
 
         healthCheckTimeout = 7200;
-        globalTTL = 3600;
+        globalTTL = 1800;
         logTimeFormat = "rfc3339";
         logToStdout = "both";
         sendLoadingState = true;


### PR DESCRIPTION
## Summary

- keep the camera model resident while other models inherit the global TTL
- apply the fixed Qwen3.8 chat template and DeepSeek reasoning format
- stop llama-swap metrics scrapes from resetting model idle time

## Validation

- `statix check profiles/ai.nix`
- `nix-instantiate --parse profiles/ai.nix`
- built the evaluated Margot llama-swap package
- `go test ./internal/process -run '^TestProcessCommand_MetricsDoesNotResetTTL$'`
